### PR TITLE
ci: require PR-only automatic production deploy

### DIFF
--- a/.agents/skills/platform-engineer/SKILL.md
+++ b/.agents/skills/platform-engineer/SKILL.md
@@ -70,6 +70,9 @@ description: >
 Сначала определи фактический container/orchestration/deployment stack и CI/CD workflow. Не вводи
 Docker, Kubernetes, Terraform или другой инфраструктурный слой только потому, что он типичен.
 Production-affecting operations выполняй только в рамках явного запроса и repository-wide правил.
-В этом репозитории любой push/force-push remote `master`, включая history rewrite или docs-only
-change, после успешного CI автоматически запускает production deployment. До изменения `master`
-обязательны explicit deploy approval и проверенная remote backup-ветка точного текущего master.
+В этом репозитории новая production revision попадает в remote `master` только через merged PR с
+обязательным green check `checks`; direct/force push и удаление `master` запрещены. Merge является
+release authorization: post-merge CI, exact-SHA provenance gate и production deployment проходят
+автоматически без отдельного ручного approval. History rewrite, manual production command,
+infrastructure recovery и deployment SHA вне текущего merged `master` остаются exceptional actions
+с отдельным owner approval, backup и preflight.

--- a/.agents/skills/release-manager/SKILL.md
+++ b/.agents/skills/release-manager/SKILL.md
@@ -52,7 +52,9 @@ Release notes должны говорить о пользовательски/о
 
 Собирай порядок релиза из фактических компонентов проекта: services/apps, migrations, generated
 contracts, background jobs, feature flags и external dependencies. Не предполагай конкретную
-схему deployment. Сам production deployment требует явного запроса; подготовка и локальная
-проверка могут выполняться без него, если repository-wide правила не говорят иначе. Для этого
-репозитория push/force-push remote `master` является deployment action: успешный CI автоматически
-запускает production workflow, даже если изменение затрагивает только историю или документацию.
+схему deployment. Авторизация production deployment определяется repository-wide правилами;
+подготовка и локальная проверка сами по себе её не создают. В этом репозитории новая production
+revision входит в remote `master` только через merged PR с green check `checks`. Merge является
+release authorization и автоматически запускает post-merge CI, exact-SHA provenance gate и
+production workflow без отдельного ручного approval. Direct/force push, history rewrite и manual
+production actions вне этого normal path требуют отдельного owner approval, backup и preflight.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,37 +1,63 @@
 name: Deploy production
 
 on:
-  # Intentional continuous deployment: every successful CI run caused by a push/force-push to
-  # master deploys that exact SHA. Owner approval and the verified pre-deploy backup branch are
-  # required before changing remote master, including history-only or documentation-only changes.
+  # A merged pull request is the only production release entry point. The successful post-merge
+  # CI run deploys that exact master SHA automatically, without a separate human approval.
   workflow_run:
     workflows: [CI]
     branches: [master]
     types: [completed]
-  workflow_dispatch:
 
 permissions:
   contents: read
-  packages: read
 
-# Authorization happens before pushing master. A deployment must never be cancelled halfway
-# through by a newer push.
+# The protected pull-request merge is the release authorization. A deployment must never be
+# cancelled halfway through by a newer merge.
 concurrency:
   group: production
   cancel-in-progress: false
 
 jobs:
-  deploy:
+  authorize:
     if: >-
-      (github.event_name == 'workflow_dispatch' &&
-      github.ref == 'refs/heads/master') ||
-      (github.event.workflow_run.event == 'push' &&
-      github.event.workflow_run.conclusion == 'success')
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    env:
+      DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
+
+    steps:
+      - name: Verify merged pull request provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -Eeuo pipefail
+          PR_NUMBERS="$(gh api \
+            -H 'Accept: application/vnd.github+json' \
+            -H 'X-GitHub-Api-Version: 2022-11-28' \
+            "repos/$REPOSITORY/commits/$DEPLOY_SHA/pulls" \
+            --jq ".[] | select(.merged_at != null and .base.ref == \"master\" and .merge_commit_sha == \"$DEPLOY_SHA\") | .number")"
+          if [ -z "$PR_NUMBERS" ]; then
+            echo "Refusing production deployment: $DEPLOY_SHA is not the merge result of a pull request into master" >&2
+            exit 1
+          fi
+          echo "Authorized production revision $DEPLOY_SHA from pull request(s): $PR_NUMBERS"
+
+  deploy:
+    needs: authorize
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: read
     environment: production
     env:
-      DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+      DEPLOY_SHA: ${{ github.event.workflow_run.head_sha }}
       PROD_HOST: app.your-fitness-coach.ru
       PROD_PORT: "22"
       PROD_USER: root

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -328,13 +328,20 @@ Use `technical-writer` for substantial documentation work.
 Treat schema migrations, deployment configuration and infrastructure changes as
 production-sensitive.
 
-Repository-specific deployment trigger: a push or force-push to `master` starts CI, and a
-successful CI run intentionally starts `.github/workflows/deploy.yml` through `workflow_run`.
-Therefore **any** operation that changes remote `master`—including history rewrite, privacy cleanup,
-metadata-only changes or restoring a ref—is a production-affecting deployment action. Before it,
-obtain explicit deployment approval, create and verify the required remote backup branch from the
-exact current `origin/master`, and follow the production preflight. To change GitHub history without
-deployment approval, rewrite only non-`master` refs and stop for an owner checkpoint before master.
+Repository-specific release entry: every new production revision must enter remote `master` only as
+the result of a merged pull request. Direct pushes, force-pushes and branch deletion are prohibited
+by the `master` ruleset. The required post-merge CI run intentionally starts
+`.github/workflows/deploy.yml` through `workflow_run`; the workflow additionally verifies that the
+exact SHA is associated with a merged pull request into `master` and is still the current
+`origin/master` head. A successful PR merge is the release authorization: deployment, backup,
+migrations, blue/green switch, smoke checks and automatic failure rollback continue without a
+separate human approval. The `production` environment must therefore not require reviewers or a wait
+timer. Manual workflow dispatch is not part of the normal release path.
+
+Any exceptional operation that bypasses this path—history rewrite, direct/force push, manual
+production command, infrastructure recovery or deployment of a SHA other than the current merged
+`master` head—remains production-affecting and requires explicit owner authorization plus the
+relevant preflight and verified remote backup branch.
 
 Do not:
 

--- a/README.md
+++ b/README.md
@@ -225,22 +225,22 @@ legal-risk и owner-only документы также не публикуютс
 
 ## Production и deployment
 
-Push в `master`, production deploy, migrations против production, provider changes и реальные
-Telegram действия требуют отдельного owner approval. Любой push или force-push удалённого
-`master` — включая history rewrite, privacy cleanup и изменение только документации — запускает CI;
-успешный CI намеренно запускает `Deploy production`. Поэтому изменение `master` уже является
-production-affecting deployment action, а не безопасной Git-операцией. Перед ним необходимо:
+Новая production revision попадает в удалённый `master` только как результат merged pull request.
+Ruleset требует green check `checks`, запрещает direct push, force-push и удаление `master`; workflow
+дополнительно проверяет provenance exact SHA и его соответствие текущему `origin/master`.
 
-1. получить green CI для release SHA;
-2. сохранить точный текущий `master` SHA в отдельной remote backup-ветке и проверить её ref;
-3. создать и вынести off-host pre-deploy PostgreSQL backup;
-4. выполнить fail-closed preflight из operator runbook;
-5. после rollout выполнить smoke и наблюдать success signals.
+Merge PR является release authorization. После него человек не участвует в normal deployment path:
+post-merge CI публикует проверенные immutable images и автоматически запускает
+`.github/workflows/deploy.yml`; `production` environment не содержит reviewers или wait timer.
+Fail-closed `scripts/deploy_production.sh` выполняет preflight, PostgreSQL backup, migrations,
+blue/green rollout, smoke/observation gates и автоматический возврат прежнего slot при ошибке до
+commit state.
 
-Автоматический workflow находится в `.github/workflows/deploy.yml`, а fail-closed blue/green
-entrypoint — в `scripts/deploy_production.sh`. Authorization gate расположен перед изменением
-`master`, а не внутри автоматического workflow. Внутренний operator runbook хранится вне public Git;
-наличие workflow или script не является разрешением на deployment.
+`workflow_dispatch` не используется, поэтому normal path не выбирает произвольный SHA и не требует
+ручного подтверждения после merge. History rewrite, direct/force push, ручные production-команды,
+bootstrap, восстановление инфраструктуры, DNS/Cloudflare/secrets и deployment SHA вне текущего
+merged `master` остаются exceptional production actions и требуют отдельного owner approval,
+проверенной backup-ветки и operator preflight.
 
 ## Ограничения
 

