### PR TITLE
feat(deploy): add zero-downtime production rollout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,20 @@ POSTGRES_IMAGE=postgres:16-alpine
 CADDY_IMAGE=caddy:2-alpine
 CLOUDFLARED_IMAGE=cloudflare/cloudflared:latest
 
+# Blue/green deployment safety envelope. Production values must be confirmed from measured host
+# headroom before the owner-approved bootstrap/rollout; these local examples are not capacity proof.
+DEPLOY_MIN_CPU_COUNT=2
+DEPLOY_MIN_AVAILABLE_MEMORY_MB=1536
+DEPLOY_MIN_AVAILABLE_DISK_MB=4096
+DEPLOY_READINESS_TIMEOUT_SECONDS=180
+DEPLOY_OBSERVATION_SECONDS=900
+DEPLOY_PROBE_INTERVAL_SECONDS=1
+DEPLOY_PROBE_TIMEOUT_SECONDS=5
+DEPLOY_GATEWAY_IDLE_TIMEOUT_SECONDS=30
+DEPLOY_BACKEND_DRAIN_SECONDS=45s
+DEPLOY_WORKER_DRAIN_SECONDS=90s
+DEPLOY_BOT_DRAIN_SECONDS=45s
+
 APP_ENV=dev
 APP_NAME=Your Fitness Coach
 APP_DEBUG=false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       (github.event.workflow_run.event == 'push' &&
       github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     environment: production
     env:
       DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ keyboard, BackButton и lifecycle contracts, но не заменяют Telegram
 - contributor architecture и task boundaries: [`AGENTS.md`](AGENTS.md);
 - Mobile Web/TMA test contract: [`docs/mobile-tma-quality-gate.md`](docs/mobile-tma-quality-gate.md);
 - public content и SEO boundaries: [`docs/seo/public-content.md`](docs/seo/public-content.md);
+- blue/green production contract: [`docs/production-deployment.md`](docs/production-deployment.md);
 - domain contracts: [`docs/exercise-domain.md`](docs/exercise-domain.md),
   [`docs/food-domain.md`](docs/food-domain.md) и
   [`docs/training-analytics.md`](docs/training-analytics.md);
@@ -236,7 +237,7 @@ production-affecting deployment action, а не безопасной Git-опе�
 4. выполнить fail-closed preflight из operator runbook;
 5. после rollout выполнить smoke и наблюдать success signals.
 
-Автоматический workflow находится в `.github/workflows/deploy.yml`, а fail-closed deployment
+Автоматический workflow находится в `.github/workflows/deploy.yml`, а fail-closed blue/green
 entrypoint — в `scripts/deploy_production.sh`. Authorization gate расположен перед изменением
 `master`, а не внутри автоматического workflow. Внутренний operator runbook хранится вне public Git;
 наличие workflow или script не является разрешением на deployment.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,6 +24,7 @@ COPY --chown=appuser:appuser backend/assets/ ./assets/
 COPY --chown=appuser:appuser backend/alembic/ ./alembic/
 COPY --chown=appuser:appuser backend/fitminiapp_api/ ./fitminiapp_api/
 COPY --chown=appuser:appuser backend/alembic.ini backend/docker-entrypoint.sh backend/worker-entrypoint.sh backend/setup-entrypoint.sh ./
+COPY --chown=appuser:appuser scripts/check_deployment.py /app/scripts/check_deployment.py
 COPY --from=frontend-build --chown=appuser:appuser /frontend/dist /app/frontend-dist
 COPY --from=frontend-build --chown=appuser:appuser /frontend/src/content/publicContent.json /app/frontend-dist/publicContent.json
 RUN chmod +x /app/docker-entrypoint.sh /app/worker-entrypoint.sh /app/setup-entrypoint.sh

--- a/backend/fitminiapp_api/services/worker.py
+++ b/backend/fitminiapp_api/services/worker.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import hashlib
 import hmac
 import logging
+import signal
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -622,31 +624,15 @@ async def run_once(*, sync_reminders: bool = True) -> None:
         db.commit()
 
 
-async def main() -> None:
-    configure_logging(
-        debug=settings.app_debug,
-        service="notification-worker",
-        sensitive_values=(
-            settings.secret_key,
-            settings.telegram_bot_token,
-            settings.bot_internal_token,
-            settings.smtp_password,
-            settings.telegram_oauth_client_secret,
-            settings.google_oauth_client_secret,
-            settings.yandex_oauth_client_secret,
-            settings.apple_oauth_client_secret,
-            settings.database_url,
-            settings.news_llm_api_key,
-            settings.news_image_cloudflare_api_token,
-        ),
-    )
-    logger.info("worker_started")
-    async with httpx.AsyncClient(timeout=15) as preflight_client:
-        news_publication_ready = await check_news_channel_rights(preflight_client)
+async def run_until_stopped(
+    stop_requested: asyncio.Event,
+    *,
+    news_publication_ready: bool,
+) -> None:
     next_reminder_sync = 0.0
     next_news_sync = 0.0
     WORKER_HEARTBEAT_PATH.touch()
-    while True:
+    while not stop_requested.is_set():
         current = monotonic()
         should_sync = current >= next_reminder_sync
         await run_once(sync_reminders=should_sync)
@@ -675,7 +661,48 @@ async def main() -> None:
             if should_fetch_news:
                 next_news_sync = current + settings.news_ingestion_cycle_seconds
         WORKER_HEARTBEAT_PATH.touch()
-        await asyncio.sleep(settings.worker_poll_seconds)
+        if stop_requested.is_set():
+            break
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(stop_requested.wait(), timeout=settings.worker_poll_seconds)
+
+
+async def main() -> None:
+    configure_logging(
+        debug=settings.app_debug,
+        service="notification-worker",
+        sensitive_values=(
+            settings.secret_key,
+            settings.telegram_bot_token,
+            settings.bot_internal_token,
+            settings.smtp_password,
+            settings.telegram_oauth_client_secret,
+            settings.google_oauth_client_secret,
+            settings.yandex_oauth_client_secret,
+            settings.apple_oauth_client_secret,
+            settings.database_url,
+            settings.news_llm_api_key,
+            settings.news_image_cloudflare_api_token,
+        ),
+    )
+    stop_requested = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def request_stop() -> None:
+        if not stop_requested.is_set():
+            logger.info("worker_drain_requested")
+            stop_requested.set()
+
+    for signal_name in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(signal_name, request_stop)
+    logger.info("worker_started")
+    async with httpx.AsyncClient(timeout=15) as preflight_client:
+        news_publication_ready = await check_news_channel_rights(preflight_client)
+    await run_until_stopped(
+        stop_requested,
+        news_publication_ready=news_publication_ready,
+    )
+    logger.info("worker_stopped")
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_deployment_smoke.py
+++ b/backend/tests/test_deployment_smoke.py
@@ -40,6 +40,13 @@ def test_deployment_smoke_covers_health_auth_tma_and_versioned_asset() -> None:
             ),
             content_type="application/json",
         ),
+        "/api/v1/me": HttpResponse(
+            status=401,
+            body=b'{"detail":"Not authenticated"}',
+            content_type="application/json",
+            final_url=f"{BASE_URL}/api/v1/me",
+            headers={"cache-control": "no-store"},
+        ),
         "/app": _response("/app", body=HTML, content_type="text/html"),
         "/login": _response("/login", body=HTML, content_type="text/html"),
         "/app?tgWebAppPlatform=android": _response(
@@ -88,10 +95,9 @@ def test_production_deploy_is_fail_closed_before_backup_and_runs_public_smoke() 
     )
 
     digest_gate = script.index("require_digest_ref POSTGRES_IMAGE")
-    runtime_gate = script.index("Validating fail-closed production runtime configuration")
-    backup = script.index("Creating a pre-deploy database backup")
-    rollout = script.index("docker compose up")
+    compose_gate = script.index("docker compose config --quiet")
+    rollout = script.index("scripts/zero_downtime_deploy.py")
 
-    assert digest_gate < runtime_gate < backup < rollout
-    assert 'check_deployment.py "$BASE_URL" --expected-environment prod' in script
-    assert 'check_seo_surface.py "$PUBLIC_BASE_URL"' in script
+    assert digest_gate < compose_gate < rollout
+    assert "--remove-orphans" not in script
+    assert "docker compose up" not in script

--- a/backend/tests/test_request_body_limits.py
+++ b/backend/tests/test_request_body_limits.py
@@ -215,7 +215,8 @@ def test_edge_and_asgi_limits_share_the_reviewed_contract() -> None:
 
     configured_sizes = [int(value) for value in re.findall(r"max_size (\d+)", caddyfile)]
     assert configured_sizes == [AUTH_BODY_LIMIT_BYTES, DEFAULT_BODY_LIMIT_BYTES]
-    assert "reverse_proxy backend:8000" in caddyfile
+    assert "reverse_proxy {$YFC_ACTIVE_UPSTREAM}" in caddyfile
+    assert "reverse_proxy {$YFC_ASSET_FALLBACK_UPSTREAM}" in caddyfile
     assert 'Cache-Control "no-store, private"' in caddyfile
     assert "reverse_proxy edge:8080" in compose
     assert "http://backend:8000" not in compose.split("  cloudflared:", maxsplit=1)[1]

--- a/backend/tests/test_worker_delivery.py
+++ b/backend/tests/test_worker_delivery.py
@@ -3,6 +3,7 @@ import json
 import logging
 from datetime import datetime, timedelta
 from itertools import pairwise
+from pathlib import Path
 from time import monotonic
 from unittest.mock import AsyncMock
 
