### PR TITLE
fix(deploy): support constrained single-slot rollout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,10 +393,15 @@ jobs:
             context: .
             dockerfile: backend/Dockerfile
             tag: fit-mini-app-backend:ci
+            no_cache: false
           - image: bot
             context: bot
             dockerfile: bot/Dockerfile
             tag: fit-mini-app-bot:ci
+            # A corrupted shared GHA COPY cache previously published a correctly
+            # labelled image with stale runtime sources. Keep this small image
+            # fail-closed until cache provenance can be proven independently.
+            no_cache: true
 
     steps:
       - uses: actions/checkout@v4
@@ -414,8 +419,21 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
           load: true
           tags: ${{ matrix.tag }}
+          no-cache: ${{ matrix.no_cache }}
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+
+      - name: Verify bot runtime image contract
+        if: matrix.image == 'bot'
+        shell: bash
+        env:
+          LOCAL_TAG: ${{ matrix.tag }}
+        run: |
+          docker run --rm --network none \
+            --env TELEGRAM_BOT_TOKEN=ci-image-contract-token \
+            --env BOT_INTERNAL_TOKEN=ci-image-contract-internal-token \
+            "$LOCAL_TAG" \
+            python -c "import fitminiapp_bot.profile_sync; import fitminiapp_bot.public_profile; import fitminiapp_bot.telegram_client"
 
       # v0.36.0 is an immutable, signed post-remediation release. Keep the full SHA.
       - name: Scan image

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,8 @@ jobs:
       PROD_USER: root
       PROD_PATH: /root/fit-mini-app
       PROD_URL: https://app.your-fitness-coach.ru
+      PROD_PUBLIC_URL: https://your-fitness-coach.ru
+      PROD_ROLLOUT_MODE: single-slot
       GHCR_BACKEND_IMAGE: ghcr.io/mikemoore1337/fit-mini-app-backend
       GHCR_BOT_IMAGE: ghcr.io/mikemoore1337/fit-mini-app-bot
 
@@ -79,6 +81,11 @@ jobs:
                exit 0
              fi
              git reset --hard '$DEPLOY_SHA'
+             DEPLOY_SINGLE_SLOT_CONFIRMED_SHA='$DEPLOY_SHA' \
              BACKEND_IMAGE='$GHCR_BACKEND_IMAGE:$DEPLOY_SHA' \
              BOT_IMAGE='$GHCR_BOT_IMAGE:$DEPLOY_SHA' \
-             bash scripts/deploy_production.sh '$DEPLOY_SHA' '$PROD_URL'"
+             bash scripts/deploy_production.sh \
+               '$DEPLOY_SHA' \
+               '$PROD_URL' \
+               '$PROD_PUBLIC_URL' \
+               '$PROD_ROLLOUT_MODE'"

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -91,36 +91,32 @@ constraint операции fail-closed. `backfill` допускает толь�
 меняются при switch. Candidate smoke проверяет liveness, readiness/DB, document, matching hashed
 asset, anonymous `401` auth boundary, public config и TMA-safe shell без credentials или записей.
 
-## Ручной режим для малоресурсного host
+## Автоматический single-slot режим для малоресурсного host
 
 Если production host объективно не может одновременно держать два application slot, уменьшать
-blue/green capacity gates запрещено. Для такого host доступен отдельный owner-approved режим с
-ограниченным техническим перерывом. Он не является zero-downtime и не включается автоматическим
-workflow: оператор передаёт четвёртый аргумент `single-slot` и одноразово подтверждает точный SHA
-через process environment `DEPLOY_SINGLE_SLOT_CONFIRMED_SHA`.
+blue/green capacity gates запрещено. Для текущего малоресурсного host owner разрешил автоматический
+single-slot rollout с ограниченным техническим перерывом. Он не является zero-downtime: после
+успешного post-merge CI production workflow сам передаёт четвёртый аргумент `single-slot` и
+подтверждает ровно проверенный SHA через process environment
+`DEPLOY_SINGLE_SLOT_CONFIRMED_SHA`. Произвольный SHA или другой rollout mode workflow не принимает.
 
-До запуска обязательны off-host PostgreSQL backup, проверенный текущий
-`last-successful-revision`, не менее `2 GiB` свободного диска, explicit maintenance window и
-готовность публичного smoke. Команда сначала скачивает и проверяет immutable images, создаёт ещё
-один локальный dump и запускает migration gate. Только после этого она последовательно останавливает
-legacy worker, bot и backend, выполняет setup/migrations, запускает новый backend и проверяет его,
-затем запускает единственных worker/bot и записывает успешную revision.
+Перед включением режима owner подтвердил off-host PostgreSQL backup, текущий
+`last-successful-revision` и допустимость bounded downtime. Каждый rollout заново проверяет не менее
+`2 GiB` свободного диска, актуальную revision и публичный smoke, затем скачивает и проверяет
+immutable images, создаёт свежий локальный dump и запускает migration gate. Только после этого
+команда последовательно останавливает legacy worker, bot и backend, выполняет setup/migrations,
+запускает новый backend и проверяет его, затем запускает единственных worker/bot и записывает
+успешную revision.
 
 Ошибка после остановки приложения пересоздаёт legacy services из зафиксированных прежних image
 digests и проверяет public smoke. Schema автоматически не откатывается: общий online-migration gate
 сохраняет совместимость старого кода. Если возврат не подтверждён, evidence получает verdict
 `manual intervention required`, а оператор действует по recovery runbook.
 
