### PR TITLE
fix(ci): quote stale deploy guard safely

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,8 +70,8 @@ jobs:
              cd '$PROD_PATH'
              git fetch --prune origin master
              LATEST_MASTER_SHA=\$(git rev-parse origin/master)
-             if [ "\$LATEST_MASTER_SHA" != '$DEPLOY_SHA' ]; then
-               echo "Skipping superseded deployment: tested revision $DEPLOY_SHA is no longer master head (\$LATEST_MASTER_SHA)"
+             if [ \"\$LATEST_MASTER_SHA\" != '$DEPLOY_SHA' ]; then
+               echo \"Skipping superseded deployment: tested revision $DEPLOY_SHA is no longer master head (\$LATEST_MASTER_SHA)\"
                exit 0
              fi
              git reset --hard '$DEPLOY_SHA'

--- a/tests/test_release_safeguards.py
+++ b/tests/test_release_safeguards.py
@@ -13,6 +13,11 @@ def test_automated_deploy_keeps_revision_provenance_and_stale_run_guards() -> No
         "git reset --hard '$DEPLOY_SHA'"
     )
     assert "Skipping superseded deployment" in deploy_workflow
+    assert "if [ \\\"\\$LATEST_MASTER_SHA\\\" != '$DEPLOY_SHA' ]; then" in deploy_workflow
+    assert (
+        'echo \\"Skipping superseded deployment: tested revision $DEPLOY_SHA '
+        'is no longer master head (\\$LATEST_MASTER_SHA)\\"' in deploy_workflow
+    )
 
     assert 'verify_image_revision "$BACKEND_IMAGE"' in deploy_script
     assert 'verify_image_revision "$BOT_IMAGE"' in deploy_script


### PR DESCRIPTION
Fixes shell quoting in the superseded-deployment guard. The failed deploy stopped on the GitHub runner before SSH, so production was not changed. Adds regression assertions for the escaped remote command. Validation: 12 targeted tests, extracted workflow bash -n, pre-commit.