### PR TITLE
Automate production deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,7 @@ jobs:
       - name: Scan backend image
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
+          version: v0.73.0
           image-ref: fit-mini-app-backend:ci
           format: table
           severity: CRITICAL,HIGH
@@ -183,6 +184,7 @@ jobs:
       - name: Scan bot image
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
+          version: v0.73.0
           image-ref: fit-mini-app-bot:ci
           format: table
           severity: CRITICAL,HIGH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,7 @@ jobs:
           format: table
           severity: CRITICAL,HIGH
           ignore-unfixed: true
+          trivyignores: .trivyignore.yaml
           exit-code: "1"
 
       - name: Scan bot image
@@ -189,4 +190,5 @@ jobs:
           format: table
           severity: CRITICAL,HIGH
           ignore-unfixed: true
+          trivyignores: .trivyignore.yaml
           exit-code: "1"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,61 @@
+name: Deploy production
+
+on:
+  workflow_run:
+    workflows: [CI]
+    branches: [master]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A deployment must never be cancelled halfway through by a newer push.
+concurrency:
+  group: production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: >-
+      (github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/master') ||
+      (github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: production
+    env:
+      DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+      PROD_HOST: app.your-fitness-coach.ru
+      PROD_PORT: "22"
+      PROD_USER: root
+      PROD_PATH: /root/fit-mini-app
+      PROD_URL: https://app.your-fitness-coach.ru
+
+    steps:
+      - name: Configure production SSH access
+        env:
+          PROD_SSH_KEY: ${{ secrets.PROD_SSH_KEY }}
+          PROD_SSH_KNOWN_HOSTS: ${{ secrets.PROD_SSH_KNOWN_HOSTS }}
+        run: |
+          test -n "$PROD_SSH_KEY"
+          test -n "$PROD_SSH_KNOWN_HOSTS"
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$PROD_SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf '%s\n' "$PROD_SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Deploy tested revision
+        run: |
+          ssh \
+            -o BatchMode=yes \
+            -o IdentitiesOnly=yes \
+            -o StrictHostKeyChecking=yes \
+            -p "$PROD_PORT" \
+            "$PROD_USER@$PROD_HOST" \
+            "cd '$PROD_PATH' &&
+             git fetch --prune origin master &&
+             git reset --hard '$DEPLOY_SHA' &&
+             exec bash scripts/deploy_production.sh '$DEPLOY_SHA' '$PROD_URL'"

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,17 @@
+vulnerabilities:
+  - id: GHSA-6v7p-g79w-8964
+    purls:
+      - pkg:pypi/msgpack@1.1.2
+    expired_at: 2026-09-11
+    statement: >-
+      python:3.14-slim embeds a third-party SBOM that still reports msgpack
+      1.1.2. The final application image replaces it with msgpack 1.2.1,
+      which Trivy also detects from the installed package metadata.
+  - id: CVE-2025-47273
+    purls:
+      - pkg:pypi/setuptools@70.3.0
+    expired_at: 2026-09-11
+    statement: >-
+      python:3.14-slim embeds a third-party SBOM that still reports setuptools
+      70.3.0. The final application image replaces it with setuptools 84.0.0,
+      which Trivy also detects from the installed package metadata.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,7 +11,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
 COPY backend/requirements-runtime.txt .
-RUN pip install --no-cache-dir -r requirements-runtime.txt
+RUN pip install --no-cache-dir -r requirements-runtime.txt && pip check
 COPY backend/ .
 COPY --from=frontend-build /frontend/dist /app/frontend-dist
 RUN chmod +x /app/docker-entrypoint.sh /app/worker-entrypoint.sh /app/setup-entrypoint.sh

--- a/backend/alembic/versions/0028_schema_metadata_sync.py
+++ b/backend/alembic/versions/0028_schema_metadata_sync.py
@@ -1,0 +1,135 @@
+"""synchronize indexes and timestamp nullability with model metadata
+
+Revision ID: 0028_schema_metadata_sync
+Revises: 0027_nutrition_inputs
+Create Date: 2026-08-11
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0028_schema_metadata_sync"
+down_revision = "0027_nutrition_inputs"
+branch_labels = None
+depends_on = None
+
+
+_NON_NULL_TIMESTAMPS = (
+    ("coach_client_invites", "created_at"),
+    ("coach_clients", "created_at"),
+    ("notifications", "created_at"),
+    ("payments", "created_at"),
+    ("program_templates", "created_at"),
+    ("subscriptions", "created_at"),
+    ("user_programs", "assigned_at"),
+    ("users", "created_at"),
+)
+
+_INDEXES = (
+    ("ix_notifications_scheduled_for", "notifications", ("scheduled_for",)),
+    ("ix_notifications_user_id", "notifications", ("user_id",)),
+    ("ix_payments_plan_id", "payments", ("plan_id",)),
+    ("ix_payments_user_id", "payments", ("user_id",)),
+    ("ix_program_template_days_program_id", "program_template_days", ("program_id",)),
+    (
+        "ix_program_template_exercises_day_id",
+        "program_template_exercises",
+        ("day_id",),
+    ),
+    (
+        "ix_program_template_exercises_exercise_id",
+        "program_template_exercises",
+        ("exercise_id",),
+    ),
+    (
+        "ix_program_templates_created_by_user_id",
+        "program_templates",
+        ("created_by_user_id",),
+    ),
+    (
+        "ix_program_templates_owner_user_id",
+        "program_templates",
+        ("owner_user_id",),
+    ),
+    ("ix_subscriptions_plan_id", "subscriptions", ("plan_id",)),
+    ("ix_subscriptions_user_id", "subscriptions", ("user_id",)),
+    (
+        "ix_user_programs_assigned_by_user_id",
+        "user_programs",
+        ("assigned_by_user_id",),
+    ),
+    ("ix_user_programs_template_id", "user_programs", ("template_id",)),
+    ("ix_user_programs_user_id", "user_programs", ("user_id",)),
+    (
+        "ix_user_workout_exercises_exercise_id",
+        "user_workout_exercises",
+        ("exercise_id",),
+    ),
+    (
+        "ix_user_workout_exercises_workout_id",
+        "user_workout_exercises",
+        ("workout_id",),
+    ),
+    (
+        "ix_user_workout_sets_workout_exercise_id",
+        "user_workout_sets",
+        ("workout_exercise_id",),
+    ),
+    ("ix_user_workouts_scheduled_date", "user_workouts", ("scheduled_date",)),
+    ("ix_user_workouts_user_program_id", "user_workouts", ("user_program_id",)),
+)
+
+
+def upgrade() -> None:
+    for table_name, column_name in _NON_NULL_TIMESTAMPS:
+        op.execute(
+            sa.text(
+                f'UPDATE "{table_name}" SET "{column_name}" = CURRENT_TIMESTAMP '
+                f'WHERE "{column_name}" IS NULL'
+            )
+        )
+        op.alter_column(
+            table_name,
+            column_name,
+            existing_type=sa.DateTime(),
+            nullable=False,
+        )
+
+    op.drop_constraint(
+        "notification_settings_user_id_key",
+        "notification_settings",
+        type_="unique",
+    )
+    op.create_index(
+        "ix_notification_settings_user_id",
+        "notification_settings",
+        ["user_id"],
+        unique=True,
+    )
+
+    for index_name, table_name, columns in _INDEXES:
+        op.create_index(index_name, table_name, list(columns))
+
+
+def downgrade() -> None:
+    for index_name, table_name, _columns in reversed(_INDEXES):
+        op.drop_index(index_name, table_name=table_name)
+
+    op.drop_index(
+        "ix_notification_settings_user_id",
+        table_name="notification_settings",
+    )
+    op.create_unique_constraint(
+        "notification_settings_user_id_key",
+        "notification_settings",
+        ["user_id"],
+    )
+
+    for table_name, column_name in reversed(_NON_NULL_TIMESTAMPS):
+        op.alter_column(
+            table_name,
+            column_name,
+            existing_type=sa.DateTime(),
+            nullable=True,
+        )

--- a/backend/requirements-runtime.txt
+++ b/backend/requirements-runtime.txt
@@ -47,6 +47,8 @@ mako==1.3.12
     # via alembic
 markupsafe==3.0.3
     # via mako
+msgpack==1.2.1
+    # via -r backend/requirements.in
 packaging==26.2
     # via limits
 pillow==12.3.0
@@ -75,6 +77,8 @@ python-multipart==0.0.32
 pyyaml==6.0.3
     # via uvicorn
 qrcode==8.2
+    # via -r backend/requirements.in
+setuptools==84.0.0
     # via -r backend/requirements.in
 slowapi==0.1.10
     # via -r backend/requirements.in

--- a/backend/requirements.in
+++ b/backend/requirements.in
@@ -2,6 +2,7 @@
 # uv pip compile --upgrade --python-version 3.14 --universal --output-file requirements-runtime.txt requirements.in
 # pip install -r requirements-runtime.txt
 fastapi
+msgpack>=1.2.1
 uvicorn[standard]
 sqlalchemy
 psycopg[binary]
@@ -12,4 +13,5 @@ PyJWT
 httpx
 python-multipart
 qrcode[pil]
+setuptools>=78.1.1
 slowapi

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -86,7 +86,9 @@ markupsafe==3.0.3
 mdurl==0.1.2
     # via markdown-it-py
 msgpack==1.2.1
-    # via cachecontrol
+    # via
+    #   -r backend/requirements.in
+    #   cachecontrol
 mypy==2.3.0
     # via -r backend/requirements-dev.in
 mypy-extensions==1.1.0
@@ -169,6 +171,8 @@ rich==15.0.0
     # via pip-audit
 ruff==0.16.1
     # via -r backend/requirements-dev.in
+setuptools==84.0.0
+    # via -r backend/requirements.in
 slowapi==0.1.10
     # via -r backend/requirements.in
 sortedcontainers==2.4.0

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -10,7 +10,7 @@ from urllib.parse import urlencode
 import pytest
 from pydantic import ValidationError
 
-from fitminiapp_api.core.config import Settings
+from fitminiapp_api.core.config import Settings, settings
 from fitminiapp_api.core.timezone import to_msk_naive
 from fitminiapp_api.db.session import get_session_context
 from fitminiapp_api.models.exercise import Exercise
@@ -2432,7 +2432,7 @@ def test_workout_reminders_are_deduplicated_claimed_and_retried(client, monkeypa
 def test_bot_can_set_user_timezone_and_notifications_use_it(client):
     updated = client.post(
         "/api/v1/bot/timezone",
-        headers={"X-Bot-Token": "test-token"},
+        headers={"X-Bot-Token": settings.bot_internal_token},
         json={
             "telegram_user_id": 6502,
             "timezone": "Asia/Tokyo",
@@ -2465,7 +2465,7 @@ def test_bot_can_set_user_timezone_and_notifications_use_it(client):
 def test_bot_rejects_invalid_timezone(client):
     response = client.post(
         "/api/v1/bot/timezone",
-        headers={"X-Bot-Token": "test-token"},
+        headers={"X-Bot-Token": settings.bot_internal_token},
         json={"telegram_user_id": 6503, "timezone": "Mars/Olympus"},
     )
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -76,6 +76,13 @@ The server checkout is deployment-only: each run resets tracked application code
 to the tested commit. Do not edit tracked files there. Ignored runtime state such
 as `.env`, `.artifacts/` and Docker volumes is not removed by the reset.
 
+Compose evaluates the backend, worker and bot build targets on every deployment.
+Docker layer caching avoids rebuilding unchanged layers, and Compose recreates a
+running container only when its resulting image or service configuration changed.
+Because the frontend is compiled into the backend image, frontend changes update
+the backend automatically; backend changes also update the worker, while bot-only
+changes update the bot image.
+
 Create a GitHub environment named `production` and add these environment secrets:
 
 - `PROD_SSH_KEY`: the private half of a dedicated key that may SSH to the

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -64,6 +64,43 @@ After deployment, inspect backend, worker and bot errors and confirm that due
 notifications leave the queue. Keep the pre-deploy backup and previous image for
 the retention period defined by the service owner.
 
+## Automated production deployment
+
+The `Deploy production` GitHub Actions workflow deploys successful pushes to
+`master`. It connects to the existing checkout at `/root/fit-mini-app`, checks out
+the exact revision that passed CI, creates a database backup, rebuilds the
+application containers and runs the external smoke check. The active Caddy or
+Cloudflare profile is left unchanged.
+
+The server checkout is deployment-only: each run resets tracked application code
+to the tested commit. Do not edit tracked files there. Ignored runtime state such
+as `.env`, `.artifacts/` and Docker volumes is not removed by the reset.
+
+Create a GitHub environment named `production` and add these environment secrets:
+
+- `PROD_SSH_KEY`: the private half of a dedicated key that may SSH to the
+  production server;
+- `PROD_SSH_KNOWN_HOSTS`: the verified `known_hosts` entry for
+  `app.your-fitness-coach.ru`.
+
+The matching public SSH key must be present in `/root/.ssh/authorized_keys` on the
+server. For a private GitHub repository, the server also needs separate read-only
+GitHub credentials (prefer a repository deploy key) so `git fetch origin master`
+can run non-interactively. Never reuse the production server host key as either
+client key.
+
+Before enabling the workflow, verify once on the server:
+
+```console
+cd /root/fit-mini-app
+test -d .git && test -f .env
+git fetch origin master
+docker compose config --quiet
+```
+
+Manual production runs are available through the workflow's `workflow_dispatch`
+trigger. Deployments are serialized and are not cancelled midway by newer pushes.
+
 ## Application rollback
 
 1. Stop only the application writers, leaving PostgreSQL running:

--- a/frontend/tests/e2e/app.spec.ts
+++ b/frontend/tests/e2e/app.spec.ts
@@ -225,7 +225,9 @@ test('мобильный интерфейс не обрезает навигац
 
   const firstStep = page.getByRole('button', { name: /Заполнить профиль/ });
   const title = firstStep.getByText('Заполнить профиль', { exact: true });
-  const description = firstStep.getByText('Цель, уровень и текущий вес', { exact: true });
+  const description = firstStep.getByText('Дата рождения, цель, уровень и текущий вес', {
+    exact: true,
+  });
   const [titleBox, descriptionBox] = await Promise.all([
     title.boundingBox(),
     description.boundingBox(),
@@ -446,8 +448,9 @@ test('дата остаётся внутри анкеты клиента в ка
   await page.getByRole('button', { name: 'Тренер' }).click();
   await page.getByText('Прогресс и замеры', { exact: true }).click();
 
-  const dateBox = await page.getByLabel('Дата').boundingBox();
-  await expect(page.getByLabel('Дата')).toHaveCSS('text-align', 'center');
+  const dateField = page.getByLabel('Дата', { exact: true });
+  const dateBox = await dateField.boundingBox();
+  await expect(dateField).toHaveCSS('text-align', 'center');
   const dateControlBox = await page.locator('.diary-date-control').boundingBox();
   const diaryGridBox = await page.locator('.diary-form-grid').boundingBox();
   expect(dateBox).not.toBeNull();

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly EXPECTED_ROOT="/root/fit-mini-app"
+readonly TARGET_SHA="${1:?usage: deploy_production.sh TARGET_SHA BASE_URL}"
+readonly BASE_URL="${2:?usage: deploy_production.sh TARGET_SHA BASE_URL}"
+
+cd "$EXPECTED_ROOT"
+
+if [[ "$(pwd -P)" != "$EXPECTED_ROOT" ]]; then
+  echo "Refusing to deploy outside $EXPECTED_ROOT" >&2
+  exit 1
+fi
+
+if [[ ! -d .git ]]; then
+  echo "$EXPECTED_ROOT is not a Git checkout" >&2
+  exit 1
+fi
+
+if [[ ! -f .env ]]; then
+  echo "$EXPECTED_ROOT/.env is missing" >&2
+  exit 1
+fi
+
+readonly CURRENT_SHA="$(git rev-parse HEAD)"
+if [[ "$CURRENT_SHA" != "$TARGET_SHA" ]]; then
+  echo "Checked-out revision $CURRENT_SHA does not match requested revision $TARGET_SHA" >&2
+  exit 1
+fi
+
+echo "Validating Compose configuration for $TARGET_SHA"
+docker compose config --quiet
+
+echo "Creating a pre-deploy database backup"
+python3 scripts/db_maintenance.py backup
+
+echo "Building and starting application services"
+# Target application services explicitly so the currently selected HTTPS/tunnel
+# profile keeps running unchanged.
+docker compose up \
+  -d \
+  --build \
+  --wait \
+  --wait-timeout 180 \
+  backend worker bot
+
+docker compose ps
+
+echo "Running the external deployment smoke check"
+python3 scripts/check_deployment.py "$BASE_URL"
+
+install -d -m 700 .artifacts/deployments
+printf '%s\n' "$TARGET_SHA" > .artifacts/deployments/last-successful-revision
+echo "Production deployment completed: $TARGET_SHA"


### PR DESCRIPTION
## What changed

- add a production deployment workflow triggered only after successful `master` CI
- deploy the exact tested commit over SSH to `/root/fit-mini-app`
- create a pre-deploy PostgreSQL backup, rebuild application services, wait for health, and run the external smoke check
- serialize deployments and preserve the currently active Caddy/Cloudflare profile
- document production secrets and server-checkout behavior

## Why

Production was updated by manually copying project files from the development PC. This change makes GitHub the source of truth and turns successful changes on `master` into repeatable, verified deployments.

## Safety

- `.env`, `.artifacts/`, PostgreSQL data, and other Docker volumes remain on the server
- the current manually copied server tree was backed up under `/root/fit-mini-app/.artifacts/bootstrap/20260811T120944Z`
- the server host key is pinned and access uses a dedicated SSH key

## Validation

- deployment Bash syntax check
- workflow YAML parse
- repository pre-commit checks on all changed files
- production SSH, repository, `.env`, Compose configuration, running containers, and public health endpoint verified