### PR TITLE
Support Python 3.10 deployment hosts

### DIFF
--- a/scripts/db_maintenance.py
+++ b/scripts/db_maintenance.py
@@ -9,12 +9,13 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 ARTIFACTS = ROOT / ".artifacts"
 BACKUP_DIR = ARTIFACTS / "backups"
+UTC = timezone.utc  # noqa: UP017 - deployment hosts can still run Python 3.10.
 BACKUP_SCRIPT = (
     "exec pg_dump --format=custom --no-owner --no-privileges "
     '--dbname="$POSTGRES_DB" --username="$POSTGRES_USER"'


### PR DESCRIPTION
## Summary
- keep the database maintenance script compatible with the server's Python 3.10
- preserve UTC backup timestamps without requiring `datetime.UTC`

## Validation
- script help invocation succeeds
- pre-commit passes

## Production failure addressed
The first automated deploy synchronized the checkout successfully, then stopped before rebuilding containers because `/usr/bin/python3` is Python 3.10 and cannot import `datetime.UTC`.