### PR TITLE
fix(deploy): accept verified clean legacy worker exit

### DIFF
--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -99,10 +99,14 @@ approval. Timeout/readiness/drain/observation параметры перечис�
 измерения только для прохождения gate запрещено.
 
 `DEPLOY_WORKER_DRAIN_SECONDS` одновременно задаёт Compose grace period и timeout команды stop.
-Значение должно быть больше измеренного worst-case времени одного worker cycle. Если после SIGTERM
-нет текущего `worker_stopped`, rollout считается имеющим неопределённое состояние consumer, новый
-worker не получает ownership, а оператор использует evidence для ручного разбора. Старые строки
-логов переиспользованного slot не принимаются: boundary берётся из `StartedAt` текущего container.
+Значение должно быть больше измеренного worst-case времени одного worker cycle. Основное
+доказательство корректного завершения — текущий `worker_stopped`; старые строки логов
+переиспользованного slot не принимаются, boundary берётся из `StartedAt` текущего container.
+Ограниченное исключение для legacy worker без доступного marker допускается только после stop того
+же заранее захваченного container ID, если `docker inspect` подтверждает строго `exited 0`. При
+`running`, ненулевом exit code, исчезнувшем container или любой другой неоднозначности rollout
+считается имеющим неопределённое состояние consumer: новый worker не получает ownership, а оператор
+использует evidence для ручного разбора.
 
 Online migration gate анализирует только `upgrade()`. Для `expand` автоматически допускается лишь
 `op.add_column` со статически проверяемым `nullable=True` без default/index/unique; обычные index и

--- a/scripts/zero_downtime_deploy.py
+++ b/scripts/zero_downtime_deploy.py
@@ -414,6 +414,20 @@ def _current_run_logs(lease: ConsumerLease) -> str:
     ).stdout
 
 