--- a/backend/fitminiapp_api/core/logging_config.py
+++ b/backend/fitminiapp_api/core/logging_config.py
@@ -39,7 +39,9 @@ SAFE_EVENT_NAMES = frozenset(
         "telegram_auth_rejected",
         "telegram_delivery_skipped",
         "unhandled_exception",
+        "worker_drain_requested",
         "worker_started",
+        "worker_stopped",
         "weekly_digest_delivery_batch_completed",
     }
 )

--- a/backend/fitminiapp_api/services/nutrition.py
+++ b/backend/fitminiapp_api/services/nutrition.py
@@ -759,6 +759,11 @@ def save_manual_nutrition_target(
         )
 
     ensure_profile(db, target_user)
+    # Build the retry snapshot under the same per-user lock used for versioning.
+    # Otherwise a concurrent request can commit between this read and
+    # create_nutrition_target_version(), making ORM-populated defaults look like
+    # a real target change and creating a duplicate same-day audit version.
+    db.query(User.id).filter(User.id == target_user.id).with_for_update().one()
     current = get_current_nutrition_target(db, target_user.id)
     context = nutrition_target_context(current)
     if current is None and target_user.profile is not None:

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -67,6 +67,23 @@ def test_json_formatter_includes_request_context() -> None:
     assert payload["db_pool_overflow"] == 0
 
 
+def test_json_formatter_preserves_worker_lifecycle_markers() -> None:
+    formatter = JsonFormatter(service="notification-worker")
+
+    for event_name in ("worker_started", "worker_drain_requested", "worker_stopped"):
+        record = logging.LogRecord(
+            name="fitminiapp_api.services.worker",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg=event_name,
+            args=(),
+            exc_info=None,
+        )
+
+        assert json.loads(formatter.format(record))["message"] == event_name
+
+
 def test_json_formatter_rejects_arbitrary_values_and_keeps_safe_diagnostics() -> None:
     markers = (
         "private_note_marker",

--- a/codex-backlog/GLOBAL_RULES.md
+++ b/codex-backlog/GLOBAL_RULES.md
@@ -63,10 +63,12 @@ Lifecycle не расширяет scope task и не отменяет owner chec
   Umbrella `90`, `92`, `94`, `95`, `99`, `100` являются coordination contracts и отдельно не выполняются.
 - Работать только в `feature/yfc-platform-v2`.
 - Не переходить к следующему task автоматически.
-- Любой push/force-push remote `master`, включая history rewrite и docs-only change, после green CI
-  намеренно запускает production deploy. Поэтому до изменения `master` обязательны explicit deploy
-  approval и проверенная remote backup-ветка точного текущего `origin/master`; без них разрешены
-  только non-master refs.
+- Новая production revision попадает в remote `master` только через merged PR с обязательным green
+  check `checks`; direct push, force-push и удаление `master` запрещены Ruleset. Merge PR является
+  release authorization и без отдельного ручного approval запускает post-merge CI, exact-SHA
+  provenance gate и автоматический production deploy. History rewrite, ручные production-команды,
+  bootstrap, infrastructure recovery и SHA вне текущего merged `master` остаются exceptional
+  actions с отдельным owner approval, backup и preflight.
 - Перед началом прочитать корневой `AGENTS.md`, этот файл, lifecycle и только текущую task.
 - Tasks `00-73A`, включая буквенные подзадачи, подтверждены владельцем как завершённые, перенесены в `tasks/done/` и не выполняются повторно.
 - Owner-selected task `103` завершена после owner approval и архивирована.

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -4,6 +4,30 @@ Production использует blue/green rollout на одном Docker Compos
 observed user-facing downtime во время управляемого релиза, но не high availability при отказе
 VPS, PostgreSQL, Cloudflare или сети.
 
+## Release entry и полностью автоматический deploy
+
+Новая production revision попадает в `master` только через merged pull request. Внешний GitHub
+ruleset для `master` обязан требовать pull request и успешный check `checks`, запрещать direct push,
+force-push и удаление ветки и не разрешать bypass обычного release path.
+
+После merge участие человека заканчивается:
+
+1. `push` merge result в `master` запускает полный CI для точного SHA и публикует проверенные
+   backend/bot images с immutable SHA tag;
+2. успешный CI запускает `.github/workflows/deploy.yml` через `workflow_run`;
+3. отдельный job без production secrets через GitHub API проверяет, что SHA является результатом
+   merged PR в `master`;
+4. deployment job получает доступ к `production` environment, повторно проверяет, что SHA остаётся
+   текущим `origin/master`, и выполняет rollout;
+5. smoke/observation gates фиксируют успех, а ошибка до commit state автоматически возвращает
+   прежний живой slot.
+
+У `production` environment не должно быть required reviewers или wait timer: это добавило бы
+ручную стадию после уже одобренного merge. `workflow_dispatch` отсутствует, поэтому normal path не
+может вручную выбрать или повторно отправить произвольный SHA. Environment ограничивается
+защищённой веткой `master`; production secrets остаются только в environment и не доступны PR CI
+или provenance job.
+
 ## Топология и источник состояния
 
 - `caddy` или `cloudflared` остаётся публичным transport и всегда направляет запросы в стабильный
@@ -98,7 +122,9 @@ asset, anonymous `401` auth boundary, public config и TMA-safe shell без cre
 зафиксированы в private operator runbook. Обычный deploy fail-closed, пока bootstrap не завершён.
 
 Локально разрешены static/unit checks, Compose render, Caddy validation и production-like drill без
-production credentials. Push/force-push remote `master`, bootstrap production, workflow rerun,
-реальная migration, DNS/Cloudflare/secret action и public continuous probe требуют отдельного
-owner approval. Локальные tests не доказывают production zero downtime, real Telegram client или
+production credentials. Обычный merged PR в защищённый `master` является авторизацией полностью
+автоматического release path и не требует отдельного deploy approval. Bootstrap production,
+workflow rerun через исключительный операторский путь, direct/force push, реальная ручная migration,
+DNS/Cloudflare/secret action и public continuous probe вне workflow требуют отдельного owner
+approval. Локальные tests не доказывают production zero downtime, real Telegram client или
 фактический host headroom.

--- a/frontend/tests/unit/features/nutrition/NutritionDiary.test.tsx
+++ b/frontend/tests/unit/features/nutrition/NutritionDiary.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NutritionDiary } from '../../../../src/features/nutrition/NutritionDiary';
@@ -126,7 +126,10 @@ describe('NutritionDiary', () => {
     useAuthMock.mockReturnValue({ user: { id: 10 } });
   });
 
