### PR TITLE
chore(ci): harden deploy and reduce Dependabot noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,38 +1,92 @@
 version: 2
 updates:
   - package-ecosystem: pip
-    directory: /
+    directories:
+      - /backend
+      - /bot
     schedule:
       interval: weekly
-  - package-ecosystem: pip
-    directory: /backend
-    schedule:
-      interval: weekly
-  - package-ecosystem: pip
-    directory: /bot
-    schedule:
-      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Moscow
+    open-pull-requests-limit: 3
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      python-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
   - package-ecosystem: npm
     directory: /frontend
     schedule:
       interval: weekly
+      day: tuesday
+      time: "06:00"
+      timezone: Europe/Moscow
+    open-pull-requests-limit: 3
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
-      frontend-dependencies:
+      frontend-minor-and-patch:
+        applies-to: version-updates
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
+
   - package-ecosystem: docker
+    directories:
+      - /backend
+      - /bot
+    schedule:
+      interval: weekly
+      day: wednesday
+      time: "06:00"
+      timezone: Europe/Moscow
+    open-pull-requests-limit: 2
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      shared-base-images:
+        group-by: dependency-name
+
+  - package-ecosystem: docker-compose
     directory: /
     schedule:
       interval: weekly
-  - package-ecosystem: docker
-    directory: /backend
-    schedule:
-      interval: weekly
-  - package-ecosystem: docker
-    directory: /bot
-    schedule:
-      interval: weekly
+      day: wednesday
+      time: "06:30"
+      timezone: Europe/Moscow
+    open-pull-requests-limit: 1
+    cooldown:
+      default-days: 14
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+      day: thursday
+      time: "06:00"
+      timezone: Europe/Moscow
+    open-pull-requests-limit: 1
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      github-actions-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,9 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
           load: true
           tags: ${{ matrix.tag }}
           cache-from: type=gha,scope=${{ matrix.image }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,9 +67,14 @@ jobs:
              trap 'rm -rf \"\$DOCKER_CONFIG_DIR\"' EXIT
              export DOCKER_CONFIG=\"\$DOCKER_CONFIG_DIR\"
              printf '%s' \"\$GHCR_TOKEN\" | docker login ghcr.io --username '$GITHUB_ACTOR' --password-stdin >/dev/null
-             cd '$PROD_PATH' &&
-             git fetch --prune origin master &&
-             git reset --hard '$DEPLOY_SHA' &&
+             cd '$PROD_PATH'
+             git fetch --prune origin master
+             LATEST_MASTER_SHA=\$(git rev-parse origin/master)
+             if [ "\$LATEST_MASTER_SHA" != '$DEPLOY_SHA' ]; then
+               echo "Skipping superseded deployment: tested revision $DEPLOY_SHA is no longer master head (\$LATEST_MASTER_SHA)"
+               exit 0
+             fi
+             git reset --hard '$DEPLOY_SHA'
              BACKEND_IMAGE='$GHCR_BACKEND_IMAGE:$DEPLOY_SHA' \
              BOT_IMAGE='$GHCR_BOT_IMAGE:$DEPLOY_SHA' \
              bash scripts/deploy_production.sh '$DEPLOY_SHA' '$PROD_URL'"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -104,37 +104,47 @@ the retention period defined by the service owner.
 
 ## Automated production deployment
 
-The `Deploy production` GitHub Actions workflow deploys successful pushes to
-`master`. It connects to the existing checkout at `/root/fit-mini-app`, checks out
-the exact revision that passed CI, creates a database backup, rebuilds the
-application containers and runs the external smoke check. The active Caddy or
-Cloudflare profile is left unchanged.
+GitHub Actions workflow `Deploy production` автоматически разворачивает успешные
+push в `master`. Триггер остаётся автоматическим, но deployment выполняется только
+для актуального `origin/master`: queued run для уже заменённого SHA завершается без
+изменения production.
 
-The server checkout is deployment-only: each run resets tracked application code
-to the tested commit. Do not edit tracked files there. Ignored runtime state such
-as `.env`, `.artifacts/` and Docker volumes is not removed by the reset.
+CI собирает backend и bot один раз, сканирует образы и публикует их в GHCR с тегом
+точного commit SHA и OCI-меткой `org.opencontainers.image.revision`. Production
+сначала скачивает оба образа и проверяет, что их тег и revision label совпадают с
+SHA, прошедшим CI. Несовпадение блокирует deployment до миграций и перезапуска
+сервисов.
 
-Compose evaluates the backend, worker and bot build targets on every deployment.
-Docker layer caching avoids rebuilding unchanged layers, and Compose recreates a
-running container only when its resulting image or service configuration changed.
-Because the frontend is compiled into the backend image, frontend changes update
-the backend automatically; backend changes also update the worker, while bot-only
-changes update the bot image.
+Server checkout предназначен только для deployment: каждый запуск сбрасывает
+tracked application code до проверенного commit. Не редактируйте tracked files на
+сервере. Игнорируемое runtime state (`.env`, `.artifacts/` и Docker volumes) при
+reset не удаляется.
 
-Create a GitHub environment named `production` and add these environment secrets:
+Перед запуском новой версии pipeline валидирует Compose configuration, создаёт
+PostgreSQL custom-format backup и проверяет его читаемость через
+`pg_restore --list`. Затем Compose применяет setup/migrations, запускает backend,
+worker и bot и ждёт readiness. Внешний smoke check проверяет `/health/ready`,
+`/api/v1/public/config` и `/app`, включая `app_env=prod` и безопасные production
+auth flags. Только после этих проверок SHA записывается как
+`.artifacts/deployments/last-successful-revision`.
 
-- `PROD_SSH_KEY`: the private half of a dedicated key that may SSH to the
-  production server;
-- `PROD_SSH_KNOWN_HOSTS`: the verified `known_hosts` entry for
+Активный Caddy или Cloudflare profile не переключается. Frontend уже включён в
+проверенный backend image; backend image также используется worker, а bot получает
+собственный проверенный image.
+
+Создайте GitHub environment `production` и добавьте environment secrets:
+
+- `PROD_SSH_KEY`: приватная часть отдельного ключа для SSH-доступа к production;
+- `PROD_SSH_KNOWN_HOSTS`: проверенная запись `known_hosts` для
   `app.your-fitness-coach.ru`.
 
-The matching public SSH key must be present in `/root/.ssh/authorized_keys` on the
-server. For a private GitHub repository, the server also needs separate read-only
-GitHub credentials (prefer a repository deploy key) so `git fetch origin master`
-can run non-interactively. Never reuse the production server host key as either
-client key.
+Соответствующий публичный SSH key должен находиться в
+`/root/.ssh/authorized_keys`. Для private repository серверу также нужны отдельные
+read-only GitHub credentials (предпочтительно repository deploy key), чтобы
+`git fetch origin master` работал non-interactively. Не используйте production
+server host key как client key.
 
-Before enabling the workflow, verify once on the server:
+Перед включением workflow один раз проверьте на сервере:
 
 ```console
 cd /root/fit-mini-app
@@ -143,8 +153,9 @@ git fetch origin master
 docker compose config --quiet
 ```
 
-Manual production runs are available through the workflow's `workflow_dispatch`
-trigger. Deployments are serialized and are not cancelled midway by newer pushes.
+Ручной production run доступен через `workflow_dispatch`. Deployments выполняются
+последовательно и не прерываются новым push посередине; устаревший queued SHA при
+этом безопасно пропускается до изменения application state.
 
 ## Application rollback
 

--- a/scripts/check_deployment.py
+++ b/scripts/check_deployment.py
@@ -24,6 +24,12 @@ def main() -> int:
     parser.add_argument("base_url", help="deployment origin, for example https://app.example.com")
     parser.add_argument("--timeout", type=float, default=10.0)
     parser.add_argument(
+        "--expect-app-env",
+        choices=("dev", "test", "prod"),
+        default=None,
+        help="require the public configuration to report this application environment",
+    )
+    parser.add_argument(
         "--allow-http",
         action="store_true",
         help="allow plain HTTP for a local/private smoke test",
@@ -49,6 +55,24 @@ def main() -> int:
         config = json.loads(config_body)
         if not isinstance(config, dict) or config_status != 200 or "app_env" not in config:
             raise RuntimeError(f"public config returned {config_status}: {config!r}")
+        if args.expect_app_env is not None and config["app_env"] != args.expect_app_env:
+            raise RuntimeError(
+                f"public config reported app_env={config['app_env']!r}, "
+                f"expected {args.expect_app_env!r}"
+            )
+        if args.expect_app_env == "prod":
+            expected_auth = {
+                "enable_dev_auth": False,
+                "enable_web_auth": True,
+                "enable_email_auth": False,
+            }
+            mismatches = {
+                key: config.get(key)
+                for key, expected in expected_auth.items()
+                if config.get(key) is not expected
+            }
+            if mismatches:
+                raise RuntimeError(f"public production auth flags are unsafe: {mismatches!r}")
 
         app_status, app_body, content_type = _read(args.base_url, "/app", timeout=args.timeout)
         if app_status != 200 or b'<div id="root"></div>' not in app_body:

--- a/scripts/db_maintenance.py
+++ b/scripts/db_maintenance.py
@@ -25,6 +25,7 @@ RESTORE_SCRIPT = (
     "--single-transaction "
     '--dbname="$POSTGRES_DB" --username="$POSTGRES_USER"'
 )
+VERIFY_DUMP_SCRIPT = "exec pg_restore --list"
 
 
 def _timestamp() -> str:
@@ -76,6 +77,19 @@ def create_backup(output: Path) -> Path:
         if process.returncode != 0:
             sys.stderr.buffer.write(process.stderr)
             raise RuntimeError(f"pg_dump failed with exit code {process.returncode}")
+
+        with partial.open("rb") as stream:
+            verification = subprocess.run(
+                _compose_exec(VERIFY_DUMP_SCRIPT),
+                cwd=ROOT,
+                check=False,
+                stdin=stream,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+        if verification.returncode != 0:
+            sys.stderr.buffer.write(verification.stderr)
+            raise RuntimeError("pg_restore could not read the new backup; refusing to accept it")
         partial.replace(target)
     except Exception:
         partial.unlink(missing_ok=True)

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -4,6 +4,23 @@ set -Eeuo pipefail
 readonly EXPECTED_ROOT="/root/fit-mini-app"
 readonly TARGET_SHA="${1:?usage: deploy_production.sh TARGET_SHA BASE_URL}"
 readonly BASE_URL="${2:?usage: deploy_production.sh TARGET_SHA BASE_URL}"
+readonly BACKEND_IMAGE="${BACKEND_IMAGE:?BACKEND_IMAGE must reference the tested backend image}"
+readonly BOT_IMAGE="${BOT_IMAGE:?BOT_IMAGE must reference the tested bot image}"
+
+verify_image_revision() {
+  local image_ref="$1"
+  local actual_revision
+
+  actual_revision="$(
+    docker image inspect \
+      --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+      "$image_ref"
+  )"
+  if [[ "$actual_revision" != "$TARGET_SHA" ]]; then
+    echo "Image $image_ref revision $actual_revision does not match $TARGET_SHA" >&2
+    exit 1
+  fi
+}
 
 profile_report_has_api_error() {
   python3 -c '
@@ -22,6 +39,16 @@ raise SystemExit(0 if identity_status == "API_ERROR" or "API_ERROR" in field_sta
 }
 
 cd "$EXPECTED_ROOT"
+
+if [[ ! "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "TARGET_SHA must be a full lowercase Git commit SHA" >&2
+  exit 1
+fi
+
+if [[ "$BACKEND_IMAGE" != *:"$TARGET_SHA" || "$BOT_IMAGE" != *:"$TARGET_SHA" ]]; then
+  echo "Application image tags must end with the tested revision $TARGET_SHA" >&2
+  exit 1
+fi
 
 if [[ "$(pwd -P)" != "$EXPECTED_ROOT" ]]; then
   echo "Refusing to deploy outside $EXPECTED_ROOT" >&2
@@ -53,6 +80,8 @@ docker compose config --quiet
 stage_started=$SECONDS
 echo "Pulling tested application images"
 docker compose pull backend bot
+verify_image_revision "$BACKEND_IMAGE"
+verify_image_revision "$BOT_IMAGE"
 echo "Application images pulled in $((SECONDS - stage_started))s"
 
 stage_started=$SECONDS
@@ -77,7 +106,7 @@ docker compose ps
 
 stage_started=$SECONDS
 echo "Running the external deployment smoke check"
-python3 scripts/check_deployment.py "$BASE_URL"
+python3 scripts/check_deployment.py "$BASE_URL" --expect-app-env prod
 echo "External smoke check completed in $((SECONDS - stage_started))s"
 
 echo "Checking the public Telegram bot profile"

--- a/tests/test_check_deployment.py
+++ b/tests/test_check_deployment.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+from scripts import check_deployment
+
+
+def _fake_read(config: dict[str, object]):
+    responses = {
+        "/health/ready": (200, b'{"status":"ok"}', "application/json"),
+        "/api/v1/public/config": (
+            200,
+            json.dumps(config).encode(),
+            "application/json",
+        ),
+        "/app": (200, b'<div id="root"></div>', "text/html; charset=utf-8"),
+    }
+
+    def read(_base_url: str, path: str, *, timeout: float) -> tuple[int, bytes, str]:
+        assert timeout == 10.0
+        return responses[path]
+
+    return read
+
+
+def test_production_smoke_requires_safe_environment_and_auth_flags(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        check_deployment,
+        "_read",
+        _fake_read(
+            {
+                "app_env": "prod",
+                "enable_dev_auth": False,
+                "enable_web_auth": True,
+                "enable_email_auth": False,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["check_deployment.py", "https://app.example.test", "--expect-app-env", "prod"],
+    )
+
+    assert check_deployment.main() == 0
+    assert "Environment reported by API: prod" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "config, expected_error",
+    [
+        (
+            {
+                "app_env": "test",
+                "enable_dev_auth": False,
+                "enable_web_auth": True,
+                "enable_email_auth": False,
+            },
+            "expected 'prod'",
+        ),
+        (
+            {
+                "app_env": "prod",
+                "enable_dev_auth": True,
+                "enable_web_auth": True,
+                "enable_email_auth": False,
+            },
+            "production auth flags are unsafe",
+        ),
+    ],
+)
+def test_production_smoke_rejects_unsafe_public_config(
+    config: dict[str, object],
+    expected_error: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(check_deployment, "_read", _fake_read(config))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["check_deployment.py", "https://app.example.test", "--expect-app-env", "prod"],
+    )
+
+    assert check_deployment.main() == 1
+    assert expected_error in capsys.readouterr().err

--- a/tests/test_db_maintenance.py
+++ b/tests/test_db_maintenance.py
@@ -90,6 +90,61 @@ def test_create_backup_refuses_to_overwrite_existing_dump(isolated_paths: Path) 
     assert target.read_bytes() == b"keep-me"
 
 
+def test_create_backup_validates_dump_before_publishing(
+    isolated_paths: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = isolated_paths / "backups" / "validated.dump"
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> SimpleNamespace:
+        calls.append(command)
+        if command == db_maintenance._compose_exec(db_maintenance.BACKUP_SCRIPT):
+            stream = kwargs["stdout"]
+            assert hasattr(stream, "write")
+            stream.write(b"postgres-custom-dump")
+            return SimpleNamespace(returncode=0, stderr=b"")
+
+        assert command == db_maintenance._compose_exec(db_maintenance.VERIFY_DUMP_SCRIPT)
+        stream = kwargs["stdin"]
+        assert hasattr(stream, "read")
+        assert stream.read() == b"postgres-custom-dump"
+        assert kwargs["stdout"] is subprocess.DEVNULL
+        return SimpleNamespace(returncode=0, stderr=b"")
+
+    monkeypatch.setattr(db_maintenance.subprocess, "run", fake_run)
+
+    assert db_maintenance.create_backup(target) == target.resolve()
+    assert target.read_bytes() == b"postgres-custom-dump"
+    assert calls == [
+        db_maintenance._compose_exec(db_maintenance.BACKUP_SCRIPT),
+        db_maintenance._compose_exec(db_maintenance.VERIFY_DUMP_SCRIPT),
+    ]
+
+
+def test_create_backup_discards_dump_that_pg_restore_cannot_read(
+    isolated_paths: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = isolated_paths / "backups" / "invalid.dump"
+
+    def fake_run(command: list[str], **kwargs: object) -> SimpleNamespace:
+        if command == db_maintenance._compose_exec(db_maintenance.BACKUP_SCRIPT):
+            stream = kwargs["stdout"]
+            assert hasattr(stream, "write")
+            stream.write(b"invalid-dump")
+            return SimpleNamespace(returncode=0, stderr=b"")
+        return SimpleNamespace(returncode=1, stderr=b"invalid archive")
+
+    monkeypatch.setattr(db_maintenance.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="could not read the new backup"):
+        db_maintenance.create_backup(target)
+
+    assert not target.exists()
+    assert not target.with_suffix(".dump.partial").exists()
+
+
 def test_cli_returns_error_for_output_outside_artifacts(
     isolated_paths: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_release_safeguards.py
+++ b/tests/test_release_safeguards.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+def test_automated_deploy_keeps_revision_provenance_and_stale_run_guards() -> None:
+    root = Path(__file__).resolve().parents[1]
+    ci_workflow = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    deploy_workflow = (root / ".github" / "workflows" / "deploy.yml").read_text(encoding="utf-8")
+    deploy_script = (root / "scripts" / "deploy_production.sh").read_text(encoding="utf-8")
+
+    assert "org.opencontainers.image.revision=${{ github.sha }}" in ci_workflow
+    assert "LATEST_MASTER_SHA=\\$(git rev-parse origin/master)" in deploy_workflow
+    assert deploy_workflow.index("LATEST_MASTER_SHA=") < deploy_workflow.index(
+        "git reset --hard '$DEPLOY_SHA'"
+    )
+    assert "Skipping superseded deployment" in deploy_workflow
+
+    assert 'verify_image_revision "$BACKEND_IMAGE"' in deploy_script
+    assert 'verify_image_revision "$BOT_IMAGE"' in deploy_script
+    assert deploy_script.index('verify_image_revision "$BOT_IMAGE"') < deploy_script.index(
+        "Creating a pre-deploy database backup"
+    )
+    assert 'scripts/check_deployment.py "$BASE_URL" --expect-app-env prod' in deploy_script
+    assert deploy_script.index("--expect-app-env prod") < deploy_script.index(
+        "last-successful-revision"
+    )


### PR DESCRIPTION
## Что изменено
- устранены пересекающиеся Dependabot scans и дублирующие Python PR
- Docker Compose переведён на правильный `docker-compose` ecosystem
- minor/patch updates сгруппированы, major остаются отдельными, version PR ограничены и разнесены по дням
- auto-deploy из `master` сохранён, stale queued SHA пропускается
- CI images получают OCI revision provenance, production проверяет label до migrations/restart
- pre-deploy backup валидируется через `pg_restore --list`
- external smoke подтверждает `app_env=prod` и безопасные auth flags

## Проверки
- targeted pytest: 12 passed
- pre-commit по всем изменённым файлам: passed
- Ruff format/check: passed
- `bash -n scripts/deploy_production.sh`: passed
- structural assertions for `dependabot.yml`: passed

Merge запустит штатный automatic production deploy после успешного CI.