+def _container_exited_cleanly(lease: ConsumerLease) -> bool:
+    state = _run(
+        [
+            "docker",
+            "inspect",
+            "--format",
+            "{{.State.Status}} {{.State.ExitCode}}",
+            lease.container_id,
+        ],
+        capture=True,
+    ).stdout.strip()
+    return state == "exited 0"
+
+
 def _wait_for_ownership(lease: ConsumerLease, timeout: float) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -460,7 +474,9 @@ def _stop_slot_consumers(slot: str, config: DeployConfig, *, require_running: bo
     if _service_is_running(worker):
         worker_lease = _consumer_lease(worker, ("worker_started",))
         _compose("stop", "-t", str(config.worker_drain_seconds), worker)
-        if "worker_stopped" not in _current_run_logs(worker_lease):
+        if "worker_stopped" not in _current_run_logs(
+            worker_lease
+        ) and not _container_exited_cleanly(worker_lease):
             raise DeploymentError(
                 f"{worker} did not acknowledge a completed drain within "
                 f"{config.worker_drain_seconds}s; consumer state is uncertain"
@@ -1100,7 +1116,11 @@ def _stop_legacy_services(config: DeployConfig) -> None:
         _compose("stop", "-t", str(timeout), service)
         if _service_is_running(service):
             raise DeploymentError(f"legacy service {service} remained running after stop")
-        if worker_lease is not None and "worker_stopped" not in _current_run_logs(worker_lease):
+        if (
+            worker_lease is not None
+            and "worker_stopped" not in _current_run_logs(worker_lease)
+            and not _container_exited_cleanly(worker_lease)
+        ):
             raise DeploymentError(
                 "worker did not acknowledge a completed drain within "
                 f"{config.worker_drain_seconds}s; consumer state is uncertain"

--- a/tests/test_zero_downtime_deploy.py
+++ b/tests/test_zero_downtime_deploy.py
@@ -421,6 +421,7 @@ def test_consumer_stop_fails_closed_when_worker_drain_is_unconfirmed(
     monkeypatch.setattr(deploy, "_consumer_lease", lambda *args: lease)
     monkeypatch.setattr(deploy, "_service_is_running", lambda service: True)
     monkeypatch.setattr(deploy, "_current_run_logs", lambda value: "worker_drain_requested\n")
+    monkeypatch.setattr(deploy, "_container_exited_cleanly", lambda value: False)
     monkeypatch.setattr(
         deploy,
         "_compose",
@@ -433,6 +434,37 @@ def test_consumer_stop_fails_closed_when_worker_drain_is_unconfirmed(
         deploy._stop_slot_consumers("blue", config)
 
     assert commands == [("stop", "-t", "120", "worker-blue")]
+
+
+def test_consumer_stop_accepts_exact_container_clean_exit_without_legacy_marker(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(tmp_path)
+    lease = deploy.ConsumerLease(
+        service="worker-blue",
+        container_id="worker-current",
+        started_at="2026-08-28T12:00:00Z",
+        required_markers=("worker_started",),
+    )
+    commands = []
+    monkeypatch.setattr(deploy, "_consumer_lease", lambda *args: lease)
+    monkeypatch.setattr(deploy, "_service_is_running", lambda service: True)
+    monkeypatch.setattr(deploy, "_current_run_logs", lambda value: "application_log\n")
+    monkeypatch.setattr(deploy, "_container_exited_cleanly", lambda value: True)
+    monkeypatch.setattr(
+        deploy,
+        "_compose",
+        lambda *args, **kwargs: (
+            commands.append(args) or subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        ),
+    )
+
+    deploy._stop_slot_consumers("blue", config)
+
+    assert commands == [
+        ("stop", "-t", "120", "worker-blue"),
+        ("stop", "-t", "60", "bot-blue"),
+    ]
 
 
 def test_manual_rollback_swaps_only_verified_revisions(tmp_path: Path, monkeypatch) -> None:
@@ -718,6 +750,7 @@ def test_single_slot_stop_fails_closed_when_worker_drain_is_unconfirmed(
     monkeypatch.setattr(deploy, "_service_is_running", lambda service: service in running)
     monkeypatch.setattr(deploy, "_consumer_lease", lambda *args: worker_lease)
     monkeypatch.setattr(deploy, "_current_run_logs", lambda lease: "worker_drain_requested\n")
+    monkeypatch.setattr(deploy, "_container_exited_cleanly", lambda lease: False)
 
     def compose(*args, **kwargs):
         del kwargs
@@ -733,3 +766,22 @@ def test_single_slot_stop_fails_closed_when_worker_drain_is_unconfirmed(
 
     assert commands == [("stop", "-t", "120", "worker")]
     assert running == {"bot", "backend"}
+
+
+def test_clean_exit_evidence_requires_exited_zero(monkeypatch) -> None:
+    lease = deploy.ConsumerLease(
+        service="worker",
+        container_id="worker-current",
+        started_at="2026-08-28T12:00:00Z",
+        required_markers=("worker_started",),
+    )
+
+    for state, expected in (("exited 0\n", True), ("exited 137\n", False), ("running 0\n", False)):
+        monkeypatch.setattr(
+            deploy,
+            "_run",
+            lambda *args, output=state, **kwargs: subprocess.CompletedProcess(
+                args, 0, stdout=output, stderr=""
+            ),
+        )
+        assert deploy._container_exited_cleanly(lease) is expected


### PR DESCRIPTION
## Что исправлено

- сохраняется основной drain-proof `worker_stopped` текущего container lease;
- для legacy image, где marker был скрыт formatter-ом, принимается только точный container с Docker state `exited` и `ExitCode=0`;
- `running`, non-zero/SIGKILL и отсутствие обоих доказательств остаются fail-closed.

## Production evidence

PR #45 успешно прошёл provenance gate, backup и migration gate, но остановился на legacy marker gap. Previous revision `74f47af` сейчас восстановлена: backend healthy, worker healthy, bot running, ownership markers подтверждены.

## Проверки

- Ruff format/check: passed
- `tests/test_zero_downtime_deploy.py` + `tests/test_release_safeguards.py`: 31 passed