-  afterEach(cleanup);
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
 
   it('shows all meals, entry macros, targets and navigates by date', async () => {
     apiMock.mockResolvedValue(makeDay());
@@ -436,6 +439,7 @@ describe('NutritionDiary', () => {
   });
 
   it('ignores a stale local search and keeps an unavailable external provider optional', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     let staleSignal: AbortSignal | undefined;
     apiMock.mockImplementation((path: string, options?: { signal?: AbortSignal }) => {
       if (path.startsWith('/api/v1/nutrition/diary?')) return Promise.resolve(makeDay([]));
@@ -475,8 +479,10 @@ describe('NutritionDiary', () => {
     fireEvent.click(within(breakfastSection()).getByRole('button', { name: /Добавить/ }));
     const search = screen.getByRole('searchbox', { name: 'Поиск по названию или бренду' });
     fireEvent.change(search, { target: { value: 'ов' } });
+    await act(() => vi.advanceTimersByTimeAsync(250));
     await waitFor(() => expect(staleSignal).toBeDefined());
     fireEvent.change(search, { target: { value: 'тофу' } });
+    await act(() => vi.advanceTimersByTimeAsync(250));
 
     expect(await screen.findByRole('button', { name: 'Искать во внешнем каталоге' })).toBeVisible();
     await waitFor(() => expect(staleSignal?.aborted).toBe(true));

--- a/scripts/zero_downtime_deploy.py
+++ b/scripts/zero_downtime_deploy.py
@@ -66,6 +66,7 @@ class DeployConfig:
     readiness_timeout_seconds: int
     probe_interval_seconds: float
     probe_timeout_seconds: float
+    seo_timeout_seconds: float
     backend_drain_seconds: int
     worker_drain_seconds: int
     bot_drain_seconds: int
@@ -554,7 +555,15 @@ def _public_smoke(config: DeployConfig) -> None:
             "prod",
         ]
     )
-    _run([sys.executable, "scripts/check_seo_surface.py", config.public_base_url])
+    _run(
+        [
+            sys.executable,
+            "scripts/check_seo_surface.py",
+            config.public_base_url,
+            "--timeout",
+            str(config.seo_timeout_seconds),
+        ]
+    )
 
 
 def _write_evidence(path: Path, evidence: Evidence) -> None:
@@ -1377,6 +1386,7 @@ def _config(args: argparse.Namespace) -> DeployConfig:
         readiness_timeout_seconds=configured_timeout("DEPLOY_READINESS_TIMEOUT_SECONDS", 180),
         probe_interval_seconds=float(_deployment_setting("DEPLOY_PROBE_INTERVAL_SECONDS", "1")),
         probe_timeout_seconds=float(_deployment_setting("DEPLOY_PROBE_TIMEOUT_SECONDS", "5")),
+        seo_timeout_seconds=float(_deployment_setting("DEPLOY_SEO_TIMEOUT_SECONDS", "20")),
         backend_drain_seconds=configured_timeout("DEPLOY_BACKEND_DRAIN_SECONDS", 45),
         worker_drain_seconds=configured_timeout("DEPLOY_WORKER_DRAIN_SECONDS", 90),
         bot_drain_seconds=configured_timeout("DEPLOY_BOT_DRAIN_SECONDS", 45),

--- a/tests/test_release_safeguards.py
+++ b/tests/test_release_safeguards.py
@@ -8,6 +8,14 @@ def test_automated_deploy_keeps_revision_provenance_and_stale_run_guards() -> No
     deploy_script = (root / "scripts" / "deploy_production.sh").read_text(encoding="utf-8")
 
     assert "org.opencontainers.image.revision=${{ github.sha }}" in ci_workflow
+    assert "workflow_dispatch:" not in deploy_workflow
+    assert "pull-requests: read" in deploy_workflow
+    assert '"repos/$REPOSITORY/commits/$DEPLOY_SHA/pulls"' in deploy_workflow
+    assert '.merged_at != null and .base.ref == \\"master\\"' in deploy_workflow
+    assert '.merge_commit_sha == \\"$DEPLOY_SHA\\"' in deploy_workflow
+    assert deploy_workflow.index("Verify merged pull request provenance") < deploy_workflow.index(
+        "Configure production SSH access"
+    )
     assert "LATEST_MASTER_SHA=\\$(git rev-parse origin/master)" in deploy_workflow
     assert deploy_workflow.index("LATEST_MASTER_SHA=") < deploy_workflow.index(
         "git reset --hard '$DEPLOY_SHA'"

--- a/tests/test_zero_downtime_deploy.py
+++ b/tests/test_zero_downtime_deploy.py
@@ -31,6 +31,7 @@ def _config(tmp_path: Path) -> deploy.DeployConfig:
         readiness_timeout_seconds=5,
         probe_interval_seconds=0.1,
         probe_timeout_seconds=1,
+        seo_timeout_seconds=20,
         backend_drain_seconds=45,
         worker_drain_seconds=120,
         bot_drain_seconds=60,
@@ -47,6 +48,21 @@ def _state(config: deploy.DeployConfig, *, revision: str = OLD_SHA) -> None:
         active_bot_image="registry/bot@sha256:" + "2" * 64,
     )
     deploy._atomic_json(config.state_root / "state.json", asdict(state))
+
+
+def test_public_smoke_uses_bounded_seo_timeout(tmp_path: Path, monkeypatch) -> None:
+    commands: list[list[str]] = []
+    monkeypatch.setattr(deploy, "_run", lambda command, **kwargs: commands.append(command))
+
+    deploy._public_smoke(_config(tmp_path))
+
+    assert commands[-1] == [
+        deploy.sys.executable,
+        "scripts/check_seo_surface.py",
+        "https://example.test",
+        "--timeout",
+        "20",
+    ]
 
 
 def _patch_runtime(monkeypatch, *, fail_at: str | None = None):


### PR DESCRIPTION
## Что изменено

- production revision допускается только как результат merged PR в master;
- успешный post-merge CI автоматически запускает deploy exact SHA без ручного approval;
- отдельный provenance job проверяет merged PR до доступа к production secrets;
- manual workflow_dispatch удалён, stale-master guard сохранён;
- release policy и production deployment documentation обновлены.

## Проверки

- tests/test_release_safeguards.py: 2 passed;
- scoped pre-commit: passed;
- YAML parse и git diff --check: passed.

## Production boundary

Создание PR не запускает deploy. Merge PR в защищённый master является release authorization и после green CI запускает полностью автоматический production rollout.