-~~~console
-DEPLOY_SINGLE_SLOT_CONFIRMED_SHA=<TARGET_SHA> \
-BACKEND_IMAGE=ghcr.io/...:<TARGET_SHA> \
-BOT_IMAGE=ghcr.io/...:<TARGET_SHA> \
-bash scripts/deploy_production.sh \
-  <TARGET_SHA> \
-  https://app.your-fitness-coach.ru \
-  https://your-fitness-coach.ru \
-  single-slot
-~~~
+В normal path оператор не запускает production command: merge PR является release authorization,
+а CI, exact-SHA confirmation, backup, migration gate, остановка, запуск, smoke и rollback проходят
+автоматически. Ручной запуск той же команды остаётся exceptional recovery operation и требует
+нового owner approval.
 
 Отсутствие четвёртого аргумента всегда сохраняет fail-closed blue/green path. Single-slot не создаёт
 `state.json`; переход к blue/green в будущем по-прежнему требует отдельного bootstrap и фактического

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -91,6 +91,41 @@ constraint операции fail-closed. `backfill` допускает толь�
 меняются при switch. Candidate smoke проверяет liveness, readiness/DB, document, matching hashed
 asset, anonymous `401` auth boundary, public config и TMA-safe shell без credentials или записей.
 
+## Ручной режим для малоресурсного host
+
+Если production host объективно не может одновременно держать два application slot, уменьшать
+blue/green capacity gates запрещено. Для такого host доступен отдельный owner-approved режим с
+ограниченным техническим перерывом. Он не является zero-downtime и не включается автоматическим
+workflow: оператор передаёт четвёртый аргумент `single-slot` и одноразово подтверждает точный SHA
+через process environment `DEPLOY_SINGLE_SLOT_CONFIRMED_SHA`.
+
+До запуска обязательны off-host PostgreSQL backup, проверенный текущий
+`last-successful-revision`, не менее `2 GiB` свободного диска, explicit maintenance window и
+готовность публичного smoke. Команда сначала скачивает и проверяет immutable images, создаёт ещё
+один локальный dump и запускает migration gate. Только после этого она последовательно останавливает
+legacy worker, bot и backend, выполняет setup/migrations, запускает новый backend и проверяет его,
+затем запускает единственных worker/bot и записывает успешную revision.
+
+Ошибка после остановки приложения пересоздаёт legacy services из зафиксированных прежних image
+digests и проверяет public smoke. Schema автоматически не откатывается: общий online-migration gate
+сохраняет совместимость старого кода. Если возврат не подтверждён, evidence получает verdict
+`manual intervention required`, а оператор действует по recovery runbook.
+
+~~~console
+DEPLOY_SINGLE_SLOT_CONFIRMED_SHA=<TARGET_SHA> \
+BACKEND_IMAGE=ghcr.io/...:<TARGET_SHA> \
+BOT_IMAGE=ghcr.io/...:<TARGET_SHA> \
+bash scripts/deploy_production.sh \
+  <TARGET_SHA> \
+  https://app.your-fitness-coach.ru \
+  https://your-fitness-coach.ru \
+  single-slot
+~~~
+
+Отсутствие четвёртого аргумента всегда сохраняет fail-closed blue/green path. Single-slot не создаёт
+`state.json`; переход к blue/green в будущем по-прежнему требует отдельного bootstrap и фактического
+parallel-slot headroom.
+
 ## Bootstrap и production boundary
 
 Существующий single-slot host не получает state/`edge_config` автоматически: первый bootstrap

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -5,6 +5,7 @@ readonly EXPECTED_ROOT="/root/fit-mini-app"
 readonly TARGET_SHA="${1:?usage: deploy_production.sh TARGET_SHA BASE_URL}"
 readonly BASE_URL="${2:?usage: deploy_production.sh TARGET_SHA BASE_URL}"
 readonly PUBLIC_BASE_URL="${3:-https://your-fitness-coach.ru}"
+readonly ROLLOUT_MODE="${4:-zero-downtime}"
 readonly BACKEND_IMAGE="${BACKEND_IMAGE:?BACKEND_IMAGE must reference the tested backend image}"
 readonly BOT_IMAGE="${BOT_IMAGE:?BOT_IMAGE must reference the tested bot image}"
 
