### PR TITLE
Keep production checkout free of untracked files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,4 +58,5 @@ jobs:
             "cd '$PROD_PATH' &&
              git fetch --prune origin master &&
              git reset --hard '$DEPLOY_SHA' &&
+             git clean -fd &&
              exec bash scripts/deploy_production.sh '$DEPLOY_SHA' '$PROD_URL'"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -73,8 +73,9 @@ application containers and runs the external smoke check. The active Caddy or
 Cloudflare profile is left unchanged.
 
 The server checkout is deployment-only: each run resets tracked application code
-to the tested commit. Do not edit tracked files there. Ignored runtime state such
-as `.env`, `.artifacts/` and Docker volumes is not removed by the reset.
+to the tested commit and removes non-ignored untracked files. Do not edit project
+files there. Ignored runtime state such as `.env`, `.artifacts/` and Docker volumes
+is preserved.
 
 Compose evaluates the backend, worker and bot build targets on every deployment.
 Docker layer caching avoids rebuilding unchanged layers, and Compose recreates a


### PR DESCRIPTION
Closed intentionally: production runtime files such as `.env` must remain untouched. The successful deployment automation already merged in PRs #18 and #19 preserves ignored runtime state and is active on `master`.