@@ -629,3 +630,30 @@ def test_worker_rechecks_invalidation_after_waiting_for_delivery_slot(monkeypatc
         stored = session.get(Notification, reminder_id)
         assert stored is not None
         assert stored.status == "cancelled"
+
+
+def test_worker_finishes_current_cycle_before_graceful_stop(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    events: list[str] = []
+
+    async def scenario() -> None:
+        stop_requested = asyncio.Event()
+
+        async def run_once(*, sync_reminders: bool) -> None:
+            events.append(f"cycle:{sync_reminders}")
+            stop_requested.set()
+
+        monkeypatch.setattr(worker, "run_once", run_once)
+        monkeypatch.setattr(worker, "WORKER_HEARTBEAT_PATH", tmp_path / "worker-heartbeat")
+        monkeypatch.setattr(worker.settings, "weekly_digest_enabled", False)
+        monkeypatch.setattr(worker.settings, "news_ingestion_enabled", False)
+
+        await worker.run_until_stopped(
+            stop_requested,
+            news_publication_ready=False,
+        )
+
+    asyncio.run(scenario())
+
+    assert events == ["cycle:True"]

--- a/bot/tests/test_bot_runtime.py
+++ b/bot/tests/test_bot_runtime.py
@@ -402,23 +402,26 @@ def test_support_start_payload_runs_before_generic_product_entry(monkeypatch):
     menu_button.assert_not_awaited()
 
 
-def test_runtime_has_one_main_token_owner_and_no_legacy_support_contract() -> None:
+def test_runtime_supports_one_active_bot_owner_across_deployment_slots() -> None:
     root = Path(__file__).resolve().parents[2]
     compose = (root / "docker-compose.yml").read_text(encoding="utf-8")
     deploy_script = (root / "scripts" / "deploy_production.sh").read_text(encoding="utf-8")
     env_example = (root / ".env.example").read_text(encoding="utf-8")
-    assert compose.count("TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN}") == 1
-    assert compose.count("TELEGRAM_BOT_PROXY_URL: ${TELEGRAM_BOT_PROXY_URL:-}") == 1
-    assert compose.count('"host.docker.internal:host-gateway"') == 3
+    assert compose.count("TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN}") == 3
+    assert compose.count("TELEGRAM_BOT_PROXY_URL: ${TELEGRAM_BOT_PROXY_URL:-}") == 3
+    assert compose.count("BOT_POLLING_LOCK_DIR: /var/lock/fitminiapp-bot") == 3
+    assert "bot-blue:" in compose
+    assert "bot-green:" in compose
+    assert "name: fitminiapp_bot_polling_lock" in compose
+    assert 'profiles: ["production-slots"]' in compose
     assert "support-bot" not in compose
     assert "support-bot" not in deploy_script
-    assert "--remove-orphans" in deploy_script
+    assert "scripts/zero_downtime_deploy.py" in deploy_script
     assert deploy_script.count("python -m fitminiapp_bot.profile_sync check") == 1
     assert deploy_script.count("python -m fitminiapp_bot.profile_sync apply") == 1
     assert deploy_script.count("docker compose run --rm --no-deps bot") == 2
-    assert deploy_script.count('docker run --rm --network none --env-file .env "$BOT_IMAGE"') == 1
     assert deploy_script.index("profile_sync check") > deploy_script.index(
-        'scripts/check_deployment.py "$BASE_URL"'
+        "scripts/zero_downtime_deploy.py"
     )
     assert "Public Telegram Bot API fields were applied and read back" in deploy_script
     assert 'profile_sync_result="pending"' in deploy_script

--- a/codex-backlog/EXECUTION_STATUS.md
+++ b/codex-backlog/EXECUTION_STATUS.md
@@ -72,6 +72,10 @@
 - [ ] owner-selected task `111-progress-bento-dashboard-periods.md` создана вне основной очереди для
       YFC bento-дашборда и периодов `1/7/30/90/365/custom`; визуальный референс не разрешает
       выдумывать hydration/steps/health score или новый data pipeline.
+- [x] owner-selected task `112-zero-downtime-production-deployment.md` завершена и архивирована вне
+      основной очереди: stable gateway, blue/green slots, online-migration fail-closed gate,
+      old-asset overlap, single-owner worker/bot handoff, rollback и production-like drill прошли
+      review/QA; production rollout не выполнялся и требует отдельного owner approval.
 
 Не выполнять повторно tasks `00-80`, включая `69B`, `73A`, task `74A` и tasks `103-106`.
 Task `77` закрыта не как factual real-user validation, а по явному owner decision принять отсутствие
@@ -79,7 +83,9 @@ Task `77` закрыта не как factual real-user validation, а по яв�
 запустил предусмотренный automatic production workflow; runtime diff относительно прежнего master
 был нулевым, health после rollout зелёный, а владелец подтвердил auto-deploy как feature. Task `81`
 назначена следующей, но её Trigger/реализация не запускались.
-`DESIGN_V2_1` с owner-approved bounded Pulse pilot остаётся production baseline.
+`DESIGN_V2_1` с owner-approved bounded Pulse pilot остаётся production baseline. Task `81` остаётся
+current/not started; выполнение следующей task не запускалось.
 Umbrella `100` отдельно не выполняется; `100A` не назначена без собственного Trigger, dependency
-и owner decision. Tasks `107-111` также не запускаются автоматически. Другие pending tasks
+и owner decision. Tasks `107-111` также не запускаются автоматически. Завершённая task `112` не
+изменила их порядок. Другие pending tasks
 автоматически не реализуются.

--- a/codex-backlog/GLOBAL_RULES.md
+++ b/codex-backlog/GLOBAL_RULES.md
@@ -3,8 +3,9 @@
 Этот файл действует для завершённых и архивированных release tasks `75-80`, включая буквенные
 подзадачи и owner-approved Pulse concepts pilot `75C`, current post-release task `81`, и
 trigger-gated post-release pool `81-101` с буквенными подзадачами и owner-selected pending tasks
-`107-111`. Completed tasks `00-73A`, включая буквенные подзадачи, tasks `74A-75` и отдельно
-завершённые tasks `103-106` не переигрываются и хранятся в `tasks/done/`.
+`107-111`. Completed tasks `00-73A`, включая буквенные подзадачи, tasks `74A-75`, отдельно
+завершённые tasks `103-106` и owner-selected task `112` не переигрываются и хранятся в
+`tasks/done/`.
 
 Tasks `109-111` остаются owner-selected pending: Landing offer использует только factual claims и
 approved security baseline task `108`; avatar сохраняет private-media lifecycle; Progress не
@@ -91,6 +92,10 @@ Lifecycle не расширяет scope task и не отменяет owner chec
   порядок `81-101`, требует отдельного owner запуска, primary role `product-lawyer` и обязательной
   проверки итогового baseline/gate профильным российским юристом; `LEGAL_COUNSEL_REQUIRED`
   выделяет дополнительные спорные вопросы.
+- Owner-selected task `112` завершена и архивирована: current-stack blue/green deployment,
+  online-migration gate, old-asset overlap, single-owner worker/bot handoff и rollback проверены
+  локально; production rollout остаётся отдельным owner checkpoint. Current `81` и порядок
+  `81-101` не изменены.
 - Current post-release task `81` и остальные trigger-gated tasks сохраняют собственные Trigger,
   dependency и owner decision.
 - Task `50A` уже создала общий continuous Mobile Web/TMA gate, который переиспользуют последующие client-facing tasks.

--- a/codex-backlog/POST_RELEASE_PRIORITY_ORDER.md
+++ b/codex-backlog/POST_RELEASE_PRIORITY_ORDER.md
@@ -71,3 +71,7 @@ Owner-selected tasks `109-111` также находятся вне pending-по
 offer, private avatar upload и Progress bento dashboard. Они не меняют current task `81` или
 порядок `81-101`, не образуют общую implementation batch и запускаются только отдельными owner
 решениями.
+
+Owner-selected task `112` завершена и архивирована вне pending-последовательности после локального
+review/QA zero-downtime deployment contract. Production rollout остался отдельным owner checkpoint;
+current task `81` и порядок `81-101` не изменились.

--- a/codex-backlog/PRIORITY_ORDER.md
+++ b/codex-backlog/PRIORITY_ORDER.md
@@ -71,3 +71,8 @@ Owner-selected tasks `109-111` созданы вне основной очере
 conversion story, `110` — private custom avatar desktop/mobile, `111` — Progress bento dashboard и
 периоды `1/7/30/90/365/custom`. Они не меняют current `81` или порядок `81-101`, не запускаются
 автоматически и требуют отдельных owner запусков; для UI до commit действует screenshot approval.
+
+Owner-selected task `112` завершена и архивирована вне основной очереди. Она добавила проверяемый
+current-stack zero-downtime deployment contract, но не выполняла production rollout и не изменила
+current `81`: следующей по основной pending-последовательности остаётся task `81`, затем `82` только
+после её Trigger, completion и отдельного owner decision.

--- a/deploy/Caddyfile.edge
+++ b/deploy/Caddyfile.edge
@@ -1,3 +1,7 @@
+{
+	grace_period 30s
+}
+
 :8080 {
 	@auth path /api/v1/auth /api/v1/auth/*
 	request_body @auth {
@@ -9,7 +13,19 @@
 		max_size 1048576
 	}
 
-	reverse_proxy backend:8000
+	@versioned_assets path /assets/*
+	handle @versioned_assets {
+		reverse_proxy {$YFC_ACTIVE_UPSTREAM} {
+			@asset_missing status 404
+			handle_response @asset_missing {
+				reverse_proxy {$YFC_ASSET_FALLBACK_UPSTREAM}
+			}
+		}
+	}
+
+	handle {
+		reverse_proxy {$YFC_ACTIVE_UPSTREAM}
+	}
 
 	handle_errors {
 		@too_large expression {http.error.status_code} == 413

--- a/deploy/edge-entrypoint.sh
+++ b/deploy/edge-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -eu
+
+if [ -s /config/caddy/autosave.json ]; then
+  exec caddy run --resume
+fi
+
+exec caddy run --config /etc/caddy/Caddyfile --adapter caddyfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,64 @@ services:
       app_edge:
         ipv4_address: 172.29.0.2
 
+  backend-blue:
+    <<: *backend-image
+    image: ${BACKEND_BLUE_IMAGE:-fit-mini-app-backend:local}
+    restart: unless-stopped
+    profiles: ["production-slots"]
+    env_file: .env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      FORWARDED_ALLOW_IPS: 172.29.0.3
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health/ready', timeout=4)\"",
+        ]
+      interval: 10s
+      timeout: 6s
+      retries: 6
+      start_period: 60s
+      start_interval: 2s
+    stop_grace_period: ${DEPLOY_BACKEND_DRAIN_SECONDS:-45s}
+    networks:
+      default:
+      app_edge:
+
+  backend-green:
+    <<: *backend-image
+    image: ${BACKEND_GREEN_IMAGE:-fit-mini-app-backend:local}
+    restart: unless-stopped
+    profiles: ["production-slots"]
+    env_file: .env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      FORWARDED_ALLOW_IPS: 172.29.0.3
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health/ready', timeout=4)\"",
+        ]
+      interval: 10s
+      timeout: 6s
+      retries: 6
+      start_period: 60s
+      start_interval: 2s
+    stop_grace_period: ${DEPLOY_BACKEND_DRAIN_SECONDS:-45s}
+    networks:
+      default:
+      app_edge:
+
   setup:
     <<: *backend-image
     restart: "no"
@@ -93,14 +151,17 @@ services:
   edge:
     image: ${CADDY_IMAGE:-caddy:2-alpine}
     restart: unless-stopped
-    command: caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
-    depends_on:
-      backend:
-        condition: service_healthy
+    entrypoint: ["/bin/sh", "/usr/local/bin/edge-entrypoint.sh"]
+    environment:
+      YFC_ACTIVE_UPSTREAM: ${YFC_ACTIVE_UPSTREAM:-backend:8000}
+      YFC_ASSET_FALLBACK_UPSTREAM: ${YFC_ASSET_FALLBACK_UPSTREAM:-backend:8000}
     volumes:
       - ./deploy/Caddyfile.edge:/etc/caddy/Caddyfile:ro
+      - ./deploy/edge-entrypoint.sh:/usr/local/bin/edge-entrypoint.sh:ro
+      - edge_config:/config
     healthcheck:
-      test: ["CMD", "caddy", "validate", "--config", "/etc/caddy/Caddyfile"]
+      test:
+        ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8080/health/live"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -196,10 +257,113 @@ services:
       retries: 3
       start_period: 90s
 
+  worker-blue:
+    <<: *backend-image
+    image: ${BACKEND_BLUE_IMAGE:-fit-mini-app-backend:local}
+    restart: unless-stopped
+    profiles: ["production-slots"]
+    env_file: .env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      db:
+        condition: service_healthy
+    command: /app/worker-entrypoint.sh
+    stop_grace_period: ${DEPLOY_WORKER_DRAIN_SECONDS:-90s}
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import os,time; from fitminiapp_api.core.config import settings; age=time.time()-os.path.getmtime('/tmp/fitminiapp-worker-heartbeat'); assert age < max(120, settings.worker_poll_seconds * 3 + 30)\"",
+        ]
+      interval: 30s
+      timeout: 6s
+      retries: 3
+      start_period: 90s
+
+  worker-green:
+    <<: *backend-image
+    image: ${BACKEND_GREEN_IMAGE:-fit-mini-app-backend:local}
+    restart: unless-stopped
+    profiles: ["production-slots"]
+    env_file: .env
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      db:
+        condition: service_healthy
+    command: /app/worker-entrypoint.sh
+    stop_grace_period: ${DEPLOY_WORKER_DRAIN_SECONDS:-90s}
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python -c \"import os,time; from fitminiapp_api.core.config import settings; age=time.time()-os.path.getmtime('/tmp/fitminiapp-worker-heartbeat'); assert age < max(120, settings.worker_poll_seconds * 3 + 30)\"",
+        ]
+      interval: 30s
+      timeout: 6s
+      retries: 3
+      start_period: 90s
+
+  bot-blue:
+    <<: *bot-image
+    image: ${BOT_BLUE_IMAGE:-fit-mini-app-bot:local}
+    restart: unless-stopped
+    profiles: ["production-slots"]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN}
+      TELEGRAM_BOT_PROXY_URL: ${TELEGRAM_BOT_PROXY_URL:-}
+      FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-https://app.your-fitness-coach.ru}
+      PRIVACY_POLICY_URL: ${PRIVACY_POLICY_URL:-}
+      BACKEND_INTERNAL_URL: http://edge:8080
+      BOT_INTERNAL_TOKEN: ${BOT_INTERNAL_TOKEN}
+      APP_ENV: ${APP_ENV:-dev}
+      BOT_POLLING_ENABLED: ${BOT_POLLING_ENABLED:-true}
+      BOT_POLLING_LOCK_DIR: /var/lock/fitminiapp-bot
+      BOT_CONFLICT_RETRY_SECONDS: ${BOT_CONFLICT_RETRY_SECONDS:-300}
+      BOT_PROFILE_SYNC_STATE_PATH: ${BOT_PROFILE_SYNC_STATE_PATH:-/var/lock/fitminiapp-bot/profile-sync-state.json}
+      ADMIN_TELEGRAM_USER_IDS: ${ADMIN_TELEGRAM_USER_IDS:-}
+    stop_grace_period: ${DEPLOY_BOT_DRAIN_SECONDS:-45s}
+    volumes:
+      - bot_polling_lock:/var/lock/fitminiapp-bot
+    networks:
+      default:
+      app_edge:
+
+  bot-green:
+    <<: *bot-image
+    image: ${BOT_GREEN_IMAGE:-fit-mini-app-bot:local}
+    restart: unless-stopped
+    profiles: ["production-slots"]
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN}
+      TELEGRAM_BOT_PROXY_URL: ${TELEGRAM_BOT_PROXY_URL:-}
+      FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-https://app.your-fitness-coach.ru}
+      PRIVACY_POLICY_URL: ${PRIVACY_POLICY_URL:-}
+      BACKEND_INTERNAL_URL: http://edge:8080
+      BOT_INTERNAL_TOKEN: ${BOT_INTERNAL_TOKEN}
+      APP_ENV: ${APP_ENV:-dev}
+      BOT_POLLING_ENABLED: ${BOT_POLLING_ENABLED:-true}
+      BOT_POLLING_LOCK_DIR: /var/lock/fitminiapp-bot
+      BOT_CONFLICT_RETRY_SECONDS: ${BOT_CONFLICT_RETRY_SECONDS:-300}
+      BOT_PROFILE_SYNC_STATE_PATH: ${BOT_PROFILE_SYNC_STATE_PATH:-/var/lock/fitminiapp-bot/profile-sync-state.json}
+      ADMIN_TELEGRAM_USER_IDS: ${ADMIN_TELEGRAM_USER_IDS:-}
+    stop_grace_period: ${DEPLOY_BOT_DRAIN_SECONDS:-45s}
+    volumes:
+      - bot_polling_lock:/var/lock/fitminiapp-bot
+    networks:
+      default:
+      app_edge:
+
 volumes:
   postgres_data:
   caddy_data:
   caddy_config:
+  edge_config:
   bot_polling_lock:
     # The explicit name makes the lock shared by bot containers started from
     # different Compose projects on the same Docker host.

--- a/docs/demo-mode.md
+++ b/docs/demo-mode.md
@@ -46,7 +46,7 @@ Web пункт нижней навигации называется `Сцена�
 названия путей. Технические слова `fixture`, `snapshot` и названия внутренних контрактов не выводятся
 посетителю: подготовленные данные называются демонстрационным примером.
 
-Текущий production deployment запускает один backend worker, поэтому process-local store даёт
+Текущий production deployment сохраняет ровно одного активного backend worker, поэтому process-local store даёт
 предсказуемую ephemeral isolation без schema и migration. Если topology станет multi-worker,
 маршрутизацию или общий ephemeral store нужно решить отдельной architecture task до увеличения
 числа workers; перенос state в production user tables запрещён.

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -1,0 +1,104 @@
+# Бесшовное развёртывание production
+
+Production использует blue/green rollout на одном Docker Compose host. Контракт означает zero
+observed user-facing downtime во время управляемого релиза, но не high availability при отказе
+VPS, PostgreSQL, Cloudflare или сети.
+
+## Топология и источник состояния
+
+- `caddy` или `cloudflared` остаётся публичным transport и всегда направляет запросы в стабильный
+  service `edge`.
+- `edge` не перезапускается при обычном application rollout. Caddy сначала выполняет `validate`,
+  ждёт bounded точки без in-flight upstream requests, затем применяет config через graceful
+  `reload`; autosave хранится в volume `edge_config`. Если такой точки нет, switch не выполняется.
+- Application revision работает в `backend-blue` или `backend-green`. У slot нет fixed IP,
+  опубликованного порта или общего mutable filesystem.
+- Единственный worker и Telegram poller принадлежат активному slot: `worker-blue/green` и
+  `bot-blue/green`. Общий `bot_polling_lock` остаётся дополнительной защитой от двух poller.
+- PostgreSQL, `edge_config`, `caddy_data`, `caddy_config` и `bot_polling_lock` не принадлежат slot и
+  не удаляются cleanup-командами rollout.
+- Canonical source of truth — `.artifacts/deployments/state.json` на production host. Он хранит
+  active/rollback slot, revision и immutable image digest без secrets. Caddy admin config
+  проверяется против этого состояния перед каждым rollout.
+
+Frontend входит в backend image. После switch Caddy направляет новый HTML/API только в candidate,
+а запрос `/assets/*`, отсутствующий в candidate, повторяет только в прежний backend. Это сохраняет
+старые hashed chunks на весь `DEPLOY_OBSERVATION_SECONDS`; после окна fallback удаляется. Обычные
+`POST/PATCH/DELETE` имеют один upstream и не повторяются proxy на другом slot.
+
+## Порядок rollout
+
+`scripts/deploy_production.sh` проверяет exact Git SHA, immutable infrastructure image references и
+production config, после чего передаёт управление `scripts/zero_downtime_deploy.py`:
+
+1. host lock, state/config drift, capacity и public active smoke;
+2. pull candidate image, проверка OCI revision и разрешение exact repository digest;
+3. непрерывный public probe существующей revision;
+4. PostgreSQL backup;
+5. online-migration gate и один запуск `setup`;
+6. start/readiness candidate backend и internal candidate smoke;
+7. Caddy validate + reload, внешний application/SEO smoke;
+8. последовательный handoff worker и bot: worker обязан записать `worker_stopped` после завершения
+   текущего cycle, а новый bot — в логах только текущего запуска получить file lock и начать polling;
+9. continuous probe и current-container health/ownership checks в bounded observation window;
+10. commit active state, drain old backend и удаление asset fallback.
+
+Любой сбой до switch оставляет прежний route. Сбой после switch до commit state выполняет reload на
+старый живой backend, проверяет public smoke и возвращает прежних worker/bot. Interrupted retry
+сериализован host lock; повтор уже активного SHA является проверенным no-op. Deployment evidence
+пишется в `.artifacts/deployments/<deployment-id>/summary.json` и содержит stages, durations,
+capacity, probe counters/latency, handoff и verdict без env values/cookies/request bodies.
+
+## Миграции
+
+Old code работает до конца observation/rollback window, поэтому новая Alembic migration обязана
+быть additive и явно объявлять contract:
+
+```python
+online_rollout_phase = "expand"
+```
+
+Каждая новая migration также содержит непустые `online_rollout_notes` с lock/data bounds. Для
+bounded идемпотентного backfill используется phase `backfill`. Gate
+отклоняет изменение/удаление исторической migration, `drop_*`, `alter_column`, `rename_table` и
+contract migration. Удаление старой схемы выполняется отдельным последующим release после удаления
+old readers/writers и истечения rollback window. Application rollback никогда не запускает
+`alembic downgrade` и не восстанавливает backup поверх новых данных автоматически.
+
+## Capacity и конфигурация
+
+Перед parallel start проверяются `MemAvailable`, свободное место и число CPU. Пороговые переменные
+`DEPLOY_MIN_CPU_COUNT`, `DEPLOY_MIN_AVAILABLE_MEMORY_MB` и
+`DEPLOY_MIN_AVAILABLE_DISK_MB` являются fail-closed minimum, а не доказательством capacity. Owner
+фиксирует фактические CPU/RAM/disk, текущую нагрузку и DB connection headroom перед production
+approval. Timeout/readiness/drain/observation параметры перечислены в `.env.example`; менять их без
+измерения только для прохождения gate запрещено.
+
+`DEPLOY_WORKER_DRAIN_SECONDS` одновременно задаёт Compose grace period и timeout команды stop.
+Значение должно быть больше измеренного worst-case времени одного worker cycle. Если после SIGTERM
+нет текущего `worker_stopped`, rollout считается имеющим неопределённое состояние consumer, новый
+worker не получает ownership, а оператор использует evidence для ручного разбора. Старые строки
+логов переиспользованного slot не принимаются: boundary берётся из `StartedAt` текущего container.
+
+Online migration gate анализирует только `upgrade()`. Для `expand` автоматически допускается лишь
+`op.add_column` со статически проверяемым `nullable=True` без default/index/unique; обычные index и
+constraint операции fail-closed. `backfill` допускает только один literal bounded `UPDATE ... WHERE`
+и требует `online_rollout_batch_size` от 1 до 10000, `online_rollout_idempotent = True` и явное
+описание bounds/idempotency. Остальные изменения требуют отдельного проверенного rollout плана, а
+не обхода gate.
+
+Оба slot используют один production `.env`, поэтому cookie/JWT secrets и server-owned auth state не
+меняются при switch. Candidate smoke проверяет liveness, readiness/DB, document, matching hashed
+asset, anonymous `401` auth boundary, public config и TMA-safe shell без credentials или записей.
+
+## Bootstrap и production boundary
+
+Существующий single-slot host не получает state/`edge_config` автоматически: первый bootstrap
+требует отдельного owner-approved окна и может пересоздать только `edge`. Команда и preflight
+зафиксированы в private operator runbook. Обычный deploy fail-closed, пока bootstrap не завершён.
+
+Локально разрешены static/unit checks, Compose render, Caddy validation и production-like drill без
+production credentials. Push/force-push remote `master`, bootstrap production, workflow rerun,
+реальная migration, DNS/Cloudflare/secret action и public continuous probe требуют отдельного
+owner approval. Локальные tests не доказывают production zero downtime, real Telegram client или
+фактический host headroom.

--- a/scripts/check_deployment.py
+++ b/scripts/check_deployment.py
@@ -26,7 +26,11 @@ def _read(base_url: str, path: str, *, timeout: float) -> HttpResponse:
         urljoin(base_url.rstrip("/") + "/", path.lstrip("/")),
         headers={"User-Agent": "fitminiapp-deployment-check/2"},
     )
-    with urllib.request.urlopen(request, timeout=timeout) as response:
+    try:
+        response = urllib.request.urlopen(request, timeout=timeout)
+    except urllib.error.HTTPError as exc:
+        response = exc
+    with response:
         return HttpResponse(
             status=response.status,
             body=response.read(),
@@ -114,6 +118,13 @@ def check_deployment(
         }
         if mismatches:
             raise RuntimeError(f"public production auth flags are unsafe: {mismatches!r}")
+
+    auth_boundary = reader(base_url, "/api/v1/me", timeout=timeout)
+    _expect_same_origin(base_url, auth_boundary, "authenticated boundary")
+    if auth_boundary.status != 401:
+        raise RuntimeError(
+            f"authenticated boundary returned {auth_boundary.status}, expected anonymous 401"
+        )
 
     app = reader(base_url, "/app", timeout=timeout)
     _expect_same_origin(base_url, app, "application shell")

--- a/scripts/check_online_migrations.py
+++ b/scripts/check_online_migrations.py
@@ -1,0 +1,353 @@
+"""Fail closed when a release contains migrations unsafe for an online slot switch."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import subprocess
+from pathlib import Path
+
+MIGRATION_ROOT = Path("backend/alembic/versions")
+ALLOWED_PHASES = {"expand", "backfill"}
+DESTRUCTIVE_CALLS = {
+    "alter_column",
+    "drop_column",
+    "drop_constraint",
+    "drop_index",
+    "drop_table",
+    "rename_table",
+}
+FORBIDDEN_ONLINE_CALLS = {
+    "create_check_constraint",
+    "create_exclude_constraint",
+    "create_foreign_key",
+    "create_index",
+    "create_primary_key",
+    "create_unique_constraint",
+}
+SAFE_COLUMN_TYPES = {
+    "BigInteger",
+    "Boolean",
+    "Date",
+    "DateTime",
+    "Float",
+    "Integer",
+    "JSON",
+    "LargeBinary",
+    "Numeric",
+    "SmallInteger",
+    "String",
+    "Text",
+    "Time",
+}
+
+
+class OnlineMigrationError(RuntimeError):
+    """The release cannot coexist with the currently active revision."""
+
+
+def _git(*args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout
+
+
+def changed_migrations(active_revision: str, target_revision: str) -> list[tuple[str, Path]]:
+    try:
+        ancestor = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", active_revision, target_revision],
+            check=False,
+        )
+    except OSError as exc:
+        raise OnlineMigrationError(f"cannot execute Git: {exc}") from exc
+    if ancestor.returncode != 0:
+        raise OnlineMigrationError(
+            f"active revision {active_revision} is not an ancestor of {target_revision}"
+        )
+
+    rows = _git(
+        "diff",
+        "--name-status",
+        active_revision,
+        target_revision,
+        "--",
+        MIGRATION_ROOT.as_posix(),
+    ).splitlines()
+    changes: list[tuple[str, Path]] = []
+    for row in rows:
+        fields = row.split("\t")
+        status = fields[0]
+        path = Path(fields[-1])
+        if path.suffix == ".py" and path.name != "__init__.py":
+            changes.append((status, path))
+    return changes
+
+
+def _assignment(tree: ast.Module, name: str) -> object | None:
+    for node in tree.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if not any(isinstance(target, ast.Name) and target.id == name for target in targets):
+            continue
+        value = node.value
+        if value is None:
+            return None
+        try:
+            return ast.literal_eval(value)
+        except ValueError, TypeError:
+            return None
+    return None
+
+
+def _upgrade_body(tree: ast.Module, path: Path) -> ast.FunctionDef | ast.AsyncFunctionDef:
+    upgrades = [
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == "upgrade"
+    ]
+    if len(upgrades) != 1:
+        raise OnlineMigrationError(f"{path} must define exactly one upgrade() function")
+    return upgrades[0]
+
+
+def _op_calls(upgrade: ast.AST) -> list[ast.Call]:
+    return [
+        node
+        for node in ast.walk(upgrade)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "op"
+    ]
+
+
+def _validate_upgrade_call_allowlist(path: Path, upgrade: ast.AST, phase: object) -> None:
+    for call in (node for node in ast.walk(upgrade) if isinstance(node, ast.Call)):
+        function = call.func
+        allowed = False
+        if isinstance(function, ast.Attribute) and isinstance(function.value, ast.Name):
+            owner = function.value.id
+            if phase == "expand":
+                allowed = (owner == "op" and function.attr == "add_column") or (
+                    owner == "sa"
+                    and (function.attr == "Column" or function.attr in SAFE_COLUMN_TYPES)
+                )
+            elif phase == "backfill":
+                allowed = owner == "op" and function.attr == "execute"
+        if not allowed:
+            raise OnlineMigrationError(
+                f"{path} calls a helper or operation outside the {phase!r} online allowlist"
+            )
+
+
+def _validate_nullable_add_column(path: Path, call: ast.Call) -> None:
+    if len(call.args) < 2 or not isinstance(call.args[1], ast.Call):
+        raise OnlineMigrationError(
+            f"{path} add_column must contain a statically verifiable nullable Column"
+        )
+    column = call.args[1]
+    if not isinstance(column.func, ast.Attribute) or column.func.attr != "Column":
+        raise OnlineMigrationError(
+            f"{path} add_column must contain a statically verifiable nullable Column"
+        )
+    if len(column.args) != 2:
+        raise OnlineMigrationError(
+            f"{path} add_column cannot contain positional constraints or generated values"
+        )
+    column_type = column.args[1]
+    if (
+        not isinstance(column_type, ast.Call)
+        or not isinstance(column_type.func, ast.Attribute)
+        or not isinstance(column_type.func.value, ast.Name)
+        or column_type.func.value.id != "sa"
+        or column_type.func.attr not in SAFE_COLUMN_TYPES
+        or any(not isinstance(argument, ast.Constant) for argument in column_type.args)
+        or any(
+            keyword.arg is None or not isinstance(keyword.value, ast.Constant)
+            for keyword in column_type.keywords
+        )
+    ):
+        raise OnlineMigrationError(
+            f"{path} add_column must use an allowlisted static SQLAlchemy scalar type"
+        )
+    keywords = {keyword.arg: keyword.value for keyword in column.keywords if keyword.arg}
+    nullable = keywords.get("nullable")
+    if not isinstance(nullable, ast.Constant) or nullable.value is not True:
+        raise OnlineMigrationError(
+            f"{path} add_column must explicitly use nullable=True during expand"
+        )
+    for unsafe_keyword in ("server_default", "unique", "index"):
+        value = keywords.get(unsafe_keyword)
+        if value is not None and not (
+            isinstance(value, ast.Constant) and value.value in {None, False}
+        ):
+            raise OnlineMigrationError(
+                f"{path} add_column cannot use {unsafe_keyword} during an online expand"
+            )
+
+
+def validate_added_migration(path: Path) -> None:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    upgrade = _upgrade_body(tree, path)
+    phase = _assignment(tree, "online_rollout_phase")
+    if phase not in ALLOWED_PHASES:
+        raise OnlineMigrationError(
+            f"{path} must declare online_rollout_phase as one of {sorted(ALLOWED_PHASES)}"
+        )
+
+    notes = _assignment(tree, "online_rollout_notes")
+    if not isinstance(notes, str) or not notes.strip():
+        raise OnlineMigrationError(
+            f"{path} must declare non-empty online_rollout_notes with lock/data bounds"
+        )
+
+    if phase == "backfill":
+        batch_size = _assignment(tree, "online_rollout_batch_size")
+        idempotent = _assignment(tree, "online_rollout_idempotent")
+        if (
+            not isinstance(batch_size, int)
+            or isinstance(batch_size, bool)
+            or not 1 <= batch_size <= 10_000
+        ):
+            raise OnlineMigrationError(
+                f"{path} backfill must declare online_rollout_batch_size between 1 and 10000"
+            )
+        if idempotent is not True:
+            raise OnlineMigrationError(
+                f"{path} backfill must declare online_rollout_idempotent = True"
+            )
+
+    destructive = sorted(
+        {
+            node.func.attr
+            for node in _op_calls(upgrade)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in DESTRUCTIVE_CALLS
+        }
+    )
+    if destructive:
+        raise OnlineMigrationError(
+            f"{path} contains destructive operations forbidden during an online rollout: "
+            + ", ".join(destructive)
+        )
+
+    for node in ast.walk(upgrade):
+        if (
+            not isinstance(node, ast.Call)
+            or not isinstance(node.func, ast.Attribute)
+            or node.func.attr not in {"execute", "exec_driver_sql"}
+        ):
+            continue
+        if not (
+            node.func.attr == "execute"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "op"
+        ):
+            raise OnlineMigrationError(
+                f"{path} uses SQL execution outside the verified op.execute backfill contract"
+            )
+
+    forbidden = sorted(
+        {
+            node.func.attr
+            for node in _op_calls(upgrade)
+            if isinstance(node.func, ast.Attribute) and node.func.attr in FORBIDDEN_ONLINE_CALLS
+        }
+    )
+    if forbidden:
+        raise OnlineMigrationError(
+            f"{path} contains lock-prone operations forbidden during an online rollout: "
+            + ", ".join(forbidden)
+        )
+
+    for call in _op_calls(upgrade):
+        operation = call.func.attr if isinstance(call.func, ast.Attribute) else ""
+        if phase == "expand" and operation == "add_column":
+            _validate_nullable_add_column(path, call)
+        elif phase == "expand" and operation not in {"add_column"}:
+            raise OnlineMigrationError(
+                f"{path} uses op.{operation}, which is not allowlisted for online expand"
+            )
+        elif phase == "backfill" and operation != "execute":
+            raise OnlineMigrationError(
+                f"{path} uses op.{operation}, which is not allowlisted for online backfill"
+            )
+
+    for node in _op_calls(upgrade):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "execute"
+        ):
+            if (
+                not node.args
+                or not isinstance(node.args[0], ast.Constant)
+                or not isinstance(node.args[0].value, str)
+            ):
+                raise OnlineMigrationError(
+                    f"{path} uses dynamic op.execute; online safety cannot be verified"
+                )
+            sql = re.sub(r"\s+", " ", node.args[0].value).strip().upper()
+            if re.search(r"\b(DROP|ALTER|TRUNCATE|DELETE)\b", sql):
+                raise OnlineMigrationError(
+                    f"{path} contains destructive SQL forbidden during an online rollout"
+                )
+            if phase != "backfill":
+                raise OnlineMigrationError(
+                    f"{path} uses op.execute but online_rollout_phase is not 'backfill'"
+                )
+            if not sql.startswith("UPDATE ") or " WHERE " not in sql or ";" in sql:
+                raise OnlineMigrationError(
+                    f"{path} backfill SQL must be one bounded UPDATE with an explicit WHERE"
+                )
+
+    if phase == "backfill" and not any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "execute"
+        for node in _op_calls(upgrade)
+    ):
+        raise OnlineMigrationError(
+            f"{path} declares backfill without an explicit bounded op.execute"
+        )
+
+    _validate_upgrade_call_allowlist(path, upgrade, phase)
+
+
+def check_online_migrations(active_revision: str, target_revision: str) -> list[Path]:
+    changes = changed_migrations(active_revision, target_revision)
+    unsafe_history = [(status, path) for status, path in changes if status != "A"]
+    if unsafe_history:
+        details = ", ".join(f"{status}:{path}" for status, path in unsafe_history)
+        raise OnlineMigrationError(
+            "applied migration history is immutable during an online rollout: " + details
+        )
+    added = [path for _status, path in changes]
+    for path in added:
+        validate_added_migration(path)
+    return added
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("active_revision")
+    parser.add_argument("target_revision")
+    args = parser.parse_args()
+    try:
+        migrations = check_online_migrations(args.active_revision, args.target_revision)
+    except (OSError, SyntaxError, subprocess.CalledProcessError, OnlineMigrationError) as exc:
+        print(f"Online migration gate failed: {exc}")
+        return 1
+    print(f"Online migration gate passed: {len(migrations)} added migration(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/continuous_deployment_probe.py
+++ b/scripts/continuous_deployment_probe.py
@@ -1,0 +1,179 @@
+"""Continuously verify the public release path and the pre-switch asset compatibility contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+if __package__:
+    from scripts.check_deployment import _first_versioned_asset, _read, check_deployment
+else:
+    from check_deployment import _first_versioned_asset, _read, check_deployment
+
+
+@dataclass
+class ProbeReport:
+    started_at: float
+    ended_at: float = 0.0
+    requests: int = 0
+    samples: int = 0
+    failures: dict[str, int] = field(
+        default_factory=lambda: {
+            "transport": 0,
+            "http_4xx": 0,
+            "http_5xx": 0,
+            "asset_mismatch": 0,
+            "contract": 0,
+        }
+    )
+    first_error: str | None = None
+    compatibility_asset: str | None = None
+    latency_max_ms: float = 0.0
+    latency_p95_ms: float = 0.0
+
+    @property
+    def failure_count(self) -> int:
+        return sum(self.failures.values())
+
+
+def _atomic_json(path: Path, value: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def _classify(exc: BaseException) -> str:
+    if isinstance(exc, urllib.error.HTTPError):
+        if 400 <= exc.code < 500:
+            return "http_4xx"
+        if exc.code >= 500:
+            return "http_5xx"
+    if isinstance(exc, (urllib.error.URLError, TimeoutError, ConnectionError, OSError)):
+        return "transport"
+    text = str(exc).lower()
+    if "asset" in text or "/assets/" in text:
+        return "asset_mismatch"
+    if "returned 4" in text:
+        return "http_4xx"
+    if "returned 5" in text:
+        return "http_5xx"
+    return "contract"
+
+
+def run_probe(
+    base_url: str,
+    *,
+    duration: float,
+    interval: float,
+    timeout: float,
+    expected_environment: str,
+    stop_requested=lambda: False,
+    compatibility_required=lambda: True,
+    on_started=lambda: None,
+    clock=time.monotonic,
+    sleeper=time.sleep,
+) -> ProbeReport:
+    started = clock()
+    report = ProbeReport(started_at=started)
+    sample_latencies_ms: list[float] = []
+    initial_document = _read(base_url, "/app", timeout=timeout)
+    report.requests += 1
+    report.compatibility_asset = _first_versioned_asset(initial_document.body)
+    on_started()
+
+    while True:
+        sample_started = clock()
+        try:
+            check_deployment(
+                base_url,
+                timeout=timeout,
+                expected_environment=expected_environment,
+            )
+            report.requests += 8
+            if compatibility_required():
+                old_asset = _read(base_url, report.compatibility_asset, timeout=timeout)
+                report.requests += 1
+                if old_asset.status != 200 or not old_asset.body:
+                    raise RuntimeError(
+                        f"compatibility asset returned {old_asset.status} or an empty body: "
+                        f"{report.compatibility_asset}"
+                    )
+        except BaseException as exc:  # bounded evidence must survive every request failure
+            category = _classify(exc)
+            report.failures[category] += 1
+            if report.first_error is None:
+                report.first_error = f"{type(exc).__name__}: {exc}"
+        report.samples += 1
+        sample_latencies_ms.append((clock() - sample_started) * 1000)
+        elapsed = clock() - started
+        if elapsed >= duration or stop_requested():
+            report.ended_at = clock()
+            ordered = sorted(sample_latencies_ms)
+            report.latency_max_ms = round(ordered[-1], 3)
+            p95_index = min(len(ordered) - 1, max(0, int(len(ordered) * 0.95) - 1))
+            report.latency_p95_ms = round(ordered[p95_index], 3)
+            return report
+        sleeper(min(interval, max(0.0, duration - elapsed)))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("base_url")
+    parser.add_argument("--duration", type=float, required=True)
+    parser.add_argument("--interval", type=float, default=1.0)
+    parser.add_argument("--timeout", type=float, default=5.0)
+    parser.add_argument("--expected-environment", default="prod")
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--stop-file", type=Path)
+    parser.add_argument("--started-file", type=Path)
+    parser.add_argument("--compatibility-stop-file", type=Path)
+    args = parser.parse_args()
+    if args.duration <= 0 or args.interval <= 0 or args.timeout <= 0:
+        parser.error("duration, interval and timeout must be positive")
+
+    try:
+        if args.started_file is not None:
+            args.started_file.parent.mkdir(parents=True, exist_ok=True)
+        report = run_probe(
+            args.base_url,
+            duration=args.duration,
+            interval=args.interval,
+            timeout=args.timeout,
+            expected_environment=args.expected_environment,
+            stop_requested=(
+                (lambda: args.stop_file.is_file())
+                if args.stop_file is not None
+                else (lambda: False)
+            ),
+            compatibility_required=(
+                (lambda: not args.compatibility_stop_file.is_file())
+                if args.compatibility_stop_file is not None
+                else (lambda: True)
+            ),
+            on_started=(
+                (lambda: args.started_file.write_text("started\n", encoding="utf-8"))
+                if args.started_file is not None
+                else (lambda: None)
+            ),
+        )
+    except BaseException as exc:
+        report = ProbeReport(started_at=time.monotonic(), ended_at=time.monotonic())
+        category = _classify(exc)
+        report.failures[category] = 1
+        report.first_error = f"{type(exc).__name__}: {exc}"
+
+    payload = asdict(report)
+    payload["failure_count"] = report.failure_count
+    _atomic_json(args.output, payload)
+    print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    return 0 if report.failure_count == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -8,21 +8,6 @@ readonly PUBLIC_BASE_URL="${3:-https://your-fitness-coach.ru}"
 readonly BACKEND_IMAGE="${BACKEND_IMAGE:?BACKEND_IMAGE must reference the tested backend image}"
 readonly BOT_IMAGE="${BOT_IMAGE:?BOT_IMAGE must reference the tested bot image}"
 
-verify_image_revision() {
-  local image_ref="$1"
-  local actual_revision
-
-  actual_revision="$(
-    docker image inspect \
-      --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
-      "$image_ref"
-  )"
-  if [[ "$actual_revision" != "$TARGET_SHA" ]]; then
-    echo "Image $image_ref revision $actual_revision does not match $TARGET_SHA" >&2
-    exit 1
-  fi
-}
-
 profile_report_has_api_error() {
   python3 -c '
 import json
@@ -92,53 +77,12 @@ python3 scripts/configure_production_auth.py .env
 echo "Validating Compose configuration for $TARGET_SHA"
 docker compose config --quiet
 
-stage_started=$SECONDS
-echo "Pulling tested application images"
-docker compose pull backend bot edge
-verify_image_revision "$BACKEND_IMAGE"
-verify_image_revision "$BOT_IMAGE"
-echo "Application images pulled in $((SECONDS - stage_started))s"
-
-echo "Validating fail-closed production runtime configuration"
-docker run --rm --network none --env-file .env "$BACKEND_IMAGE" \
-  python -c "from fitminiapp_api.core.config import settings; assert settings.app_env == 'prod'; print('Backend production config is valid')"
-docker run --rm --network none --env-file .env "$BOT_IMAGE" \
-  python -c "from fitminiapp_bot.config import settings; assert settings.app_env == 'prod'; print('Bot production config is valid')"
-
-stage_started=$SECONDS
-echo "Creating a pre-deploy database backup"
-python3 scripts/db_maintenance.py backup
-echo "Database backup completed in $((SECONDS - stage_started))s"
-
-stage_started=$SECONDS
-echo "Starting application services"
-# Target application services explicitly so the currently selected HTTPS/tunnel
-# profile stays selected while its active gateway receives the new edge route.
-gateway_services=(edge)
-# A failed rollout can leave the selected public gateway stopped after its
-# backend dependency was recreated. Preserve that selection during recovery.
-if docker compose ps --services --all | grep -qx caddy; then
-  gateway_services+=(caddy)
-fi
-if docker compose ps --services --all | grep -qx cloudflared; then
-  gateway_services+=(cloudflared)
-fi
-docker compose up \
-  -d \
-  --no-build \
-  --remove-orphans \
-  --wait \
-  --wait-timeout 180 \
-  backend worker bot "${gateway_services[@]}"
-echo "Application services became ready in $((SECONDS - stage_started))s"
-
-docker compose ps
-
-stage_started=$SECONDS
-echo "Running the external deployment smoke check"
-python3 scripts/check_deployment.py "$BASE_URL" --expected-environment prod
-python3 scripts/check_seo_surface.py "$PUBLIC_BASE_URL"
-echo "External smoke check completed in $((SECONDS - stage_started))s"
+echo "Starting fail-closed blue/green rollout"
+python3 scripts/zero_downtime_deploy.py \
+  deploy \
+  "$TARGET_SHA" \
+  "$BASE_URL" \
+  "$PUBLIC_BASE_URL"
 
 echo "Checking the public Telegram bot profile"
 set +e
@@ -188,6 +132,4 @@ esac
 echo "Public Telegram bot profile sync result: $profile_sync_result"
 echo "Review owner actions in the profile reports when Telegram Bot API is reachable"
 
-install -d -m 700 .artifacts/deployments
-printf '%s\n' "$TARGET_SHA" > .artifacts/deployments/last-successful-revision
 echo "Production deployment completed: $TARGET_SHA"

--- a/scripts/run_zero_downtime_drill.py
+++ b/scripts/run_zero_downtime_drill.py
@@ -1,0 +1,363 @@
+"""Run a credential-free production-like A-to-B Caddy switch and failure drill."""
+
+from __future__ import annotations
+
+import argparse
+import http.cookiejar
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+if __package__:
+    from scripts.check_deployment import check_deployment
+else:
+    from check_deployment import check_deployment
+
+
+class DrillError(RuntimeError):
+    """The production-like rollout contract was not observed."""
+
+
+def _run(args: list[str], *, check: bool = True, capture: bool = False):
+    return subprocess.run(args, check=check, text=True, capture_output=capture)
+
+
+def _compose(compose_file: Path, project: str, *args: str, check: bool = True, capture=False):
+    return _run(
+        ["docker", "compose", "-p", project, "-f", str(compose_file), *args],
+        check=check,
+        capture=capture,
+    )
+
+
+def _wait_until_ready(base_url: str, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    last_error: BaseException | None = None
+    while time.monotonic() < deadline:
+        try:
+            check_deployment(base_url, timeout=1, expected_environment="prod")
+            return
+        except Exception as exc:
+            last_error = exc
+            time.sleep(0.2)
+    raise DrillError(f"drill route was not ready: {last_error}")
+
+
+def _read(opener, url: str) -> bytes:
+    with opener.open(url, timeout=3) as response:
+        return response.read()
+
+
+def run_drill(*, port: int, artifact_root: Path) -> dict[str, object]:
+    root = Path(__file__).resolve().parents[1]
+    compose_file = root / "tests" / "fixtures" / "zero-downtime" / "docker-compose.yml"
+    project = f"yfc-zdt-drill-{os.getpid()}"
+    base_url = f"http://127.0.0.1:{port}"
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    probe_output = artifact_root / "continuous-probe.json"
+    probe_stop = artifact_root / "continuous-probe.stop"
+    probe_started = artifact_root / "continuous-probe.started"
+    compatibility_stop = artifact_root / "asset-compatibility.stop"
+    invalid_config = artifact_root / "Caddyfile.invalid"
+    for stale_path in (probe_output, probe_stop, probe_started, compatibility_stop):
+        stale_path.unlink(missing_ok=True)
+    invalid_config.write_text(":8080 { reverse_proxy }\n", encoding="utf-8")
+    previous_port = os.environ.get("DRILL_PORT")
+    os.environ["DRILL_PORT"] = str(port)
+    probe: subprocess.Popen[str] | None = None
+
+    try:
+        _run(
+            [
+                "docker",
+                "compose",
+                "-p",
+                project,
+                "-f",
+                str(compose_file),
+                "up",
+                "-d",
+                "release-a",
+                "edge",
+            ],
+            check=True,
+        )
+        _wait_until_ready(base_url, 30)
+
+        cookie_jar = http.cookiejar.CookieJar()
+        opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cookie_jar))
+        if _read(opener, f"{base_url}/session") != b"stable":
+            raise DrillError("session bootstrap failed")
+
+        probe = subprocess.Popen(
+            [
+                sys.executable,
+                "scripts/continuous_deployment_probe.py",
+                base_url,
+                "--duration",
+                "30",
+                "--interval",
+                "0.1",
+                "--timeout",
+                "1",
+                "--expected-environment",
+                "prod",
+                "--output",
+                str(probe_output),
+                "--stop-file",
+                str(probe_stop),
+                "--started-file",
+                str(probe_started),
+                "--compatibility-stop-file",
+                str(compatibility_stop),
+            ],
+            text=True,
+        )
+        deadline = time.monotonic() + 10
+        while not probe_started.is_file() and time.monotonic() < deadline:
+            if probe.poll() is not None:
+                raise DrillError("continuous probe stopped before candidate start")
+            time.sleep(0.1)
+        if not probe_started.is_file():
+            raise DrillError("continuous probe did not confirm active release A")
+
+        _compose(compose_file, project, "up", "-d", "release-b")
+        _compose(
+            compose_file,
+            project,
+            "exec",
+            "-T",
+            "release-b",
+            "python",
+            "-c",
+            "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health/ready', timeout=2)",
+        )
+
+        _compose(compose_file, project, "cp", str(invalid_config), "edge:/tmp/Caddyfile.invalid")
+        invalid = _compose(
+            compose_file,
+            project,
+            "exec",
+            "-T",
+            "edge",
+            "caddy",
+            "validate",
+            "--config",
+            "/tmp/Caddyfile.invalid",
+            "--adapter",
+            "caddyfile",
+            check=False,
+        )
+        if invalid.returncode == 0:
+            raise DrillError("invalid gateway config unexpectedly passed validation")
+        if b'data-revision="a"' not in _read(opener, f"{base_url}/app"):
+            raise DrillError("failed validation changed the active route")
+
+        gateway_env = [
+            "-e",
+            "YFC_ACTIVE_UPSTREAM=release-b:8000",
+            "-e",
+            "YFC_ASSET_FALLBACK_UPSTREAM=release-a:8000",
+        ]
+        _compose(
+            compose_file,
+            project,
+            "exec",
+            "-T",
+            *gateway_env,
+            "edge",
+            "caddy",
+            "validate",
+            "--config",
+            "/etc/caddy/Caddyfile",
+            "--adapter",
+            "caddyfile",
+        )
+        idle_deadline = time.monotonic() + 10
+        while time.monotonic() < idle_deadline:
+            upstreams = json.loads(
+                _compose(
+                    compose_file,
+                    project,
+                    "exec",
+                    "-T",
+                    "edge",
+                    "wget",
+                    "-qO-",
+                    "http://127.0.0.1:2019/reverse_proxy/upstreams",
+                    capture=True,
+                ).stdout
+            )
+            if all(item.get("num_requests") == 0 for item in upstreams):
+                break
+            time.sleep(0.05)
+        else:
+            raise DrillError("gateway had no bounded request-free switch point")
+        _compose(
+            compose_file,
+            project,
+            "exec",
+            "-T",
+            *gateway_env,
+            "edge",
+            "caddy",
+            "reload",
+            "--config",
+            "/etc/caddy/Caddyfile",
+            "--adapter",
+            "caddyfile",
+        )
+
+        switched_document = _read(opener, f"{base_url}/app")
+        if b'data-revision="b"' not in switched_document:
+            current_config = _compose(
+                compose_file,
+                project,
+                "exec",
+                "-T",
+                "edge",
+                "wget",
+                "-qO-",
+                "http://127.0.0.1:2019/config/",
+                capture=True,
+            ).stdout
+            raise DrillError(
+                f"traffic did not switch to release B: document={switched_document!r}; "
+                f"config={current_config}"
+            )
+        if _read(opener, f"{base_url}/assets/app-a.js") == b"":
+            raise DrillError("old hashed asset fallback returned an empty body")
+        if _read(opener, f"{base_url}/session") != b"stable":
+            raise DrillError("active cookie session did not survive the switch")
+
+        request = urllib.request.Request(
+            f"{base_url}/write",
+            method="POST",
+            data=b"{}",
+            headers={"Content-Type": "application/json", "Idempotency-Key": "drill-write-1"},
+        )
+        with opener.open(request, timeout=3) as response:
+            write_result = json.loads(response.read())
+        if write_result != {"revision": "b", "operation_id": "drill-write-1", "count": 1}:
+            raise DrillError(f"safe write was duplicated or reached the wrong slot: {write_result}")
+
+        compatibility_stop.write_text("compatibility window complete\n", encoding="utf-8")
+        cleanup_env = [
+            "-e",
+            "YFC_ACTIVE_UPSTREAM=release-b:8000",
+            "-e",
+            "YFC_ASSET_FALLBACK_UPSTREAM=release-b:8000",
+        ]
+        _compose(
+            compose_file,
+            project,
+            "exec",
+            "-T",
+            *cleanup_env,
+            "edge",
+            "caddy",
+            "validate",
+            "--config",
+            "/etc/caddy/Caddyfile",
+            "--adapter",
+            "caddyfile",
+        )
+        idle_deadline = time.monotonic() + 10
+        while time.monotonic() < idle_deadline:
+            upstreams = json.loads(
+                _compose(
+                    compose_file,
+                    project,
+                    "exec",
+                    "-T",
+                    "edge",
+                    "wget",
+                    "-qO-",
+                    "http://127.0.0.1:2019/reverse_proxy/upstreams",
+                    capture=True,
+                ).stdout
+            )
+            if all(item.get("num_requests") == 0 for item in upstreams):
+                break
+            time.sleep(0.05)
+        else:
+            raise DrillError("gateway had no request-free cleanup point")
+        _compose(
+            compose_file,
+            project,
+            "exec",
+            "-T",
+            *cleanup_env,
+            "edge",
+            "caddy",
+            "reload",
+            "--config",
+            "/etc/caddy/Caddyfile",
+            "--adapter",
+            "caddyfile",
+        )
+        if b'data-revision="b"' not in _read(opener, f"{base_url}/app"):
+            raise DrillError("cleanup reload changed the active release")
+        _compose(compose_file, project, "stop", "release-a")
+
+        probe_stop.write_text("stop\n", encoding="utf-8")
+        if probe.wait(timeout=15) != 0:
+            raise DrillError("continuous probe observed a rollout failure")
+        report = json.loads(probe_output.read_text(encoding="utf-8"))
+        if report.get("failure_count") != 0 or report.get("samples", 0) < 2:
+            raise DrillError(f"continuous probe evidence is not green: {report}")
+        result = {
+            "verdict": "passed",
+            "active_revision": "b",
+            "old_asset": "available",
+            "session": "preserved",
+            "write_count": 1,
+            "invalid_gateway_config": "kept_release_a",
+            "probe": report,
+        }
+        (artifact_root / "summary.json").write_text(
+            json.dumps(result, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+        )
+        return result
+    finally:
+        if probe is not None and probe.poll() is None:
+            probe.terminate()
+            probe.wait(timeout=5)
+        _compose(
+            compose_file,
+            project,
+            "down",
+            "--volumes",
+            "--remove-orphans",
+            check=False,
+        )
+        if previous_port is None:
+            os.environ.pop("DRILL_PORT", None)
+        else:
+            os.environ["DRILL_PORT"] = previous_port
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=18080)
+    parser.add_argument(
+        "--artifact-root",
+        type=Path,
+        default=Path(".artifacts/deployments/zero-downtime-drill"),
+    )
+    args = parser.parse_args()
+    try:
+        result = run_drill(port=args.port, artifact_root=args.artifact_root)
+    except (OSError, ValueError, subprocess.SubprocessError, DrillError) as exc:
+        print(f"Zero-downtime drill failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/zero_downtime_deploy.py
+++ b/scripts/zero_downtime_deploy.py
@@ -1,0 +1,1086 @@
+"""Blue/green production rollout for the current single-host Docker Compose stack."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from collections.abc import Iterator, Sequence
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - production deployment runs on Linux
+    fcntl = None  # type: ignore[assignment]
+
+SLOTS = ("blue", "green")
+STATE_VERSION = 1
+
+
+class DeploymentError(RuntimeError):
+    """The rollout stopped without an unverified traffic state."""
+
+
+@dataclass(frozen=True)
+class ReleaseState:
+    version: int
+    active_slot: str
+    active_revision: str
+    active_backend_image: str
+    active_bot_image: str
+    rollback_slot: str | None = None
+    rollback_revision: str | None = None
+    rollback_backend_image: str | None = None
+    rollback_bot_image: str | None = None
+
+    @classmethod
+    def from_path(cls, path: Path) -> ReleaseState:
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+            state = cls(**value)
+        except (OSError, TypeError, json.JSONDecodeError) as exc:
+            raise DeploymentError(f"cannot read deployment state {path}: {exc}") from exc
+        if state.version != STATE_VERSION or state.active_slot not in {"legacy", *SLOTS}:
+            raise DeploymentError(f"unsupported deployment state in {path}")
+        return state
+
+
+@dataclass(frozen=True)
+class DeployConfig:
+    target_revision: str
+    base_url: str
+    public_base_url: str
+    backend_image: str
+    bot_image: str
+    root: Path
+    state_root: Path
+    observation_seconds: float
+    readiness_timeout_seconds: int
+    probe_interval_seconds: float
+    probe_timeout_seconds: float
+    backend_drain_seconds: int
+    worker_drain_seconds: int
+    bot_drain_seconds: int
+    bot_polling_enabled: bool
+
+
+@dataclass(frozen=True)
+class ConsumerLease:
+    service: str
+    container_id: str
+    started_at: str
+    required_markers: tuple[str, ...]
+
+
+@dataclass
+class StageRecord:
+    name: str
+    started_at: float
+    ended_at: float = 0.0
+    status: str = "running"
+    reason: str | None = None
+
+
+@dataclass
+class Evidence:
+    deployment_id: str
+    target_revision: str
+    previous_revision: str
+    active_slot: str
+    candidate_slot: str
+    started_at: float
+    ended_at: float = 0.0
+    verdict: str = "manual intervention required"
+    stages: list[StageRecord] = field(default_factory=list)
+    capacity: dict[str, int] = field(default_factory=dict)
+    probe: dict[str, object] = field(default_factory=dict)
+    worker_handoff_seconds: float | None = None
+    bot_handoff_seconds: float | None = None
+
+
+def _deployment_setting(key: str, default: str) -> str:
+    if key in os.environ:
+        return os.environ[key]
+    env_path = Path(".env")
+    if not env_path.is_file():
+        return default
+    pattern = re.compile(rf"^\s*(?:export\s+)?{re.escape(key)}\s*=\s*(.*?)\s*$")
+    value = default
+    for line in env_path.read_text(encoding="utf-8-sig").splitlines():
+        match = pattern.match(line)
+        if match is None:
+            continue
+        value = match.group(1).strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        elif " #" in value:
+            value = value.split(" #", maxsplit=1)[0].rstrip()
+    return value
+
+
+def configured_timeout(key: str, default: int) -> int:
+    raw = _deployment_setting(key, str(default)).strip()
+    match = re.fullmatch(r"([1-9][0-9]*)(?:s)?", raw)
+    if match is None:
+        raise DeploymentError(f"{key} must be a positive whole number of seconds")
+    return int(match.group(1))
+
+
+def _atomic_json(path: Path, value: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def _atomic_text(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(value, encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def _run(
+    args: Sequence[str],
+    *,
+    env: dict[str, str] | None = None,
+    capture: bool = False,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        check=check,
+        env=env,
+        text=True,
+        capture_output=capture,
+    )
+
+
+def _compose(*args: str, env: dict[str, str] | None = None, capture: bool = False):
+    return _run(
+        ["docker", "compose", "--profile", "production-slots", *args],
+        env=env,
+        capture=capture,
+    )
+
+
+def _slot_service(kind: str, slot: str) -> str:
+    return kind if slot == "legacy" else f"{kind}-{slot}"
+
+
+def _upstream(slot: str) -> str:
+    return f"{_slot_service('backend', slot)}:8000"
+
+
+def _slot_environment(
+    slot: str,
+    *,
+    backend_image: str,
+    bot_image: str,
+) -> dict[str, str]:
+    env = os.environ.copy()
+    upper = slot.upper()
+    env[f"BACKEND_{upper}_IMAGE"] = backend_image
+    env[f"BOT_{upper}_IMAGE"] = bot_image
+    return env
+
+
+def _image_digest(image: str, expected_revision: str) -> str:
+    result = _run(
+        [
+            "docker",
+            "image",
+            "inspect",
+            "--format",
+            '{{json .RepoDigests}}|{{index .Config.Labels "org.opencontainers.image.revision"}}',
+            image,
+        ],
+        capture=True,
+    ).stdout.strip()
+    digests_json, separator, revision = result.partition("|")
+    if not separator or revision != expected_revision:
+        raise DeploymentError(
+            f"image {image} revision {revision!r} does not match {expected_revision}"
+        )
+    digests = json.loads(digests_json)
+    if not isinstance(digests, list) or not digests:
+        raise DeploymentError(f"image {image} has no immutable repository digest")
+    repository = image.split("@", 1)[0].rsplit(":", 1)[0]
+    matching = [
+        value for value in digests if isinstance(value, str) and value.startswith(repository)
+    ]
+    digest = matching[0] if matching else digests[0]
+    if not isinstance(digest, str) or "@sha256:" not in digest:
+        raise DeploymentError(f"image {image} returned an invalid repository digest")
+    return digest
+
+
+def _capacity() -> dict[str, int]:
+    memory_kib = 0
+    meminfo = Path("/proc/meminfo")
+    if meminfo.is_file():
+        for line in meminfo.read_text(encoding="utf-8").splitlines():
+            if line.startswith("MemAvailable:"):
+                memory_kib = int(line.split()[1])
+                break
+    disk = shutil.disk_usage(Path.cwd())
+    report = {
+        "cpu_count": os.cpu_count() or 0,
+        "memory_available_mb": memory_kib // 1024,
+        "disk_available_mb": disk.free // (1024 * 1024),
+    }
+    minimums = {
+        "cpu_count": int(_deployment_setting("DEPLOY_MIN_CPU_COUNT", "2")),
+        "memory_available_mb": int(_deployment_setting("DEPLOY_MIN_AVAILABLE_MEMORY_MB", "1536")),
+        "disk_available_mb": int(_deployment_setting("DEPLOY_MIN_AVAILABLE_DISK_MB", "4096")),
+    }
+    missing = {
+        key: (report[key], required) for key, required in minimums.items() if report[key] < required
+    }
+    if missing:
+        raise DeploymentError(f"parallel-slot capacity gate failed: {missing}")
+    return report
+
+
+@contextlib.contextmanager
+def _deployment_lock(path: Path) -> Iterator[None]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+", encoding="utf-8") as lock_file:
+        if fcntl is None:
+            yield
+            return
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            raise DeploymentError("another production deployment owns the host lock") from exc
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _switch_gateway(active_slot: str, fallback_slot: str) -> None:
+    gateway_env = [
+        "-e",
+        f"YFC_ACTIVE_UPSTREAM={_upstream(active_slot)}",
+        "-e",
+        f"YFC_ASSET_FALLBACK_UPSTREAM={_upstream(fallback_slot)}",
+    ]
+    base = ["exec", "-T", *gateway_env, "edge", "caddy"]
+    _compose(
+        *base,
+        "validate",
+        "--config",
+        "/etc/caddy/Caddyfile",
+        "--adapter",
+        "caddyfile",
+    )
+    expected_config = json.loads(
+        _compose(
+            *base,
+            "adapt",
+            "--config",
+            "/etc/caddy/Caddyfile",
+            "--adapter",
+            "caddyfile",
+            capture=True,
+        ).stdout
+    )
+    current_config = json.loads(
+        _compose(
+            "exec",
+            "-T",
+            "edge",
+            "wget",
+            "-qO-",
+            "http://127.0.0.1:2019/config/",
+            capture=True,
+        ).stdout
+    )
+    if current_config == expected_config:
+        return
+    deadline = time.monotonic() + float(
+        _deployment_setting("DEPLOY_GATEWAY_IDLE_TIMEOUT_SECONDS", "30")
+    )
+    while time.monotonic() < deadline:
+        upstreams = json.loads(
+            _compose(
+                "exec",
+                "-T",
+                "edge",
+                "wget",
+                "-qO-",
+                "http://127.0.0.1:2019/reverse_proxy/upstreams",
+                capture=True,
+            ).stdout
+        )
+        if isinstance(upstreams, list) and all(
+            isinstance(item, dict) and item.get("num_requests") == 0 for item in upstreams
+        ):
+            break
+        time.sleep(0.05)
+    else:
+        raise DeploymentError("gateway had no bounded request-free switch point")
+    _compose(
+        *base,
+        "reload",
+        "--config",
+        "/etc/caddy/Caddyfile",
+        "--adapter",
+        "caddyfile",
+    )
+    current = _compose(
+        "exec",
+        "-T",
+        "edge",
+        "wget",
+        "-qO-",
+        "http://127.0.0.1:2019/config/",
+        capture=True,
+    ).stdout
+    if _upstream(active_slot) not in current:
+        raise DeploymentError("gateway reload returned without the requested active upstream")
+
+
+def _service_is_running(service: str) -> bool:
+    result = _compose("ps", "--status", "running", "--services", service, capture=True)
+    return service in result.stdout.splitlines()
+
+
+def _consumer_lease(service: str, required_markers: tuple[str, ...]) -> ConsumerLease:
+    container_id = _compose("ps", "-q", service, capture=True).stdout.strip()
+    if not container_id:
+        raise DeploymentError(f"{service} has no container for ownership verification")
+    started_at = _run(
+        ["docker", "inspect", "--format", "{{.State.StartedAt}}", container_id],
+        capture=True,
+    ).stdout.strip()
+    if not started_at:
+        raise DeploymentError(f"{service} has no current container start boundary")
+    return ConsumerLease(service, container_id, started_at, required_markers)
+
+
+def _current_run_logs(lease: ConsumerLease) -> str:
+    return _compose(
+        "logs",
+        "--no-color",
+        "--since",
+        lease.started_at,
+        lease.service,
+        capture=True,
+    ).stdout
+
+
+def _wait_for_ownership(lease: ConsumerLease, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not _lease_is_current_and_healthy(lease, require_markers=False):
+            raise DeploymentError(f"{lease.service} stopped before ownership confirmation")
+        output = _current_run_logs(lease)
+        if all(marker in output for marker in lease.required_markers):
+            return
+        time.sleep(1)
+    raise DeploymentError(f"{lease.service} ownership confirmation timed out")
+
+
+def _lease_is_current_and_healthy(lease: ConsumerLease, *, require_markers: bool = True) -> bool:
+    if not _service_is_running(lease.service):
+        return False
+    current_id = _compose("ps", "-q", lease.service, capture=True).stdout.strip()
+    if current_id != lease.container_id:
+        return False
+    current_started_at = _run(
+        ["docker", "inspect", "--format", "{{.State.StartedAt}}", current_id],
+        capture=True,
+    ).stdout.strip()
+    if current_started_at != lease.started_at:
+        return False
+    health = _run(
+        [
+            "docker",
+            "inspect",
+            "--format",
+            "{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}",
+            current_id,
+        ],
+        capture=True,
+    ).stdout.strip()
+    if health not in {"healthy", "running"}:
+        return False
+    return not require_markers or all(
+        marker in _current_run_logs(lease) for marker in lease.required_markers
+    )
+
+
+def _stop_slot_consumers(slot: str, config: DeployConfig, *, require_running: bool = True) -> None:
+    worker = _slot_service("worker", slot)
+    if _service_is_running(worker):
+        worker_lease = _consumer_lease(worker, ("worker_started",))
+        _compose("stop", "-t", str(config.worker_drain_seconds), worker)
+        if "worker_stopped" not in _current_run_logs(worker_lease):
+            raise DeploymentError(
+                f"{worker} did not acknowledge a completed drain within "
+                f"{config.worker_drain_seconds}s; consumer state is uncertain"
+            )
+    elif require_running:
+        raise DeploymentError(f"{worker} was not running before consumer handoff")
+    bot = _slot_service("bot", slot)
+    if _service_is_running(bot):
+        _compose("stop", "-t", str(config.bot_drain_seconds), bot)
+    elif require_running:
+        raise DeploymentError(f"{bot} was not running before consumer handoff")
+
+
+def _start_slot_consumers(
+    slot: str,
+    *,
+    env: dict[str, str],
+    evidence: Evidence,
+    config: DeployConfig,
+) -> tuple[ConsumerLease, ConsumerLease]:
+    ownership_timeout = config.readiness_timeout_seconds
+    worker = _slot_service("worker", slot)
+    started = time.monotonic()
+    if slot == "legacy":
+        _compose("start", worker)
+    else:
+        _compose(
+            "up",
+            "-d",
+            "--no-build",
+            "--no-deps",
+            "--wait",
+            "--wait-timeout",
+            str(ownership_timeout),
+            worker,
+            env=env,
+        )
+    worker_lease = _consumer_lease(worker, ("worker_started",))
+    _wait_for_ownership(worker_lease, timeout=ownership_timeout)
+    evidence.worker_handoff_seconds = round(time.monotonic() - started, 3)
+
+    bot = _slot_service("bot", slot)
+    started = time.monotonic()
+    if slot == "legacy":
+        _compose("start", bot)
+    else:
+        _compose("up", "-d", "--no-build", "--no-deps", bot, env=env)
+    bot_markers = (
+        ("polling_file_lock_acquired", "telegram_polling_started")
+        if config.bot_polling_enabled
+        else ("polling_disabled",)
+    )
+    bot_lease = _consumer_lease(bot, bot_markers)
+    _wait_for_ownership(bot_lease, timeout=ownership_timeout)
+    evidence.bot_handoff_seconds = round(time.monotonic() - started, 3)
+    return worker_lease, bot_lease
+
+
+def _candidate_smoke(slot: str) -> None:
+    if slot == "legacy":
+        _run(
+            [
+                sys.executable,
+                "scripts/check_deployment.py",
+                "http://127.0.0.1:8000",
+                "--allow-http",
+                "--expected-environment",
+                "prod",
+            ]
+        )
+        return
+    _compose(
+        "exec",
+        "-T",
+        _slot_service("backend", slot),
+        "python",
+        "/app/scripts/check_deployment.py",
+        "http://127.0.0.1:8000",
+        "--allow-http",
+        "--expected-environment",
+        "prod",
+    )
+
+
+def _public_smoke(config: DeployConfig) -> None:
+    _run(
+        [
+            sys.executable,
+            "scripts/check_deployment.py",
+            config.base_url,
+            "--expected-environment",
+            "prod",
+        ]
+    )
+    _run([sys.executable, "scripts/check_seo_surface.py", config.public_base_url])
+
+
+def _write_evidence(path: Path, evidence: Evidence) -> None:
+    evidence.ended_at = time.time()
+    _atomic_json(path, asdict(evidence))
+
+
+@contextlib.contextmanager
+def _stage(evidence: Evidence, name: str) -> Iterator[None]:
+    stage = StageRecord(name=name, started_at=time.time())
+    evidence.stages.append(stage)
+    try:
+        yield
+    except BaseException as exc:
+        stage.status = "failed"
+        stage.reason = f"{type(exc).__name__}: {exc}"
+        raise
+    else:
+        stage.status = "passed"
+    finally:
+        stage.ended_at = time.time()
+
+
+def _start_probe(
+    config: DeployConfig,
+    output: Path,
+    stop_file: Path,
+    compatibility_stop_file: Path,
+) -> subprocess.Popen[str]:
+    maximum_duration = max(
+        300.0,
+        config.readiness_timeout_seconds + config.observation_seconds + 300.0,
+    )
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "scripts/continuous_deployment_probe.py",
+            config.base_url,
+            "--duration",
+            str(maximum_duration),
+            "--interval",
+            str(config.probe_interval_seconds),
+            "--timeout",
+            str(config.probe_timeout_seconds),
+            "--expected-environment",
+            "prod",
+            "--output",
+            str(output),
+            "--stop-file",
+            str(stop_file),
+            "--compatibility-stop-file",
+            str(compatibility_stop_file),
+        ],
+        text=True,
+    )
+
+
+def _wait_observation(
+    process: subprocess.Popen[str],
+    seconds: float,
+    services: Sequence[str],
+    consumer_leases: Sequence[ConsumerLease],
+) -> None:
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        code = process.poll()
+        if code is not None:
+            raise DeploymentError(f"continuous public probe stopped early with exit code {code}")
+        for service in services:
+            if not _service_is_running(service):
+                raise DeploymentError(f"{service} stopped during the observation window")
+        for lease in consumer_leases:
+            if not _lease_is_current_and_healthy(lease):
+                raise DeploymentError(
+                    f"{lease.service} lost current-run ownership or health during observation"
+                )
+        time.sleep(min(5.0, max(0.0, deadline - time.monotonic())))
+
+
+def _finish_probe(
+    process: subprocess.Popen[str], output: Path, stop_file: Path
+) -> dict[str, object]:
+    _atomic_text(stop_file, "stop\n")
+    try:
+        return_code = process.wait(timeout=60)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+        raise DeploymentError("continuous public probe did not stop cleanly")
+    if not output.is_file():
+        raise DeploymentError(f"continuous probe did not write {output}")
+    report = json.loads(output.read_text(encoding="utf-8"))
+    if return_code != 0 or report.get("failure_count") != 0:
+        raise DeploymentError(f"continuous public probe failed: {report}")
+    return report
+
+
+def bootstrap_state(config: DeployConfig) -> None:
+    state_path = config.state_root / "state.json"
+    if state_path.exists():
+        raise DeploymentError(f"deployment state already exists: {state_path}")
+    for service in ("backend", "worker", "bot", "edge"):
+        if not _service_is_running(service):
+            raise DeploymentError(f"legacy bootstrap requires running service {service}")
+    _public_smoke(config)
+    backend_container = _compose("ps", "-q", "backend", capture=True).stdout.strip()
+    bot_container = _compose("ps", "-q", "bot", capture=True).stdout.strip()
+    backend_image_ref = _run(
+        ["docker", "inspect", "--format", "{{.Config.Image}}", backend_container], capture=True
+    ).stdout.strip()
+    bot_image_ref = _run(
+        ["docker", "inspect", "--format", "{{.Config.Image}}", bot_container], capture=True
+    ).stdout.strip()
+    active_revision_path = config.state_root / "last-successful-revision"
+    if not active_revision_path.is_file():
+        raise DeploymentError("legacy bootstrap requires last-successful-revision evidence")
+    active_revision = active_revision_path.read_text(encoding="utf-8").strip()
+    backend_image = _image_digest(backend_image_ref, active_revision)
+    bot_image = _image_digest(bot_image_ref, active_revision)
+    _compose("up", "-d", "--no-build", "--no-deps", "--wait", "edge")
+    _switch_gateway("legacy", "legacy")
+    state = ReleaseState(
+        version=STATE_VERSION,
+        active_slot="legacy",
+        active_revision=active_revision,
+        active_backend_image=backend_image,
+        active_bot_image=bot_image,
+    )
+    _atomic_json(state_path, asdict(state))
+    _public_smoke(config)
+    print(f"Zero-downtime state initialized at legacy revision {active_revision}")
+
+
+def rollback(config: DeployConfig) -> None:
+    state_path = config.state_root / "state.json"
+    state = ReleaseState.from_path(state_path)
+    if state.active_revision != config.target_revision:
+        raise DeploymentError(
+            f"rollback expected active revision {config.target_revision}, found {state.active_revision}"
+        )
+    if (
+        state.rollback_slot is None
+        or state.rollback_revision is None
+        or state.rollback_backend_image is None
+        or state.rollback_bot_image is None
+    ):
+        raise DeploymentError("deployment state has no rollback-capable revision")
+
+    rollback_env = (
+        _slot_environment(
+            state.rollback_slot,
+            backend_image=state.rollback_backend_image,
+            bot_image=state.rollback_bot_image,
+        )
+        if state.rollback_slot != "legacy"
+        else os.environ.copy()
+    )
+    rollback_backend = _slot_service("backend", state.rollback_slot)
+    if state.rollback_slot == "legacy":
+        _compose("start", rollback_backend)
+    else:
+        _compose(
+            "up",
+            "-d",
+            "--no-build",
+            "--no-deps",
+            "--wait",
+            "--wait-timeout",
+            str(config.readiness_timeout_seconds),
+            rollback_backend,
+            env=rollback_env,
+        )
+    _candidate_smoke(state.rollback_slot)
+
+    switched = False
+    consumers_stopped = False
+    state_committed = False
+    try:
+        _switch_gateway(state.rollback_slot, state.active_slot)
+        switched = True
+        _public_smoke(config)
+        consumers_stopped = True
+        _stop_slot_consumers(state.active_slot, config)
+        rollback_evidence = Evidence(
+            deployment_id=f"rollback-{int(time.time())}-{state.rollback_revision[:12]}",
+            target_revision=state.rollback_revision,
+            previous_revision=state.active_revision,
+            active_slot=state.active_slot,
+            candidate_slot=state.rollback_slot,
+            started_at=time.time(),
+        )
+        _start_slot_consumers(
+            state.rollback_slot, env=rollback_env, evidence=rollback_evidence, config=config
+        )
+        next_state = ReleaseState(
+            version=STATE_VERSION,
+            active_slot=state.rollback_slot,
+            active_revision=state.rollback_revision,
+            active_backend_image=state.rollback_backend_image,
+            active_bot_image=state.rollback_bot_image,
+            rollback_slot=state.active_slot,
+            rollback_revision=state.active_revision,
+            rollback_backend_image=state.active_backend_image,
+            rollback_bot_image=state.active_bot_image,
+        )
+        _public_smoke(config)
+        _atomic_json(state_path, asdict(next_state))
+        state_committed = True
+        _atomic_text(config.state_root / "last-successful-revision", state.rollback_revision + "\n")
+    except BaseException:
+        if switched and not state_committed:
+            with contextlib.suppress(BaseException):
+                _switch_gateway(state.active_slot, state.active_slot)
+                if consumers_stopped:
+                    active_env = (
+                        _slot_environment(
+                            state.active_slot,
+                            backend_image=state.active_backend_image,
+                            bot_image=state.active_bot_image,
+                        )
+                        if state.active_slot != "legacy"
+                        else os.environ.copy()
+                    )
+                    _stop_slot_consumers(state.rollback_slot, config)
+                    _start_slot_consumers(
+                        state.active_slot,
+                        env=active_env,
+                        evidence=rollback_evidence,
+                        config=config,
+                    )
+                _public_smoke(config)
+        raise
+    print(
+        f"Rollback verified: active revision={state.rollback_revision}; slot={state.rollback_slot}"
+    )
+
+
+def deploy(config: DeployConfig) -> Evidence:
+    state_path = config.state_root / "state.json"
+    if not state_path.is_file():
+        raise DeploymentError(
+            "zero-downtime state is not initialized; use the documented owner-approved bootstrap"
+        )
+    state = ReleaseState.from_path(state_path)
+    if state.active_revision == config.target_revision:
+        _switch_gateway(state.active_slot, state.active_slot)
+        if state.rollback_slot is not None:
+            _compose("stop", "-t", "45", _slot_service("backend", state.rollback_slot))
+        _atomic_text(config.state_root / "last-successful-revision", config.target_revision + "\n")
+        _public_smoke(config)
+        print(f"Revision {config.target_revision} is already active; verified idempotent no-op")
+        return Evidence(
+            deployment_id=f"noop-{config.target_revision[:12]}",
+            target_revision=config.target_revision,
+            previous_revision=state.active_revision,
+            active_slot=state.active_slot,
+            candidate_slot=state.active_slot,
+            started_at=time.time(),
+            ended_at=time.time(),
+            verdict="active",
+        )
+
+    candidate_slot = "blue" if state.active_slot in {"legacy", "green"} else "green"
+    deployment_id = f"{int(time.time())}-{config.target_revision[:12]}-{uuid.uuid4().hex[:8]}"
+    deployment_root = config.state_root / deployment_id
+    evidence_path = deployment_root / "summary.json"
+    probe_path = deployment_root / "continuous-probe.json"
+    probe_stop_path = deployment_root / "continuous-probe.stop"
+    compatibility_stop_path = deployment_root / "asset-compatibility.stop"
+    evidence = Evidence(
+        deployment_id=deployment_id,
+        target_revision=config.target_revision,
+        previous_revision=state.active_revision,
+        active_slot=state.active_slot,
+        candidate_slot=candidate_slot,
+        started_at=time.time(),
+    )
+    candidate_backend = config.backend_image
+    candidate_bot = config.bot_image
+    candidate_env: dict[str, str] | None = None
+    probe: subprocess.Popen[str] | None = None
+    switched = False
+    state_committed = False
+    candidate_backend_mutated = False
+    candidate_consumers_mutated = False
+    consumers_stopped = False
+
+    try:
+        with _stage(evidence, "preflight"):
+            evidence.capacity = _capacity()
+            _compose("config", "--quiet")
+            _switch_gateway(state.active_slot, state.active_slot)
+            _public_smoke(config)
+
+        with _stage(evidence, "pull_and_verify"):
+            preliminary_env = _slot_environment(
+                candidate_slot,
+                backend_image=config.backend_image,
+                bot_image=config.bot_image,
+            )
+            _compose(
+                "pull",
+                "setup",
+                _slot_service("backend", candidate_slot),
+                _slot_service("worker", candidate_slot),
+                _slot_service("bot", candidate_slot),
+                env=preliminary_env,
+            )
+            candidate_backend = _image_digest(config.backend_image, config.target_revision)
+            candidate_bot = _image_digest(config.bot_image, config.target_revision)
+            candidate_env = _slot_environment(
+                candidate_slot,
+                backend_image=candidate_backend,
+                bot_image=candidate_bot,
+            )
+            candidate_env["BACKEND_IMAGE"] = candidate_backend
+            candidate_env["BOT_IMAGE"] = candidate_bot
+            _compose("config", "--quiet", env=candidate_env)
+            _run(
+                [
+                    "docker",
+                    "run",
+                    "--rm",
+                    "--network",
+                    "none",
+                    "--env-file",
+                    ".env",
+                    candidate_backend,
+                    "python",
+                    "-c",
+                    "from fitminiapp_api.core.config import settings; assert settings.app_env == 'prod'",
+                ],
+            )
+            _run(
+                [
+                    "docker",
+                    "run",
+                    "--rm",
+                    "--network",
+                    "none",
+                    "--env-file",
+                    ".env",
+                    candidate_bot,
+                    "python",
+                    "-c",
+                    "from fitminiapp_bot.config import settings; assert settings.app_env == 'prod'",
+                ],
+            )
+
+        probe = _start_probe(config, probe_path, probe_stop_path, compatibility_stop_path)
+
+        with _stage(evidence, "backup"):
+            _run([sys.executable, "scripts/db_maintenance.py", "backup"])
+
+        with _stage(evidence, "migration"):
+            _run(
+                [
+                    sys.executable,
+                    "scripts/check_online_migrations.py",
+                    state.active_revision,
+                    config.target_revision,
+                ]
+            )
+            _compose("run", "--rm", "--no-deps", "setup", env=candidate_env)
+
+        with _stage(evidence, "candidate_start"):
+            candidate_backend_service = _slot_service("backend", candidate_slot)
+            candidate_backend_mutated = True
+            _compose(
+                "up",
+                "-d",
+                "--no-build",
+                "--no-deps",
+                "--wait",
+                "--wait-timeout",
+                str(config.readiness_timeout_seconds),
+                candidate_backend_service,
+                env=candidate_env,
+            )
+
+        with _stage(evidence, "candidate_smoke"):
+            _candidate_smoke(candidate_slot)
+            if probe.poll() is not None:
+                raise DeploymentError("public route failed while the candidate was prepared")
+
+        with _stage(evidence, "traffic_switch"):
+            _switch_gateway(candidate_slot, state.active_slot)
+            switched = True
+
+        with _stage(evidence, "external_verification"):
+            _public_smoke(config)
+
+        with _stage(evidence, "consumer_handoff"):
+            consumers_stopped = True
+            _stop_slot_consumers(state.active_slot, config)
+            candidate_consumers_mutated = True
+            consumer_leases = _start_slot_consumers(
+                candidate_slot, env=candidate_env, evidence=evidence, config=config
+            )
+
+        with _stage(evidence, "observation"):
+            _wait_observation(
+                probe,
+                config.observation_seconds,
+                (
+                    _slot_service("backend", candidate_slot),
+                    _slot_service("worker", candidate_slot),
+                    _slot_service("bot", candidate_slot),
+                    "edge",
+                ),
+                consumer_leases,
+            )
+
+        with _stage(evidence, "drain_and_cleanup"):
+            _atomic_text(compatibility_stop_path, "compatibility window complete\n")
+            next_state = ReleaseState(
+                version=STATE_VERSION,
+                active_slot=candidate_slot,
+                active_revision=config.target_revision,
+                active_backend_image=candidate_backend,
+                active_bot_image=candidate_bot,
+                rollback_slot=state.active_slot,
+                rollback_revision=state.active_revision,
+                rollback_backend_image=state.active_backend_image,
+                rollback_bot_image=state.active_bot_image,
+            )
+            _switch_gateway(candidate_slot, candidate_slot)
+            evidence.probe = _finish_probe(probe, probe_path, probe_stop_path)
+            probe = None
+            _atomic_json(state_path, asdict(next_state))
+            state_committed = True
+            _atomic_text(
+                config.state_root / "last-successful-revision", config.target_revision + "\n"
+            )
+            _compose(
+                "stop",
+                "-t",
+                str(config.backend_drain_seconds),
+                _slot_service("backend", state.active_slot),
+            )
+            superseded_slot = state.rollback_slot
+            if superseded_slot not in {None, state.active_slot, candidate_slot}:
+                _compose(
+                    "rm",
+                    "-f",
+                    "-s",
+                    _slot_service("backend", superseded_slot),
+                    _slot_service("worker", superseded_slot),
+                    _slot_service("bot", superseded_slot),
+                )
+        evidence.verdict = "active"
+        return evidence
+    except BaseException:
+        rollback_verified = not switched
+        if switched and not state_committed:
+            rollback_stage = StageRecord(name="rollback", started_at=time.time())
+            evidence.stages.append(rollback_stage)
+            try:
+                _switch_gateway(state.active_slot, state.active_slot)
+                if candidate_consumers_mutated:
+                    _stop_slot_consumers(candidate_slot, config, require_running=False)
+                active_env = (
+                    _slot_environment(
+                        state.active_slot,
+                        backend_image=state.active_backend_image,
+                        bot_image=state.active_bot_image,
+                    )
+                    if state.active_slot != "legacy"
+                    else os.environ.copy()
+                )
+                if consumers_stopped:
+                    _start_slot_consumers(
+                        state.active_slot, env=active_env, evidence=evidence, config=config
+                    )
+                _public_smoke(config)
+                evidence.verdict = "rolled back"
+                rollback_verified = True
+                rollback_stage.status = "passed"
+            except BaseException as rollback_exc:
+                rollback_stage.status = "failed"
+                rollback_stage.reason = f"{type(rollback_exc).__name__}: {rollback_exc}"
+                evidence.verdict = "manual intervention required"
+            finally:
+                rollback_stage.ended_at = time.time()
+        else:
+            if not state_committed:
+                evidence.verdict = "not switched"
+        if not state_committed and rollback_verified:
+            mutated_services = []
+            if candidate_backend_mutated:
+                mutated_services.append(_slot_service("backend", candidate_slot))
+            if candidate_consumers_mutated:
+                mutated_services.extend(
+                    (
+                        _slot_service("worker", candidate_slot),
+                        _slot_service("bot", candidate_slot),
+                    )
+                )
+            with contextlib.suppress(BaseException):
+                if mutated_services:
+                    _compose("rm", "-f", "-s", *mutated_services)
+        raise
+    finally:
+        if probe is not None:
+            with contextlib.suppress(BaseException):
+                evidence.probe = _finish_probe(probe, probe_path, probe_stop_path)
+        _write_evidence(evidence_path, evidence)
+
+
+def _config(args: argparse.Namespace) -> DeployConfig:
+    root = Path.cwd().resolve()
+    polling_value = _deployment_setting("BOT_POLLING_ENABLED", "true").strip().lower()
+    if polling_value not in {"1", "true", "yes", "on", "0", "false", "no", "off"}:
+        raise DeploymentError("BOT_POLLING_ENABLED must be a boolean value")
+    return DeployConfig(
+        target_revision=args.target_revision,
+        base_url=args.base_url,
+        public_base_url=args.public_base_url,
+        backend_image=os.environ["BACKEND_IMAGE"],
+        bot_image=os.environ["BOT_IMAGE"],
+        root=root,
+        state_root=root / ".artifacts" / "deployments",
+        observation_seconds=float(_deployment_setting("DEPLOY_OBSERVATION_SECONDS", "900")),
+        readiness_timeout_seconds=configured_timeout("DEPLOY_READINESS_TIMEOUT_SECONDS", 180),
+        probe_interval_seconds=float(_deployment_setting("DEPLOY_PROBE_INTERVAL_SECONDS", "1")),
+        probe_timeout_seconds=float(_deployment_setting("DEPLOY_PROBE_TIMEOUT_SECONDS", "5")),
+        backend_drain_seconds=configured_timeout("DEPLOY_BACKEND_DRAIN_SECONDS", 45),
+        worker_drain_seconds=configured_timeout("DEPLOY_WORKER_DRAIN_SECONDS", 90),
+        bot_drain_seconds=configured_timeout("DEPLOY_BOT_DRAIN_SECONDS", 45),
+        bot_polling_enabled=polling_value in {"1", "true", "yes", "on"},
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    for command in ("deploy", "bootstrap", "rollback"):
+        subparser = subparsers.add_parser(command)
+        subparser.add_argument("target_revision")
+        subparser.add_argument("base_url")
+        subparser.add_argument("public_base_url")
+    args = parser.parse_args()
+    try:
+        config = _config(args)
+        with _deployment_lock(config.state_root / "deployment.lock"):
+            if args.command == "bootstrap":
+                bootstrap_state(config)
+            elif args.command == "rollback":
+                rollback(config)
+            else:
+                evidence = deploy(config)
+                print(
+                    f"Deployment verdict: {evidence.verdict}; "
+                    f"revision={evidence.target_revision}; slot={evidence.candidate_slot}"
+                )
+    except (KeyError, OSError, ValueError, subprocess.CalledProcessError, DeploymentError) as exc:
+        print(f"Zero-downtime deployment failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/zero-downtime/docker-compose.yml
+++ b/tests/fixtures/zero-downtime/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  release-a:
+    image: ${DRILL_APP_IMAGE:-fit-mini-app-backend:local}
+    command: python /drill/server.py a
+    volumes:
+      - ./server.py:/drill/server.py:ro
+
+  release-b:
+    image: ${DRILL_APP_IMAGE:-fit-mini-app-backend:local}
+    command: python /drill/server.py b
+    volumes:
+      - ./server.py:/drill/server.py:ro
+
+  edge:
+    image: ${CADDY_IMAGE:-caddy:2-alpine}
+    command: caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
+    environment:
+      YFC_ACTIVE_UPSTREAM: release-a:8000
+      YFC_ASSET_FALLBACK_UPSTREAM: release-a:8000
+    ports:
+      - "127.0.0.1:${DRILL_PORT:-18080}:8080"
+    volumes:
+      - ../../../deploy/Caddyfile.edge:/etc/caddy/Caddyfile:ro

--- a/tests/fixtures/zero-downtime/server.py
+++ b/tests/fixtures/zero-downtime/server.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+REVISION = sys.argv[1].lower()
+WRITE_RESULTS: dict[str, int] = {}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, format: str, *args: object) -> None:
+        del format, args
+
+    def _send(
+        self,
+        status: int,
+        body: bytes,
+        content_type: str,
+        *,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        for key, value in (headers or {}).items():
+            self.send_header(key, value)
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:
+        path = self.path.split("?", 1)[0]
+        if path in {"/health", "/health/live", "/health/ready"}:
+            self._send(200, b'{"status":"ok"}', "application/json")
+            return
+        if path == "/api/v1/public/config":
+            body = json.dumps(
+                {
+                    "app_env": "prod",
+                    "enable_dev_auth": False,
+                    "enable_web_auth": True,
+                    "enable_email_auth": False,
+                }
+            ).encode()
+            self._send(200, body, "application/json")
+            return
+        if path == "/api/v1/me":
+            self._send(401, b'{"detail":"Not authenticated"}', "application/json")
+            return
+        if path in {"/", "/app", "/login"}:
+            body = (
+                f'<div id="root" data-revision="{REVISION}"></div>'
+                f'<script src="/assets/app-{REVISION}.js"></script>'
+            ).encode()
+            self._send(
+                200,
+                body,
+                "text/html; charset=utf-8",
+                headers={"Cache-Control": "no-store"},
+            )
+            return
+        if path == f"/assets/app-{REVISION}.js":
+            self._send(
+                200,
+                f'globalThis.release="{REVISION}";'.encode(),
+                "text/javascript",
+                headers={"Cache-Control": "public, max-age=31536000, immutable"},
+            )
+            return
+        if path == "/session":
+            cookie = self.headers.get("Cookie", "")
+            if "drill_session=stable" not in cookie:
+                self._send(
+                    200,
+                    b"stable",
+                    "text/plain",
+                    headers={"Set-Cookie": "drill_session=stable; Path=/; HttpOnly"},
+                )
+            else:
+                self._send(200, b"stable", "text/plain")
+            return
+        self._send(404, b"missing", "text/plain")
+
+    def do_POST(self) -> None:
+        if self.path != "/write":
+            self._send(404, b"missing", "text/plain")
+            return
+        operation_id = self.headers.get("Idempotency-Key", "missing")
+        WRITE_RESULTS[operation_id] = WRITE_RESULTS.get(operation_id, 0) + 1
+        body = json.dumps(
+            {
+                "revision": REVISION,
+                "operation_id": operation_id,
+                "count": WRITE_RESULTS[operation_id],
+            }
+        ).encode()
+        self._send(200, body, "application/json")
+
+
+ThreadingHTTPServer(("0.0.0.0", 8000), Handler).serve_forever()

--- a/tests/test_check_deployment.py
+++ b/tests/test_check_deployment.py
@@ -34,6 +34,13 @@ def _fake_read(config: dict[str, object]):
             json.dumps(config).encode(),
             "application/json",
         ),
+        "/api/v1/me": check_deployment.HttpResponse(
+            status=401,
+            body=b'{"detail":"Not authenticated"}',
+            content_type="application/json",
+            final_url=f"{base_url}/api/v1/me",
+            headers={"cache-control": "no-store"},
+        ),
         "/app": response("/app", html, "text/html; charset=utf-8"),
         "/login": response("/login", html, "text/html; charset=utf-8"),
         "/app?tgWebAppPlatform=android": response(

--- a/tests/test_continuous_deployment_probe.py
+++ b/tests/test_continuous_deployment_probe.py
@@ -1,0 +1,82 @@
+from scripts import continuous_deployment_probe as probe
+from scripts.check_deployment import HttpResponse
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    def __call__(self) -> float:
+        return self.value
+
+    def sleep(self, seconds: float) -> None:
+        self.value += seconds
+
+
+def _response(path: str, *, status: int = 200, body: bytes = b"ok") -> HttpResponse:
+    return HttpResponse(
+        status=status,
+        body=body,
+        content_type="text/html",
+        final_url=f"https://app.example.test{path}",
+        headers={"cache-control": "public, immutable"},
+    )
+
+
+def test_probe_keeps_the_initial_asset_across_switch(monkeypatch) -> None:
+    clock = FakeClock()
+    reads: list[str] = []
+
+    def read(_base_url: str, path: str, *, timeout: float) -> HttpResponse:
+        assert timeout == 1
+        reads.append(path)
+        if path == "/app":
+            return _response(
+                path, body=b'<div id="root"></div><script src="/assets/a-old.js"></script>'
+            )
+        return _response(path, body=b"old asset")
+
+    monkeypatch.setattr(probe, "_read", read)
+    monkeypatch.setattr(probe, "check_deployment", lambda *args, **kwargs: "prod")
+
+    report = probe.run_probe(
+        "https://app.example.test",
+        duration=2,
+        interval=1,
+        timeout=1,
+        expected_environment="prod",
+        clock=clock,
+        sleeper=clock.sleep,
+    )
+
+    assert report.failure_count == 0
+    assert report.compatibility_asset == "/assets/a-old.js"
+    assert reads.count("/assets/a-old.js") == 3
+
+
+def test_probe_classifies_broken_old_asset(monkeypatch) -> None:
+    clock = FakeClock()
+
+    def read(_base_url: str, path: str, *, timeout: float) -> HttpResponse:
+        del timeout
+        if path == "/app":
+            return _response(
+                path, body=b'<div id="root"></div><script src="/assets/a-old.js"></script>'
+            )
+        return _response(path, status=404, body=b"")
+
+    monkeypatch.setattr(probe, "_read", read)
+    monkeypatch.setattr(probe, "check_deployment", lambda *args, **kwargs: "prod")
+
+    report = probe.run_probe(
+        "https://app.example.test",
+        duration=0,
+        interval=1,
+        timeout=1,
+        expected_environment="prod",
+        clock=clock,
+        sleeper=clock.sleep,
+    )
+
+    assert report.failure_count == 1
+    assert report.failures["asset_mismatch"] == 1

--- a/tests/test_online_migrations.py
+++ b/tests/test_online_migrations.py
@@ -1,0 +1,189 @@
+from pathlib import Path
+
+import pytest
+from scripts.check_online_migrations import OnlineMigrationError, validate_added_migration
+
+
+def _migration(path: Path, body: str) -> Path:
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_online_migration_accepts_declared_additive_expand(tmp_path: Path) -> None:
+    path = _migration(
+        tmp_path / "0064_expand.py",
+        'online_rollout_phase = "expand"\n'
+        'online_rollout_notes = "Nullable additive column; metadata-only lock."\n\n'
+        "def upgrade():\n"
+        '    op.add_column("users", sa.Column("nickname", sa.String(), nullable=True))\n'
+        '\ndef downgrade():\n    op.drop_column("users", "nickname")\n',
+    )
+
+    validate_added_migration(path)
+
+
+@pytest.mark.parametrize("operation", ["drop_table", "drop_column", "alter_column"])
+def test_online_migration_rejects_destructive_contract_operation(
+    tmp_path: Path, operation: str
+) -> None:
+    path = _migration(
+        tmp_path / "0064_contract.py",
+        f'online_rollout_phase = "expand"\n'
+        f'online_rollout_notes = "reviewed"\n\ndef upgrade():\n    op.{operation}("users")\n',
+    )
+
+    with pytest.raises(OnlineMigrationError, match="destructive operations"):
+        validate_added_migration(path)
+
+
+def test_online_backfill_requires_bounded_idempotency_notes(tmp_path: Path) -> None:
+    path = _migration(
+        tmp_path / "0064_backfill.py",
+        'online_rollout_phase = "backfill"\n\ndef upgrade():\n    op.execute("UPDATE users")\n',
+    )
+
+    with pytest.raises(OnlineMigrationError, match="online_rollout_notes"):
+        validate_added_migration(path)
+
+
+def test_online_backfill_rejects_destructive_sql(tmp_path: Path) -> None:
+    path = _migration(
+        tmp_path / "0064_backfill.py",
+        'online_rollout_phase = "backfill"\n'
+        'online_rollout_notes = "bounded by primary key batches"\n\n'
+        "online_rollout_batch_size = 1000\n"
+        "online_rollout_idempotent = True\n\n"
+        'def upgrade():\n    op.execute("DELETE FROM users")\n',
+    )
+
+    with pytest.raises(OnlineMigrationError, match="destructive SQL"):
+        validate_added_migration(path)
+
+
+def test_online_backfill_accepts_explicit_bounded_idempotent_update(tmp_path: Path) -> None:
+    path = _migration(
+        tmp_path / "0064_backfill.py",
+        'online_rollout_phase = "backfill"\n'
+        'online_rollout_notes = "bounded deterministic update by primary key window"\n'
+        "online_rollout_batch_size = 1000\n"
+        "online_rollout_idempotent = True\n\n"
+        "def upgrade():\n"
+        '    op.execute("UPDATE users SET normalized = TRUE WHERE id >= 1 AND id < 1001")\n',
+    )
+
+    validate_added_migration(path)
+
+
+def test_online_backfill_rejects_unbounded_update(tmp_path: Path) -> None:
+    path = _migration(
+        tmp_path / "0064_backfill.py",
+        'online_rollout_phase = "backfill"\n'
+        'online_rollout_notes = "claimed bounded update"\n'
+        "online_rollout_batch_size = 1000\n"
+        "online_rollout_idempotent = True\n\n"
+        'def upgrade():\n    op.execute("UPDATE users SET normalized = TRUE")\n',
+    )
+
+    with pytest.raises(OnlineMigrationError, match="bounded UPDATE"):
+        validate_added_migration(path)
+
+
+@pytest.mark.parametrize("method", ["execute", "exec_driver_sql"])
+def test_online_migration_rejects_sql_execution_outside_op_contract(
+    tmp_path: Path, method: str
+) -> None:
+    path = _migration(
+        tmp_path / "0064_raw_connection.py",
+        'online_rollout_phase = "expand"\n'
+        'online_rollout_notes = "reviewed"\n\n'
+        "def upgrade():\n"
+        "    connection = context.get_bind()\n"
+        f'    connection.{method}(sa.text("DROP TABLE users"))\n',
+    )
+
+    with pytest.raises(OnlineMigrationError, match=r"outside the verified op\.execute"):
+        validate_added_migration(path)
+
+
+def test_online_migration_rejects_destructive_top_level_helper(tmp_path: Path) -> None:
+    path = _migration(
+        tmp_path / "0064_helper.py",
+        'online_rollout_phase = "expand"\n'
+        'online_rollout_notes = "reviewed"\n\n'
+        'def destroy():\n    op.drop_table("users")\n\n'
+        "def upgrade():\n    destroy()\n",
+    )
+
+    with pytest.raises(OnlineMigrationError, match="outside the 'expand' online allowlist"):
+        validate_added_migration(path)
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        'op.create_index("ix_users_email", "users", ["email"])',
+        'op.create_unique_constraint("uq_users_email", "users", ["email"])',
+        'op.create_foreign_key("fk_users_team", "users", "teams", ["team_id"], ["id"])',
+    ],
+)
+def test_online_expand_rejects_lock_prone_operations(tmp_path: Path, operation: str) -> None:
+    path = _migration(
+        tmp_path / "0064_locking.py",
+        'online_rollout_phase = "expand"\n'
+        'online_rollout_notes = "reviewed"\n\n'
+        f"def upgrade():\n    {operation}\n",
+    )
+
+    with pytest.raises(OnlineMigrationError, match="lock-prone operations"):
+        validate_added_migration(path)
+
+
+@pytest.mark.parametrize(
+    "column",
+    [
+        'sa.Column("nickname", sa.String(), nullable=False)',
+        'sa.Column("nickname", sa.String(), nullable=True, server_default="")',
+        'sa.Column("nickname", sa.String(), nullable=True, unique=True)',
+        'sa.Column("nickname", sa.String(), nullable=True, index=True)',
+    ],
+)
+def test_online_expand_rejects_rewrite_or_constraint_add_column(
+    tmp_path: Path, column: str
+) -> None:
+    path = _migration(
+        tmp_path / "0064_unsafe_column.py",
+        'online_rollout_phase = "expand"\n'
+        'online_rollout_notes = "reviewed"\n\n'
+        f'def upgrade():\n    op.add_column("users", {column})\n',
+    )
+
+    with pytest.raises(OnlineMigrationError, match="add_column"):
+        validate_added_migration(path)
+
+
+def test_online_expand_rejects_positional_foreign_key_in_add_column(tmp_path: Path) -> None:
+    path = _migration(
+        tmp_path / "0064_foreign_key.py",
+        'online_rollout_phase = "expand"\n'
+        'online_rollout_notes = "reviewed"\n\n'
+        "def upgrade():\n"
+        '    op.add_column("users", sa.Column("team_id", sa.Integer(), '
+        'sa.ForeignKey("teams.id"), nullable=True))\n',
+    )
+
+    with pytest.raises(OnlineMigrationError, match="positional constraints"):
+        validate_added_migration(path)
+
+
+def test_online_expand_rejects_two_argument_foreign_key_column(tmp_path: Path) -> None:
+    path = _migration(
+        tmp_path / "0064_foreign_key_only.py",
+        'online_rollout_phase = "expand"\n'
+        'online_rollout_notes = "reviewed"\n\n'
+        "def upgrade():\n"
+        '    op.add_column("users", sa.Column("team_id", '
+        'sa.ForeignKey("teams.id"), nullable=True))\n',
+    )
+
+    with pytest.raises(OnlineMigrationError, match="allowlisted static SQLAlchemy scalar type"):
+        validate_added_migration(path)

--- a/tests/test_release_safeguards.py
+++ b/tests/test_release_safeguards.py
@@ -19,16 +19,26 @@ def test_automated_deploy_keeps_revision_provenance_and_stale_run_guards() -> No
         'is no longer master head (\\$LATEST_MASTER_SHA)\\"' in deploy_workflow
     )
 
-    assert 'verify_image_revision "$BACKEND_IMAGE"' in deploy_script
-    assert 'verify_image_revision "$BOT_IMAGE"' in deploy_script
-    assert deploy_script.index('verify_image_revision "$BOT_IMAGE"') < deploy_script.index(
-        "Creating a pre-deploy database backup"
+    assert "scripts/zero_downtime_deploy.py" in deploy_script
+    assert "docker compose config --quiet" in deploy_script
+    assert "--remove-orphans" not in deploy_script
+    assert "docker compose up" not in deploy_script
+
+
+def test_slot_topology_keeps_gateway_stable_and_consumers_single_owner() -> None:
+    root = Path(__file__).resolve().parents[1]
+    compose = (root / "docker-compose.yml").read_text(encoding="utf-8")
+    edge = (root / "deploy" / "Caddyfile.edge").read_text(encoding="utf-8")
+    orchestrator = (root / "scripts" / "zero_downtime_deploy.py").read_text(encoding="utf-8")
+
+    assert "backend-blue:" in compose and "backend-green:" in compose
+    assert "worker-blue:" in compose and "worker-green:" in compose
+    assert "bot-blue:" in compose and "bot-green:" in compose
+    assert "edge_config:/config" in compose
+    assert "caddy run --resume" in (root / "deploy" / "edge-entrypoint.sh").read_text(
+        encoding="utf-8"
     )
-    assert 'scripts/check_deployment.py "$BASE_URL" --expected-environment prod' in deploy_script
-    assert deploy_script.index("--expected-environment prod") < deploy_script.index(
-        "last-successful-revision"
-    )
-    assert "docker compose ps --services --all | grep -qx caddy" in deploy_script
-    assert "docker compose ps --services --all | grep -qx cloudflared" in deploy_script
-    assert 'docker run --rm --network none --env-file .env "$BACKEND_IMAGE"' in deploy_script
-    assert 'docker run --rm --network none --env-file .env "$BOT_IMAGE"' in deploy_script
+    assert "handle_response @asset_missing" in edge
+    assert "lb_retries" not in edge
+    assert orchestrator.index('"validate"') < orchestrator.index('"reload"')
+    assert "another production deployment owns the host lock" in orchestrator

--- a/tests/test_zero_downtime_deploy.py
+++ b/tests/test_zero_downtime_deploy.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+import subprocess
+from dataclasses import asdict
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from scripts import zero_downtime_deploy as deploy
+
+OLD_SHA = "a" * 40
+NEW_SHA = "b" * 40
+
+
+class FakeProbe:
+    def poll(self):
+        return None
+
+
+def _config(tmp_path: Path) -> deploy.DeployConfig:
+    return deploy.DeployConfig(
+        target_revision=NEW_SHA,
+        base_url="https://app.example.test",
+        public_base_url="https://example.test",
+        backend_image=f"registry/backend:{NEW_SHA}",
+        bot_image=f"registry/bot:{NEW_SHA}",
+        root=tmp_path,
+        state_root=tmp_path / ".artifacts" / "deployments",
+        observation_seconds=1,
+        readiness_timeout_seconds=5,
+        probe_interval_seconds=0.1,
+        probe_timeout_seconds=1,
+        backend_drain_seconds=45,
+        worker_drain_seconds=120,
+        bot_drain_seconds=60,
+        bot_polling_enabled=True,
+    )
+
+
+def _state(config: deploy.DeployConfig, *, revision: str = OLD_SHA) -> None:
+    state = deploy.ReleaseState(
+        version=1,
+        active_slot="blue",
+        active_revision=revision,
+        active_backend_image="registry/backend@sha256:" + "1" * 64,
+        active_bot_image="registry/bot@sha256:" + "2" * 64,
+    )
+    deploy._atomic_json(config.state_root / "state.json", asdict(state))
+
+
+def _patch_runtime(monkeypatch, *, fail_at: str | None = None):
+    calls: dict[str, list] = {
+        "compose": [],
+        "switch": [],
+        "run": [],
+        "consumer_start": [],
+        "consumer_stop": [],
+    }
+
+    def compose(*args, **kwargs):
+        del kwargs
+        calls["compose"].append(args)
+        if fail_at == "candidate_start" and "backend-green" in args and "up" in args:
+            raise subprocess.CalledProcessError(1, args)
+        return subprocess.CompletedProcess(args, 0, stdout="backend-green\n", stderr="")
+
+    public_smoke_count = 0
+
+    def public_smoke(_config):
+        nonlocal public_smoke_count
+        public_smoke_count += 1
+        if fail_at == "external_smoke" and public_smoke_count == 2:
+            raise deploy.DeploymentError("external smoke failed")
+
+    def run(args, **kwargs):
+        del kwargs
+        calls["run"].append(args)
+        if fail_at == "migration" and "scripts/check_online_migrations.py" in args:
+            raise subprocess.CalledProcessError(1, args)
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    def switch(active, fallback):
+        calls["switch"].append((active, fallback))
+        if fail_at == "gateway" and active == "green":
+            raise deploy.DeploymentError("invalid gateway config")
+
+    def candidate_smoke(slot):
+        if fail_at == "candidate_smoke":
+            raise deploy.DeploymentError(f"{slot} smoke failed")
+
+    def start_consumers(slot, **kwargs):
+        del kwargs
+        calls["consumer_start"].append(slot)
+        if fail_at == "consumer" and slot == "green":
+            raise deploy.DeploymentError("consumer ownership failed")
+
+    def stop_consumers(slot, config, **kwargs):
+        del kwargs
+        assert config.worker_drain_seconds == 120
+        calls["consumer_stop"].append(slot)
+
+    monkeypatch.setattr(deploy, "_capacity", lambda: {"cpu_count": 4})
+    monkeypatch.setattr(deploy, "_compose", compose)
+    monkeypatch.setattr(deploy, "_run", run)
+    monkeypatch.setattr(deploy, "_public_smoke", public_smoke)
+    monkeypatch.setattr(deploy, "_switch_gateway", switch)
+    monkeypatch.setattr(deploy, "_candidate_smoke", candidate_smoke)
+    monkeypatch.setattr(
+        deploy, "_image_digest", lambda image, revision: image + "@sha256:" + "3" * 64
+    )
+    monkeypatch.setattr(deploy, "_start_probe", lambda *args: FakeProbe())
+    monkeypatch.setattr(deploy, "_finish_probe", lambda *args: {"failure_count": 0})
+
+    def wait_observation(*args):
+        del args
+        if fail_at == "interrupt":
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(deploy, "_wait_observation", wait_observation)
+    monkeypatch.setattr(deploy, "_stop_slot_consumers", stop_consumers)
+    monkeypatch.setattr(deploy, "_start_slot_consumers", start_consumers)
+    return calls
+
+
+def test_successful_rollout_updates_state_only_after_observation(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(tmp_path)
+    _state(config)
+    calls = _patch_runtime(monkeypatch)
+
+    evidence = deploy.deploy(config)
+
+    state = deploy.ReleaseState.from_path(config.state_root / "state.json")
+    assert evidence.verdict == "active"
+    assert state.active_slot == "green"
+    assert state.active_revision == NEW_SHA
+    assert state.rollback_revision == OLD_SHA
+    assert calls["switch"] == [("blue", "blue"), ("green", "blue"), ("green", "green")]
+
+
+@pytest.mark.parametrize("fail_at", ["candidate_start", "candidate_smoke", "gateway", "migration"])
+def test_pre_switch_failure_preserves_active_state(
+    tmp_path: Path, monkeypatch, fail_at: str
+) -> None:
+    config = _config(tmp_path)
+    _state(config)
+    calls = _patch_runtime(monkeypatch, fail_at=fail_at)
+
+    with pytest.raises((deploy.DeploymentError, subprocess.CalledProcessError)):
+        deploy.deploy(config)
+
+    state = deploy.ReleaseState.from_path(config.state_root / "state.json")
+    assert state.active_revision == OLD_SHA
+    assert ("green", "blue") not in calls["switch"] or fail_at == "gateway"
+
+
+def test_post_switch_failure_reloads_verified_old_route(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    _state(config)
+    calls = _patch_runtime(monkeypatch, fail_at="external_smoke")
+
+    with pytest.raises(deploy.DeploymentError, match="external smoke"):
+        deploy.deploy(config)
+
+    assert calls["switch"][-1] == ("blue", "blue")
+    assert (
+        deploy.ReleaseState.from_path(config.state_root / "state.json").active_revision == OLD_SHA
+    )
+
+
+def test_partial_consumer_handoff_restores_the_previous_single_owner(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(tmp_path)
+    _state(config)
+    calls = _patch_runtime(monkeypatch, fail_at="consumer")
+
+    with pytest.raises(deploy.DeploymentError, match="consumer ownership"):
+        deploy.deploy(config)
+
+    assert calls["switch"][-1] == ("blue", "blue")
+    assert calls["consumer_stop"] == ["blue", "green"]
+    assert calls["consumer_start"] == ["green", "blue"]
+
+
+def test_interrupted_post_switch_rollout_restores_state_and_route(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(tmp_path)
+    _state(config)
+    calls = _patch_runtime(monkeypatch, fail_at="interrupt")
+
+    with pytest.raises(KeyboardInterrupt):
+        deploy.deploy(config)
+
+    assert calls["switch"][-1] == ("blue", "blue")
+    assert (
+        deploy.ReleaseState.from_path(config.state_root / "state.json").active_revision == OLD_SHA
+    )
+
+
+def test_repeated_same_sha_is_a_verified_no_op(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    _state(config, revision=NEW_SHA)
+    calls = _patch_runtime(monkeypatch)
+    smoke = []
+    monkeypatch.setattr(deploy, "_public_smoke", lambda value: smoke.append(value.base_url))
+
+    evidence = deploy.deploy(config)
+
+    assert evidence.verdict == "active"
+    assert smoke == [config.base_url]
+    assert calls["switch"] == [("blue", "blue")]
+
+
+def test_gateway_switch_validates_before_atomic_reload(monkeypatch) -> None:
+    commands = []
+    reloaded = False
+
+    def compose(*args, **kwargs):
+        nonlocal reloaded
+        commands.append(args)
+        if "reload" in args:
+            reloaded = True
+        if "adapt" in args:
+            output = '{"apps":{"dial":"backend-green:8000"}}'
+        elif any("reverse_proxy/upstreams" in part for part in args):
+            output = '[{"num_requests":0}]'
+        elif any("2019/config/" in part for part in args):
+            dial = "backend-green:8000" if reloaded else "backend-blue:8000"
+            output = f'{{"apps":{{"dial":"{dial}"}}}}'
+        else:
+            output = ""
+        return subprocess.CompletedProcess(args, 0, stdout=output, stderr="")
+
+    monkeypatch.setattr(deploy, "_compose", compose)
+
+    deploy._switch_gateway("green", "blue")
+
+    assert "validate" in commands[0]
+    assert any("reload" in command for command in commands)
+    assert commands.index(
+        next(command for command in commands if "validate" in command)
+    ) < commands.index(next(command for command in commands if "reload" in command))
+    assert any("YFC_ASSET_FALLBACK_UPSTREAM=backend-blue:8000" in part for part in commands[0])
+
+
+def test_current_run_logs_use_the_container_start_boundary(monkeypatch) -> None:
+    commands = []
+
+    def compose(*args, **kwargs):
+        del kwargs
+        commands.append(args)
+        return subprocess.CompletedProcess(args, 0, stdout="current run\n", stderr="")
+
+    monkeypatch.setattr(deploy, "_compose", compose)
+    lease = deploy.ConsumerLease(
+        service="bot-green",
+        container_id="container-new",
+        started_at="2026-08-28T12:00:00.000000000Z",
+        required_markers=("polling_file_lock_acquired", "telegram_polling_started"),
+    )
+
+    assert deploy._current_run_logs(lease) == "current run\n"
+    assert commands == [
+        (
+            "logs",
+            "--no-color",
+            "--since",
+            "2026-08-28T12:00:00.000000000Z",
+            "bot-green",
+        )
+    ]
+
+
+def test_bot_lease_requires_lock_and_polling_markers_from_current_run(monkeypatch) -> None:
+    lease = deploy.ConsumerLease(
+        service="bot-green",
+        container_id="container-new",
+        started_at="2026-08-28T12:00:00Z",
+        required_markers=("polling_file_lock_acquired", "telegram_polling_started"),
+    )
+    monkeypatch.setattr(deploy, "_service_is_running", lambda service: service == "bot-green")
+    monkeypatch.setattr(
+        deploy,
+        "_compose",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args, 0, stdout="container-new\n", stderr=""
+        ),
+    )
+    monkeypatch.setattr(
+        deploy,
+        "_run",
+        lambda args, **kwargs: subprocess.CompletedProcess(
+            args,
+            0,
+            stdout=("2026-08-28T12:00:00Z\n" if "{{.State.StartedAt}}" in args else "running\n"),
+            stderr="",
+        ),
+    )
+    monkeypatch.setattr(deploy, "_current_run_logs", lambda value: "telegram_polling_started\n")
+
+    assert deploy._lease_is_current_and_healthy(lease) is False
+
+
+def test_consumer_lease_rejects_restart_with_same_container_id(monkeypatch) -> None:
+    lease = deploy.ConsumerLease(
+        service="worker-green",
+        container_id="container-same",
+        started_at="2026-08-28T12:00:00Z",
+        required_markers=("worker_started",),
+    )
+    monkeypatch.setattr(deploy, "_service_is_running", lambda service: True)
+    monkeypatch.setattr(
+        deploy,
+        "_compose",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args, 0, stdout="container-same\n", stderr=""
+        ),
+    )
+    monkeypatch.setattr(
+        deploy,
+        "_run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args, 0, stdout="2026-08-28T12:05:00Z\n", stderr=""
+        ),
+    )
+    monkeypatch.setattr(
+        deploy,
+        "_current_run_logs",
+        lambda value: "worker_started\nworker_stopped\nworker_started\n",
+    )
+
+    assert deploy._lease_is_current_and_healthy(lease) is False
+
+
+def test_config_reads_drain_and_polling_values_from_compose_dotenv(
+    tmp_path: Path, monkeypatch
+) -> None:
+    (tmp_path / ".env").write_text(
+        "DEPLOY_WORKER_DRAIN_SECONDS=300s\nBOT_POLLING_ENABLED=false\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("BACKEND_IMAGE", "registry/backend:" + NEW_SHA)
+    monkeypatch.setenv("BOT_IMAGE", "registry/bot:" + NEW_SHA)
+    monkeypatch.delenv("DEPLOY_WORKER_DRAIN_SECONDS", raising=False)
+    monkeypatch.delenv("BOT_POLLING_ENABLED", raising=False)
+
+    config = deploy._config(
+        SimpleNamespace(
+            target_revision=NEW_SHA,
+            base_url="https://app.example.test",
+            public_base_url="https://example.test",
+        )
+    )
+
+    assert config.worker_drain_seconds == 300
+    assert config.bot_polling_enabled is False
+
+
+def test_consumer_stop_uses_configured_drain_and_requires_worker_ack(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(tmp_path)
+    commands = []
+    lease = deploy.ConsumerLease(
+        service="worker-blue",
+        container_id="worker-current",
+        started_at="2026-08-28T12:00:00Z",
+        required_markers=("worker_started",),
+    )
+    monkeypatch.setattr(deploy, "_consumer_lease", lambda *args: lease)
+    monkeypatch.setattr(deploy, "_service_is_running", lambda service: True)
+    monkeypatch.setattr(deploy, "_current_run_logs", lambda value: "worker_stopped\n")
+    monkeypatch.setattr(
+        deploy,
+        "_compose",
+        lambda *args, **kwargs: (
+            commands.append(args) or subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        ),
+    )
+
+    deploy._stop_slot_consumers("blue", config)
+
+    assert commands == [
+        ("stop", "-t", "120", "worker-blue"),
+        ("stop", "-t", "60", "bot-blue"),
+    ]
+
+
+def test_consumer_stop_fails_closed_when_worker_drain_is_unconfirmed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(tmp_path)
+    commands = []
+    lease = deploy.ConsumerLease(
+        service="worker-blue",
+        container_id="worker-current",
+        started_at="2026-08-28T12:00:00Z",
+        required_markers=("worker_started",),
+    )
+    monkeypatch.setattr(deploy, "_consumer_lease", lambda *args: lease)
+    monkeypatch.setattr(deploy, "_service_is_running", lambda service: True)
+    monkeypatch.setattr(deploy, "_current_run_logs", lambda value: "worker_drain_requested\n")
+    monkeypatch.setattr(
+        deploy,
+        "_compose",
+        lambda *args, **kwargs: (
+            commands.append(args) or subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        ),
+    )
+
+    with pytest.raises(deploy.DeploymentError, match="consumer state is uncertain"):
+        deploy._stop_slot_consumers("blue", config)
+
+    assert commands == [("stop", "-t", "120", "worker-blue")]
+
+
+def test_manual_rollback_swaps_only_verified_revisions(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    state = deploy.ReleaseState(
+        version=1,
+        active_slot="green",
+        active_revision=NEW_SHA,
+        active_backend_image="registry/backend@sha256:" + "3" * 64,
+        active_bot_image="registry/bot@sha256:" + "4" * 64,
+        rollback_slot="blue",
+        rollback_revision=OLD_SHA,
+        rollback_backend_image="registry/backend@sha256:" + "1" * 64,
+        rollback_bot_image="registry/bot@sha256:" + "2" * 64,
+    )
+    deploy._atomic_json(config.state_root / "state.json", asdict(state))
+    calls = _patch_runtime(monkeypatch)
+
+    deploy.rollback(config)
+
+    restored = deploy.ReleaseState.from_path(config.state_root / "state.json")
+    assert restored.active_revision == OLD_SHA
+    assert restored.rollback_revision == NEW_SHA
+    assert calls["switch"] == [("blue", "green")]


### PR DESCRIPTION
## Summary
- add stable Caddy edge and blue/green application slots
- add fail-closed online migration, worker/bot ownership, drain and rollback contracts
- add continuous production-like probe, failure injection tests and Russian operator documentation
- archive Task 112 locally and keep Task 81 current/not started

## Verification
- independent review: APPROVED; ZDT-REV-001..004 closed
- QA: APPROVED; ZDT-QA-001..002 closed
- final targeted pytest: 74 passed
- production-like A-to-B drill: 301 requests, 36 samples, 0 failures
- pre-commit, Ruff, mypy, Compose config, Caddy validation, shell syntax and migration gate passed

## Production
Merging to master intentionally triggers CI and then production deployment. Owner explicitly approved PR, push and deployment. Verified pre-deploy backup branch: backup/master-before-d5fa5df-20260828 at cdca4256ae3e3c4ed63ed6e7b6d1020bb01340b8.