@@ -77,12 +78,28 @@ python3 scripts/configure_production_auth.py .env
 echo "Validating Compose configuration for $TARGET_SHA"
 docker compose config --quiet
 
-echo "Starting fail-closed blue/green rollout"
-python3 scripts/zero_downtime_deploy.py \
-  deploy \
-  "$TARGET_SHA" \
-  "$BASE_URL" \
-  "$PUBLIC_BASE_URL"
+case "$ROLLOUT_MODE" in
+  zero-downtime)
+    echo "Starting fail-closed blue/green rollout"
+    python3 scripts/zero_downtime_deploy.py \
+      deploy \
+      "$TARGET_SHA" \
+      "$BASE_URL" \
+      "$PUBLIC_BASE_URL"
+    ;;
+  single-slot)
+    echo "Starting explicitly authorized single-slot rollout with bounded downtime"
+    python3 scripts/zero_downtime_deploy.py \
+      single-slot \
+      "$TARGET_SHA" \
+      "$BASE_URL" \
+      "$PUBLIC_BASE_URL"
+    ;;
+  *)
+    echo "Unsupported rollout mode: $ROLLOUT_MODE" >&2
+    exit 1
+    ;;
+esac
 
 echo "Checking the public Telegram bot profile"
 set +e

--- a/scripts/zero_downtime_deploy.py
+++ b/scripts/zero_downtime_deploy.py
@@ -1,4 +1,4 @@
-"""Blue/green production rollout for the current single-host Docker Compose stack."""
+"""Fail-closed production rollouts for the current single-host Docker Compose stack."""
 
 from __future__ import annotations
 
