### PR TITLE
fix(ui): keep Pulse artwork across Today states

### DIFF
--- a/frontend/src/features/dashboard/TodayDashboard.tsx
+++ b/frontend/src/features/dashboard/TodayDashboard.tsx
@@ -520,7 +520,6 @@ function WorkoutOverview({
     const started = workout.status === 'in_progress';
     return (
       <>
-        <SemanticArtwork variant="current-action" />
         <div className="today-workout-copy">
           <div className="today-workout-copy__status">
             <Badge tone={started ? 'warning' : 'neutral'}>
@@ -899,8 +898,12 @@ export function TodayDashboard() {
       />
 
       <div className="today-dashboard__overview">
-        <section className="today-workout-spotlight" aria-labelledby="today-workout-title">
+        <section
+          className={`today-workout-spotlight${noTodayWorkout ? ' today-workout-spotlight--rest-day' : ''}`}
+          aria-labelledby="today-workout-title"
+        >
           <span className="today-workout-spotlight__label">Тренировка</span>
+          <SemanticArtwork variant="current-action" />
           {workout.isLoading ||
           priorityContextLoading ||
           (noTodayWorkout && progress.isLoading && user?.has_active_program) ? (

--- a/frontend/src/styles/pulse-concepts.css
+++ b/frontend/src/styles/pulse-concepts.css
@@ -81,6 +81,10 @@
   background: currentColor;
 }
 
+.today-workout-spotlight--rest-day > .ui-semantic-artwork--current-action i:last-child {
+  bottom: 12px;
+}
+
 .today-pulse-action {
   position: relative;
   overflow: hidden;

--- a/frontend/tests/e2e/pulse-concepts-pilot.spec.ts
+++ b/frontend/tests/e2e/pulse-concepts-pilot.spec.ts
@@ -189,6 +189,49 @@ test('selected current-action artwork and floating dock preserve the shared navi
   }
 });
 
+test('current-action artwork remains visible on a rest day', async ({ page }) => {
+  await page.setViewportSize({ width: 430, height: 932 });
+  await installPlatformApi(page, { browserSession: true, workoutStatus: 'none' });
+  await page.goto('/app?section=today');
+
+  await expect(page.getByRole('heading', { name: 'Сегодня без тренировки' })).toBeVisible();
+  const surface = page.locator('.today-workout-spotlight');
+  const artwork = surface.locator('.ui-semantic-artwork--current-action');
+  await expect(surface).toHaveClass(/today-workout-spotlight--rest-day/);
+  await expect(artwork).toHaveCount(1);
+
+  const visualImpact = await surface.evaluate((element) => {
+    const surfaceStyle = getComputedStyle(element);
+    const artworkStyle = getComputedStyle(
+      element.querySelector<HTMLElement>('.ui-semantic-artwork--current-action')!,
+    );
+    return {
+      artworkOpacity: Number.parseFloat(artworkStyle.opacity),
+      artworkShadow: artworkStyle.boxShadow,
+      artworkWidth: Number.parseFloat(artworkStyle.width),
+      background: surfaceStyle.backgroundImage,
+      stripeWidth: Number.parseFloat(getComputedStyle(element, '::before').width),
+    };
+  });
+
+  expect(visualImpact.artworkOpacity).toBeGreaterThanOrEqual(0.9);
+  expect(visualImpact.stripeWidth).toBe(2);
+  expect(visualImpact.artworkWidth).toBeGreaterThanOrEqual(250);
+  expect(visualImpact.artworkShadow).not.toBe('none');
+  expect(visualImpact.background).toContain('radial-gradient');
+  await expectNoOverlap(
+    page.getByRole('heading', { name: 'Сегодня без тренировки' }),
+    artwork.locator('i').last(),
+  );
+  await expectNoHorizontalOverflow(page);
+
+  if (capture) {
+    await page.screenshot({
+      path: `${screenshotRoot}/today-rest-day-mobile-web-430-light.png`,
+    });
+  }
+});
+
 test('frequent current action feedback is interruptible, repeatable and reduced-motion safe', async ({
   page,
 }) => {

--- a/frontend/tests/unit/features/dashboard/TodayDashboard.test.tsx
+++ b/frontend/tests/unit/features/dashboard/TodayDashboard.test.tsx
@@ -433,6 +433,7 @@ describe('TodayDashboard', () => {
     expect(
       await screen.findByRole('heading', { name: 'Сегодня без тренировки' }),
     ).toBeInTheDocument();
+    expect(document.querySelector('.ui-semantic-artwork--current-action')).toBeInTheDocument();
     expect(screen.getByText(/Ближайшая .*Верх тела/)).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Добавить питание' })).toHaveAttribute(
       'href',


### PR DESCRIPTION
## Что изменено

- фоновый Pulse-рисунок вынесен на общий уровень карточки «Тренировка»;
- рисунок остаётся видимым в состоянии «Сегодня без тренировки»;
- rest-day геометрия не пересекает заголовок;
- добавлены unit и Playwright regression checks.

## Проверки

- targeted unit: 9/9;
- typecheck, build, lint, Prettier и perf:check;
- Pulse Playwright: 7/7;
- Mobile Web screenshot 430x932 одобрен владельцем.

Release scope: только четыре frontend-файла visual fix, без CI/deployment-контракта PR #45.