@@ -193,6 +193,13 @@ def _slot_environment(
     return env
 
 
+def _legacy_environment(*, backend_image: str, bot_image: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env["BACKEND_IMAGE"] = backend_image
+    env["BOT_IMAGE"] = bot_image
+    return env
+
+
 def _image_digest(image: str, expected_revision: str) -> str:
     result = _run(
         [
@@ -247,6 +254,33 @@ def _capacity() -> dict[str, int]:
     }
     if missing:
         raise DeploymentError(f"parallel-slot capacity gate failed: {missing}")
+    return report
+
+
+def _single_slot_capacity() -> dict[str, int]:
+    memory_kib = 0
+    meminfo = Path("/proc/meminfo")
+    if meminfo.is_file():
+        for line in meminfo.read_text(encoding="utf-8").splitlines():
+            if line.startswith("MemAvailable:"):
+                memory_kib = int(line.split()[1])
+                break
+    disk = shutil.disk_usage(Path.cwd())
+    report = {
+        "cpu_count": os.cpu_count() or 0,
+        "memory_available_mb": memory_kib // 1024,
+        "disk_available_mb": disk.free // (1024 * 1024),
+    }
+    minimums = {
+        "cpu_count": 1,
+        "memory_available_mb": 64,
+        "disk_available_mb": 2048,
+    }
+    missing = {
+        key: (report[key], required) for key, required in minimums.items() if report[key] < required
+    }
+    if missing:
+        raise DeploymentError(f"single-slot capacity gate failed: {missing}")
     return report
 
 
@@ -1030,6 +1064,294 @@ def deploy(config: DeployConfig) -> Evidence:
         _write_evidence(evidence_path, evidence)
 
 
+def _legacy_running_image(service: str) -> str:
+    container_id = _compose("ps", "-q", service, capture=True).stdout.strip()
+    if not container_id or not _service_is_running(service):
+        raise DeploymentError(f"single-slot rollout requires running legacy service {service}")
+    image = _run(
+        ["docker", "inspect", "--format", "{{.Config.Image}}", container_id],
+        capture=True,
+    ).stdout.strip()
+    if not image:
+        raise DeploymentError(f"legacy service {service} has no image reference")
+    return image
+
+
+def _stop_legacy_services(config: DeployConfig) -> None:
+    for service, timeout in (
+        ("worker", config.worker_drain_seconds),
+        ("bot", config.bot_drain_seconds),
+        ("backend", config.backend_drain_seconds),
+    ):
+        if not _service_is_running(service):
+            raise DeploymentError(f"legacy service {service} stopped before maintenance handoff")
+        _compose("stop", "-t", str(timeout), service)
+        if _service_is_running(service):
+            raise DeploymentError(f"legacy service {service} remained running after stop")
+
+
+def _start_legacy_backend(env: dict[str, str], config: DeployConfig) -> None:
+    _compose(
+        "up",
+        "-d",
+        "--no-build",
+        "--no-deps",
+        "--force-recreate",
+        "--wait",
+        "--wait-timeout",
+        str(config.readiness_timeout_seconds),
+        "backend",
+        env=env,
+    )
+    _candidate_smoke("legacy")
+
+
+def _start_legacy_consumers(
+    env: dict[str, str],
+    evidence: Evidence,
+    config: DeployConfig,
+    *,
+    require_markers: bool,
+) -> tuple[ConsumerLease, ConsumerLease]:
+    started = time.monotonic()
+    _compose(
+        "up",
+        "-d",
+        "--no-build",
+        "--no-deps",
+        "--force-recreate",
+        "--wait",
+        "--wait-timeout",
+        str(config.readiness_timeout_seconds),
+        "worker",
+        env=env,
+    )
+    worker_markers = ("worker_started",) if require_markers else ()
+    worker_lease = _consumer_lease("worker", worker_markers)
+    _wait_for_ownership(worker_lease, timeout=config.readiness_timeout_seconds)
+    evidence.worker_handoff_seconds = round(time.monotonic() - started, 3)
+
+    started = time.monotonic()
+    _compose(
+        "up",
+        "-d",
+        "--no-build",
+        "--no-deps",
+        "--force-recreate",
+        "bot",
+        env=env,
+    )
+    bot_markers = (
+        ("polling_file_lock_acquired", "telegram_polling_started")
+        if config.bot_polling_enabled
+        else ("polling_disabled",)
+    )
+    if not require_markers:
+        bot_markers = ()
+    bot_lease = _consumer_lease("bot", bot_markers)
+    _wait_for_ownership(bot_lease, timeout=config.readiness_timeout_seconds)
+    evidence.bot_handoff_seconds = round(time.monotonic() - started, 3)
+    return worker_lease, bot_lease
+
+
+def single_slot_deploy(config: DeployConfig) -> Evidence:
+    confirmed_sha = os.environ.get("DEPLOY_SINGLE_SLOT_CONFIRMED_SHA", "")
+    if confirmed_sha != config.target_revision:
+        raise DeploymentError(
+            "single-slot rollout requires DEPLOY_SINGLE_SLOT_CONFIRMED_SHA "
+            "to equal the exact target revision"
+        )
+    if (config.state_root / "state.json").exists():
+        raise DeploymentError(
+            "single-slot rollout is only allowed before blue/green state initialization"
+        )
+
+    active_revision_path = config.state_root / "last-successful-revision"
+    if not active_revision_path.is_file():
+        raise DeploymentError("single-slot rollout requires last-successful-revision evidence")
+    active_revision = active_revision_path.read_text(encoding="utf-8").strip()
+    if not re.fullmatch(r"[0-9a-f]{40}", active_revision):
+        raise DeploymentError("last-successful-revision is not a full Git SHA")
+
+    deployment_id = (
+        f"single-slot-{int(time.time())}-{config.target_revision[:12]}-{uuid.uuid4().hex[:8]}"
+    )
+    evidence = Evidence(
+        deployment_id=deployment_id,
+        target_revision=config.target_revision,
+        previous_revision=active_revision,
+        active_slot="legacy",
+        candidate_slot="legacy",
+        started_at=time.time(),
+    )
+    evidence_path = config.state_root / deployment_id / "summary.json"
+
+    if active_revision == config.target_revision:
+        _switch_gateway("legacy", "legacy")
+        _public_smoke(config)
+        evidence.verdict = "active"
+        _write_evidence(evidence_path, evidence)
+        print(f"Revision {config.target_revision} is already active; verified single-slot no-op")
+        return evidence
+
+    old_backend = ""
+    old_bot = ""
+    target_env: dict[str, str] | None = None
+    services_stopped = False
+
+    try:
+        with _stage(evidence, "single_slot_preflight"):
+            evidence.capacity = _single_slot_capacity()
+            _compose("config", "--quiet")
+            _switch_gateway("legacy", "legacy")
+            _public_smoke(config)
+            old_backend = _image_digest(_legacy_running_image("backend"), active_revision)
+            old_bot = _image_digest(_legacy_running_image("bot"), active_revision)
+            old_worker = _image_digest(_legacy_running_image("worker"), active_revision)
+            if old_worker != old_backend:
+                raise DeploymentError(
+                    "legacy backend and worker do not use the same verified image digest"
+                )
+            _legacy_running_image("edge")
+
+        with _stage(evidence, "pull_and_verify"):
+            preliminary_env = _legacy_environment(
+                backend_image=config.backend_image,
+                bot_image=config.bot_image,
+            )
+            _compose(
+                "pull",
+                "setup",
+                "backend",
+                "worker",
+                "bot",
+                env=preliminary_env,
+            )
+            target_backend = _image_digest(config.backend_image, config.target_revision)
+            target_bot = _image_digest(config.bot_image, config.target_revision)
+            target_env = _legacy_environment(
+                backend_image=target_backend,
+                bot_image=target_bot,
+            )
+            _compose("config", "--quiet", env=target_env)
+            _run(
+                [
+                    "docker",
+                    "run",
+                    "--rm",
+                    "--network",
+                    "none",
+                    "--env-file",
+                    ".env",
+                    target_backend,
+                    "python",
+                    "-c",
+                    "from fitminiapp_api.core.config import settings; assert settings.app_env == 'prod'",
+                ]
+            )
+            _run(
+                [
+                    "docker",
+                    "run",
+                    "--rm",
+                    "--network",
+                    "none",
+                    "--env-file",
+                    ".env",
+                    target_bot,
+                    "python",
+                    "-c",
+                    "from fitminiapp_bot.config import settings; assert settings.app_env == 'prod'",
+                ]
+            )
+
+        with _stage(evidence, "backup"):
+            _run([sys.executable, "scripts/db_maintenance.py", "backup"])
+
+        with _stage(evidence, "migration_gate"):
+            _run(
+                [
+                    sys.executable,
+                    "scripts/check_online_migrations.py",
+                    active_revision,
+                    config.target_revision,
+                ]
+            )
+
+        with _stage(evidence, "pre_stop_capacity"):
+            evidence.capacity = _single_slot_capacity()
+
+        with _stage(evidence, "maintenance_stop"):
+            services_stopped = True
+            _stop_legacy_services(config)
+
+        with _stage(evidence, "migration"):
+            if target_env is None:
+                raise DeploymentError("target images were not resolved before maintenance")
+            _compose("run", "--rm", "--no-deps", "setup", env=target_env)
+
+        with _stage(evidence, "application_start"):
+            _start_legacy_backend(target_env, config)
+            _public_smoke(config)
+            consumer_leases = _start_legacy_consumers(
+                target_env,
+                evidence,
+                config,
+                require_markers=True,
+            )
+
+        with _stage(evidence, "verification"):
+            for lease in consumer_leases:
+                if not _lease_is_current_and_healthy(lease):
+                    raise DeploymentError(
+                        f"{lease.service} lost current-run ownership after single-slot start"
+                    )
+            _public_smoke(config)
+            _atomic_text(active_revision_path, config.target_revision + "\n")
+
+        evidence.verdict = "active"
+        print(f"Single-slot deployment verified: revision={config.target_revision}; slot=legacy")
+        return evidence
+    except BaseException:
+        if services_stopped and old_backend and old_bot:
+            rollback_stage = StageRecord(name="single_slot_rollback", started_at=time.time())
+            evidence.stages.append(rollback_stage)
+            try:
+                for service, timeout in (
+                    ("worker", config.worker_drain_seconds),
+                    ("bot", config.bot_drain_seconds),
+                    ("backend", config.backend_drain_seconds),
+                ):
+                    if _service_is_running(service):
+                        _compose("stop", "-t", str(timeout), service)
+                rollback_env = _legacy_environment(
+                    backend_image=old_backend,
+                    bot_image=old_bot,
+                )
+                _start_legacy_backend(rollback_env, config)
+                _public_smoke(config)
+                _start_legacy_consumers(
+                    rollback_env,
+                    evidence,
+                    config,
+                    require_markers=False,
+                )
+                _public_smoke(config)
+                evidence.verdict = "rolled back"
+                rollback_stage.status = "passed"
+            except BaseException as rollback_exc:
+                rollback_stage.status = "failed"
+                rollback_stage.reason = f"{type(rollback_exc).__name__}: {rollback_exc}"
+                evidence.verdict = "manual intervention required"
+            finally:
+                rollback_stage.ended_at = time.time()
+        else:
+            evidence.verdict = "not stopped"
+        raise
+    finally:
+        _write_evidence(evidence_path, evidence)
+
+
 def _config(args: argparse.Namespace) -> DeployConfig:
     root = Path.cwd().resolve()
     polling_value = _deployment_setting("BOT_POLLING_ENABLED", "true").strip().lower()
@@ -1057,7 +1379,7 @@ def _config(args: argparse.Namespace) -> DeployConfig:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
-    for command in ("deploy", "bootstrap", "rollback"):
+    for command in ("deploy", "bootstrap", "rollback", "single-slot"):
         subparser = subparsers.add_parser(command)
         subparser.add_argument("target_revision")
         subparser.add_argument("base_url")
@@ -1070,6 +1392,12 @@ def main() -> int:
                 bootstrap_state(config)
             elif args.command == "rollback":
                 rollback(config)
+            elif args.command == "single-slot":
+                evidence = single_slot_deploy(config)
+                print(
+                    f"Deployment verdict: {evidence.verdict}; "
+                    f"revision={evidence.target_revision}; slot={evidence.candidate_slot}"
+                )
             else:
                 evidence = deploy(config)
                 print(
@@ -1077,7 +1405,7 @@ def main() -> int:
                     f"revision={evidence.target_revision}; slot={evidence.candidate_slot}"
                 )
     except (KeyError, OSError, ValueError, subprocess.CalledProcessError, DeploymentError) as exc:
-        print(f"Zero-downtime deployment failed: {exc}", file=sys.stderr)
+        print(f"Production deployment failed: {exc}", file=sys.stderr)
         return 1
     return 0
 

--- a/scripts/zero_downtime_deploy.py
+++ b/scripts/zero_downtime_deploy.py
@@ -1085,9 +1085,17 @@ def _stop_legacy_services(config: DeployConfig) -> None:
     ):
         if not _service_is_running(service):
             raise DeploymentError(f"legacy service {service} stopped before maintenance handoff")
+        worker_lease = (
+            _consumer_lease(service, ("worker_started",)) if service == "worker" else None
+        )
         _compose("stop", "-t", str(timeout), service)
         if _service_is_running(service):
             raise DeploymentError(f"legacy service {service} remained running after stop")
+        if worker_lease is not None and "worker_stopped" not in _current_run_logs(worker_lease):
+            raise DeploymentError(
+                "worker did not acknowledge a completed drain within "
+                f"{config.worker_drain_seconds}s; consumer state is uncertain"
+            )
 
 
 def _start_legacy_backend(env: dict[str, str], config: DeployConfig) -> None:

--- a/tests/test_container_image_contract.py
+++ b/tests/test_container_image_contract.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_ci_rebuilds_and_verifies_bot_runtime_sources_before_publish() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    assert "no_cache: true" in workflow
+    assert "no-cache: ${{ matrix.no_cache }}" in workflow
+    assert "Verify bot runtime image contract" in workflow
+    assert "import fitminiapp_bot.profile_sync" in workflow
+    assert workflow.index("Verify bot runtime image contract") < workflow.index("Scan image")
+    assert workflow.index("Verify bot runtime image contract") < workflow.index(
+        "Publish scanned image"
+    )

--- a/tests/test_release_safeguards.py
+++ b/tests/test_release_safeguards.py
@@ -20,6 +20,11 @@ def test_automated_deploy_keeps_revision_provenance_and_stale_run_guards() -> No
     )
 
     assert "scripts/zero_downtime_deploy.py" in deploy_script
+    assert 'ROLLOUT_MODE="${4:-zero-downtime}"' in deploy_script
+    assert "single-slot" in deploy_script
+    assert "DEPLOY_SINGLE_SLOT_CONFIRMED_SHA" in (
+        root / "scripts" / "zero_downtime_deploy.py"
+    ).read_text(encoding="utf-8")
     assert "docker compose config --quiet" in deploy_script
     assert "--remove-orphans" not in deploy_script
     assert "docker compose up" not in deploy_script

--- a/tests/test_release_safeguards.py
+++ b/tests/test_release_safeguards.py
@@ -19,6 +19,13 @@ def test_automated_deploy_keeps_revision_provenance_and_stale_run_guards() -> No
         'is no longer master head (\\$LATEST_MASTER_SHA)\\"' in deploy_workflow
     )
 
+    assert "PROD_ROLLOUT_MODE: single-slot" in deploy_workflow
+    assert "DEPLOY_SINGLE_SLOT_CONFIRMED_SHA='$DEPLOY_SHA'" in deploy_workflow
+    assert "'$PROD_ROLLOUT_MODE'" in deploy_workflow
+    assert deploy_workflow.index("LATEST_MASTER_SHA=") < deploy_workflow.index(
+        "DEPLOY_SINGLE_SLOT_CONFIRMED_SHA="
+    )
+
     assert "scripts/zero_downtime_deploy.py" in deploy_script
     assert 'ROLLOUT_MODE="${4:-zero-downtime}"' in deploy_script
     assert "single-slot" in deploy_script

--- a/tests/test_zero_downtime_deploy.py
+++ b/tests/test_zero_downtime_deploy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 from dataclasses import asdict
 from pathlib import Path
@@ -440,3 +441,202 @@ def test_manual_rollback_swaps_only_verified_revisions(tmp_path: Path, monkeypat
     assert restored.active_revision == OLD_SHA
     assert restored.rollback_revision == NEW_SHA
     assert calls["switch"] == [("blue", "green")]
+
+
+def _patch_single_slot_runtime(tmp_path: Path, monkeypatch) -> dict[str, list]:
+    calls: dict[str, list] = {
+        "compose": [],
+        "stops": [],
+        "backend_starts": [],
+        "consumer_starts": [],
+    }
+    config = _config(tmp_path)
+    active_revision_path = config.state_root / "last-successful-revision"
+    active_revision_path.parent.mkdir(parents=True)
+    active_revision_path.write_text(OLD_SHA + "\n", encoding="utf-8")
+    monkeypatch.setenv("DEPLOY_SINGLE_SLOT_CONFIRMED_SHA", NEW_SHA)
+    monkeypatch.setattr(
+        deploy,
+        "_single_slot_capacity",
+        lambda: {"cpu_count": 1, "memory_available_mb": 128, "disk_available_mb": 4096},
+    )
+    monkeypatch.setattr(
+        deploy,
+        "_compose",
+        lambda *args, **kwargs: (
+            calls["compose"].append((args, kwargs))
+            or subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        ),
+    )
+    monkeypatch.setattr(deploy, "_switch_gateway", lambda *args: None)
+    monkeypatch.setattr(deploy, "_public_smoke", lambda *args: None)
+    monkeypatch.setattr(
+        deploy,
+        "_legacy_running_image",
+        lambda service: f"registry/{'bot' if service == 'bot' else 'backend'}:{OLD_SHA}",
+    )
+    monkeypatch.setattr(
+        deploy,
+        "_image_digest",
+        lambda image, revision: f"{image.split(':', maxsplit=1)[0]}@sha256:{revision[0] * 64}",
+    )
+    monkeypatch.setattr(
+        deploy,
+        "_run",
+        lambda args, **kwargs: subprocess.CompletedProcess(args, 0, stdout="", stderr=""),
+    )
+    monkeypatch.setattr(
+        deploy,
+        "_stop_legacy_services",
+        lambda value: calls["stops"].append(value.target_revision),
+    )
+    monkeypatch.setattr(
+        deploy,
+        "_start_legacy_backend",
+        lambda env, value: calls["backend_starts"].append(env["BACKEND_IMAGE"]),
+    )
+
+    def start_consumers(env, evidence, value, *, require_markers):
+        del evidence, value
+        calls["consumer_starts"].append((env["BOT_IMAGE"], require_markers))
+        markers = ("worker_started",) if require_markers else ()
+        return (
+            deploy.ConsumerLease("worker", "worker-id", "now", markers),
+            deploy.ConsumerLease("bot", "bot-id", "now", markers),
+        )
+
+    monkeypatch.setattr(deploy, "_start_legacy_consumers", start_consumers)
+    monkeypatch.setattr(deploy, "_lease_is_current_and_healthy", lambda lease: True)
+    return calls
+
+
+def test_single_slot_rollout_requires_exact_one_shot_confirmation(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(tmp_path)
+    monkeypatch.delenv("DEPLOY_SINGLE_SLOT_CONFIRMED_SHA", raising=False)
+
+    with pytest.raises(deploy.DeploymentError, match="exact target revision"):
+        deploy.single_slot_deploy(config)
+
+
+def test_single_slot_refuses_initialized_blue_green_host(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    _state(config)
+    monkeypatch.setenv("DEPLOY_SINGLE_SLOT_CONFIRMED_SHA", NEW_SHA)
+
+    with pytest.raises(deploy.DeploymentError, match="before blue/green state initialization"):
+        deploy.single_slot_deploy(config)
+
+
+def test_single_slot_rollout_replaces_legacy_services_and_records_success(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(tmp_path)
+    calls = _patch_single_slot_runtime(tmp_path, monkeypatch)
+
+    evidence = deploy.single_slot_deploy(config)
+
+    assert evidence.verdict == "active"
+    assert calls["stops"] == [NEW_SHA]
+    assert calls["backend_starts"] == ["registry/backend@sha256:" + "b" * 64]
+    assert calls["consumer_starts"] == [("registry/bot@sha256:" + "b" * 64, True)]
+    assert (
+        config.state_root.joinpath("last-successful-revision").read_text(encoding="utf-8").strip()
+        == NEW_SHA
+    )
+    assert not config.state_root.joinpath("state.json").exists()
+
+
+def test_single_slot_failure_after_stop_restores_previous_images(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(tmp_path)
+    calls = _patch_single_slot_runtime(tmp_path, monkeypatch)
+    starts = 0
+
+    def fail_target_once(env, value):
+        nonlocal starts
+        del value
+        starts += 1
+        calls["backend_starts"].append(env["BACKEND_IMAGE"])
+        if starts == 1:
+            raise deploy.DeploymentError("new backend failed")
+
+    monkeypatch.setattr(deploy, "_start_legacy_backend", fail_target_once)
+    monkeypatch.setattr(deploy, "_service_is_running", lambda service: False)
+
+    with pytest.raises(deploy.DeploymentError, match="new backend failed"):
+        deploy.single_slot_deploy(config)
+
+    assert calls["backend_starts"] == [
+        "registry/backend@sha256:" + "b" * 64,
+        "registry/backend@sha256:" + "a" * 64,
+    ]
+    assert calls["consumer_starts"] == [("registry/bot@sha256:" + "a" * 64, False)]
+    summaries = list(config.state_root.glob("single-slot-*/summary.json"))
+    assert len(summaries) == 1
+    assert json.loads(summaries[0].read_text(encoding="utf-8"))["verdict"] == "rolled back"
+
+
+def test_single_slot_rechecks_capacity_after_pull_and_backup(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    calls = _patch_single_slot_runtime(tmp_path, monkeypatch)
+    capacity_checks = 0
+
+    def capacity():
+        nonlocal capacity_checks
+        capacity_checks += 1
+        if capacity_checks == 2:
+            raise deploy.DeploymentError("single-slot capacity gate failed after pull")
+        return {"cpu_count": 1, "memory_available_mb": 128, "disk_available_mb": 4096}
+
+    monkeypatch.setattr(deploy, "_single_slot_capacity", capacity)
+
+    with pytest.raises(deploy.DeploymentError, match="failed after pull"):
+        deploy.single_slot_deploy(config)
+
+    assert capacity_checks == 2
+    assert calls["stops"] == []
+
+
+def test_single_slot_rejects_backend_worker_image_drift(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    calls = _patch_single_slot_runtime(tmp_path, monkeypatch)
+
+    def running_image(service):
+        if service == "worker":
+            return f"registry/worker-drift:{OLD_SHA}"
+        return f"registry/{'bot' if service == 'bot' else 'backend'}:{OLD_SHA}"
+
+    monkeypatch.setattr(deploy, "_legacy_running_image", running_image)
+
+    with pytest.raises(deploy.DeploymentError, match="same verified image digest"):
+        deploy.single_slot_deploy(config)
+
+    assert calls["stops"] == []
+
+
+def test_single_slot_stop_is_ordered_and_uses_bounded_timeouts(tmp_path: Path, monkeypatch) -> None:
+    config = _config(tmp_path)
+    running = {"worker", "bot", "backend"}
+    commands = []
+
+    monkeypatch.setattr(deploy, "_service_is_running", lambda service: service in running)
+
+    def compose(*args, **kwargs):
+        del kwargs
+        commands.append(args)
+        if args[0] == "stop":
+            running.remove(args[-1])
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(deploy, "_compose", compose)
+
+    deploy._stop_legacy_services(config)
+
+    assert commands == [
+        ("stop", "-t", "120", "worker"),
+        ("stop", "-t", "60", "bot"),
+        ("stop", "-t", "45", "backend"),
+    ]

--- a/tests/test_zero_downtime_deploy.py
+++ b/tests/test_zero_downtime_deploy.py
@@ -621,8 +621,16 @@ def test_single_slot_stop_is_ordered_and_uses_bounded_timeouts(tmp_path: Path, m
     config = _config(tmp_path)
     running = {"worker", "bot", "backend"}
     commands = []
+    worker_lease = deploy.ConsumerLease(
+        service="worker",
+        container_id="worker-current",
+        started_at="2026-08-28T12:00:00Z",
+        required_markers=("worker_started",),
+    )
 
     monkeypatch.setattr(deploy, "_service_is_running", lambda service: service in running)
+    monkeypatch.setattr(deploy, "_consumer_lease", lambda *args: worker_lease)
+    monkeypatch.setattr(deploy, "_current_run_logs", lambda lease: "worker_stopped\n")
 
     def compose(*args, **kwargs):
         del kwargs
@@ -640,3 +648,36 @@ def test_single_slot_stop_is_ordered_and_uses_bounded_timeouts(tmp_path: Path, m
         ("stop", "-t", "60", "bot"),
         ("stop", "-t", "45", "backend"),
     ]
+
+
+def test_single_slot_stop_fails_closed_when_worker_drain_is_unconfirmed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(tmp_path)
+    running = {"worker", "bot", "backend"}
+    commands = []
+    worker_lease = deploy.ConsumerLease(
+        service="worker",
+        container_id="worker-current",
+        started_at="2026-08-28T12:00:00Z",
+        required_markers=("worker_started",),
+    )
+
+    monkeypatch.setattr(deploy, "_service_is_running", lambda service: service in running)
+    monkeypatch.setattr(deploy, "_consumer_lease", lambda *args: worker_lease)
+    monkeypatch.setattr(deploy, "_current_run_logs", lambda lease: "worker_drain_requested\n")
+
+    def compose(*args, **kwargs):
+        del kwargs
+        commands.append(args)
+        if args[0] == "stop":
+            running.remove(args[-1])
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(deploy, "_compose", compose)
+
+    with pytest.raises(deploy.DeploymentError, match="consumer state is uncertain"):
+        deploy._stop_legacy_services(config)
+
+    assert commands == [("stop", "-t", "120", "worker")]
+    assert running == {"bot", "backend"}


### PR DESCRIPTION
## Что изменено

- добавлен явный single-slot rollout для host без parallel-slot headroom
- требуется одноразовое подтверждение exact target SHA
- до остановки выполняются image validation, backup, migration gate и повторный capacity check
- при ошибке восстанавливаются прежние exact image digests и выполняется public smoke
- normal blue/green path и его capacity gates не ослаблены

## Проверки

- Ruff format/check
- 34 targeted pytest tests
- Bash syntax check
- pre-commit hooks

## Production preflight

- backup branch: backup/master-before-single-slot-20260828-2130
- off-host EFS AES-256 PostgreSQL dump, SHA-256 verified
- owner approved bounded maintenance downtime