### PR TITLE
fix(deploy): harden single-slot recovery

### DIFF
--- a/scripts/zero_downtime_deploy.py
+++ b/scripts/zero_downtime_deploy.py
@@ -535,7 +535,7 @@ def _start_slot_consumers(
     return worker_lease, bot_lease
 
 
-def _candidate_smoke(slot: str) -> None:
+def _candidate_smoke(slot: str, *, timeout_seconds: int = 10) -> None:
     if slot == "legacy":
         _run(
             [
@@ -545,6 +545,8 @@ def _candidate_smoke(slot: str) -> None:
                 "--allow-http",
                 "--expected-environment",
                 "prod",
+                "--timeout",
+                str(timeout_seconds),
             ]
         )
         return
@@ -1140,7 +1142,7 @@ def _start_legacy_backend(env: dict[str, str], config: DeployConfig) -> None:
         "backend",
         env=env,
     )
-    _candidate_smoke("legacy")
+    _candidate_smoke("legacy", timeout_seconds=config.readiness_timeout_seconds)
 
 
 def _start_legacy_consumers(
@@ -1149,45 +1151,63 @@ def _start_legacy_consumers(
     config: DeployConfig,
     *,
     require_markers: bool,
+    best_effort: bool = False,
 ) -> tuple[ConsumerLease, ConsumerLease]:
-    started = time.monotonic()
-    _compose(
-        "up",
-        "-d",
-        "--no-build",
-        "--no-deps",
-        "--force-recreate",
-        "--wait",
-        "--wait-timeout",
-        str(config.readiness_timeout_seconds),
-        "worker",
-        env=env,
-    )
-    worker_markers = ("worker_started",) if require_markers else ()
-    worker_lease = _consumer_lease("worker", worker_markers)
-    _wait_for_ownership(worker_lease, timeout=config.readiness_timeout_seconds)
-    evidence.worker_handoff_seconds = round(time.monotonic() - started, 3)
+    errors: list[str] = []
+    worker_lease: ConsumerLease | None = None
+    bot_lease: ConsumerLease | None = None
 
     started = time.monotonic()
-    _compose(
-        "up",
-        "-d",
-        "--no-build",
-        "--no-deps",
-        "--force-recreate",
-        "bot",
-        env=env,
-    )
-    bot_markers = (
-        ("polling_file_lock_acquired", "telegram_polling_started")
-        if config.bot_polling_enabled
-        else ("polling_disabled",)
-    )
-    if not require_markers:
-        bot_markers = ()
-    bot_lease = _consumer_lease("bot", bot_markers)
-    _wait_for_ownership(bot_lease, timeout=config.readiness_timeout_seconds)
-    evidence.bot_handoff_seconds = round(time.monotonic() - started, 3)
+    try:
+        _compose(
+            "up",
+            "-d",
+            "--no-build",
+            "--no-deps",
+            "--force-recreate",
+            "--wait",
+            "--wait-timeout",
+            str(config.readiness_timeout_seconds),
+            "worker",
+            env=env,
+        )
+        worker_markers = ("worker_started",) if require_markers else ()
+        worker_lease = _consumer_lease("worker", worker_markers)
+        _wait_for_ownership(worker_lease, timeout=config.readiness_timeout_seconds)
+        evidence.worker_handoff_seconds = round(time.monotonic() - started, 3)
+    except BaseException as worker_exc:
+        if not best_effort:
+            raise
+        errors.append(f"worker: {type(worker_exc).__name__}: {worker_exc}")
+
+    started = time.monotonic()
+    try:
+        _compose(
+            "up",
+            "-d",
+            "--no-build",
+            "--no-deps",
+            "--force-recreate",
+            "bot",
+            env=env,
+        )
+        bot_markers = (
+            ("polling_file_lock_acquired", "telegram_polling_started")
+            if config.bot_polling_enabled
+            else ("polling_disabled",)
+        )
+        if not require_markers:
+            bot_markers = ()
+        bot_lease = _consumer_lease("bot", bot_markers)
+        _wait_for_ownership(bot_lease, timeout=config.readiness_timeout_seconds)
+        evidence.bot_handoff_seconds = round(time.monotonic() - started, 3)
+    except BaseException as bot_exc:
+        errors.append(f"bot: {type(bot_exc).__name__}: {bot_exc}")
+
+    if errors:
+        raise DeploymentError("consumer restoration was incomplete: " + "; ".join(errors))
+    if worker_lease is None or bot_lease is None:
+        raise DeploymentError("consumer restoration returned no verified ownership lease")
     return worker_lease, bot_lease
 
 
@@ -1365,15 +1385,36 @@ def single_slot_deploy(config: DeployConfig) -> Evidence:
                     backend_image=old_backend,
                     bot_image=old_bot,
                 )
-                _start_legacy_backend(rollback_env, config)
-                _public_smoke(config)
-                _start_legacy_consumers(
-                    rollback_env,
-                    evidence,
-                    config,
-                    require_markers=True,
-                )
-                _public_smoke(config)
+                rollback_errors: list[str] = []
+                try:
+                    _start_legacy_backend(rollback_env, config)
+                except BaseException as rollback_backend_exc:
+                    rollback_errors.append(
+                        f"backend: {type(rollback_backend_exc).__name__}: {rollback_backend_exc}"
+                    )
+                try:
+                    _start_legacy_consumers(
+                        rollback_env,
+                        evidence,
+                        config,
+                        require_markers=True,
+                        best_effort=True,
+                    )
+                except BaseException as rollback_consumers_exc:
+                    rollback_errors.append(
+                        "consumers: "
+                        f"{type(rollback_consumers_exc).__name__}: {rollback_consumers_exc}"
+                    )
+                try:
+                    _public_smoke(config)
+                except BaseException as rollback_smoke_exc:
+                    rollback_errors.append(
+                        f"public smoke: {type(rollback_smoke_exc).__name__}: {rollback_smoke_exc}"
+                    )
+                if rollback_errors:
+                    raise DeploymentError(
+                        "rollback restoration was incomplete: " + "; ".join(rollback_errors)
+                    )
                 evidence.verdict = "rolled back"
                 rollback_stage.status = "passed"
             except BaseException as rollback_exc:

--- a/tests/test_zero_downtime_deploy.py
+++ b/tests/test_zero_downtime_deploy.py
@@ -544,8 +544,9 @@ def _patch_single_slot_runtime(tmp_path: Path, monkeypatch) -> dict[str, list]:
         lambda env, value: calls["backend_starts"].append(env["BACKEND_IMAGE"]),
     )
 
-    def start_consumers(env, evidence, value, *, require_markers):
+    def start_consumers(env, evidence, value, *, require_markers, best_effort=False):
         del evidence, value
+        del best_effort
         calls["consumer_starts"].append((env["BOT_IMAGE"], require_markers))
         markers = ("worker_started",) if require_markers else ()
         return (
@@ -642,9 +643,10 @@ def test_single_slot_rollback_requires_verified_consumer_ownership(
         if starts == 1:
             raise deploy.DeploymentError("new backend failed")
 
-    def fail_consumer_ownership(env, evidence, value, *, require_markers):
+    def fail_consumer_ownership(env, evidence, value, *, require_markers, best_effort=False):
         del env, evidence, value
         assert require_markers is True
+        assert best_effort is True
         raise deploy.DeploymentError("bot ownership confirmation timed out")
 
     monkeypatch.setattr(deploy, "_start_legacy_backend", fail_target_once)
@@ -661,6 +663,123 @@ def test_single_slot_rollback_requires_verified_consumer_ownership(
     rollback = next(stage for stage in summary["stages"] if stage["name"] == "single_slot_rollback")
     assert rollback["status"] == "failed"
     assert "ownership confirmation timed out" in rollback["reason"]
+
+
+def test_single_slot_rollback_attempts_consumers_after_backend_smoke_failure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(tmp_path)
+    calls = _patch_single_slot_runtime(tmp_path, monkeypatch)
+    starts = 0
+
+    def fail_target_and_rollback_smoke(env, value):
+        nonlocal starts
+        del value
+        starts += 1
+        calls["backend_starts"].append(env["BACKEND_IMAGE"])
+        if starts == 1:
+            raise deploy.DeploymentError("new backend failed")
+        raise deploy.DeploymentError("rollback smoke timed out")
+
+    monkeypatch.setattr(deploy, "_start_legacy_backend", fail_target_and_rollback_smoke)
+    monkeypatch.setattr(deploy, "_service_is_running", lambda service: False)
+
+    with pytest.raises(deploy.DeploymentError, match="new backend failed"):
+        deploy.single_slot_deploy(config)
+
+    assert calls["consumer_starts"] == [("registry/bot@sha256:" + "a" * 64, True)]
+    summaries = list(config.state_root.glob("single-slot-*/summary.json"))
+    assert len(summaries) == 1
+    summary = json.loads(summaries[0].read_text(encoding="utf-8"))
+    assert summary["verdict"] == "manual intervention required"
+    rollback = next(stage for stage in summary["stages"] if stage["name"] == "single_slot_rollback")
+    assert "rollback smoke timed out" in rollback["reason"]
+
+
+def test_legacy_consumer_restore_attempts_bot_after_worker_failure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(tmp_path)
+    evidence = deploy.Evidence(
+        deployment_id="test",
+        target_revision=NEW_SHA,
+        previous_revision=OLD_SHA,
+        active_slot="legacy",
+        candidate_slot="legacy",
+        started_at=0,
+    )
+    started_services = []
+
+    def compose(*args, **kwargs):
+        del kwargs
+        if args[0] == "up":
+            started_services.append(args[-1])
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    def consumer_lease(service, markers):
+        return deploy.ConsumerLease(
+            service=service,
+            container_id=f"{service}-current",
+            started_at="2026-08-28T12:00:00Z",
+            required_markers=markers,
+        )
+
+    def wait_for_ownership(lease, timeout):
+        del timeout
+        if lease.service == "worker":
+            raise deploy.DeploymentError("worker ownership failed")
+
+    monkeypatch.setattr(deploy, "_compose", compose)
+    monkeypatch.setattr(deploy, "_consumer_lease", consumer_lease)
+    monkeypatch.setattr(deploy, "_wait_for_ownership", wait_for_ownership)
+
+    with pytest.raises(deploy.DeploymentError, match="worker ownership failed"):
+        deploy._start_legacy_consumers({}, evidence, config, require_markers=True, best_effort=True)
+
+    assert started_services == ["worker", "bot"]
+
+
+def test_forward_consumer_start_is_fail_fast_after_worker_failure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    config = _config(tmp_path)
+    evidence = deploy.Evidence(
+        deployment_id="test",
+        target_revision=NEW_SHA,
+        previous_revision=OLD_SHA,
+        active_slot="legacy",
+        candidate_slot="legacy",
+        started_at=0,
+    )
+    started_services = []
+
+    def compose(*args, **kwargs):
+        del kwargs
+        if args[0] == "up":
+            started_services.append(args[-1])
+        return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+    def consumer_lease(service, markers):
+        return deploy.ConsumerLease(
+            service=service,
+            container_id=f"{service}-current",
+            started_at="2026-08-28T12:00:00Z",
+            required_markers=markers,
+        )
+
+    def wait_for_ownership(lease, timeout):
+        del timeout
+        if lease.service == "worker":
+            raise deploy.DeploymentError("worker ownership failed")
+
+    monkeypatch.setattr(deploy, "_compose", compose)
+    monkeypatch.setattr(deploy, "_consumer_lease", consumer_lease)
+    monkeypatch.setattr(deploy, "_wait_for_ownership", wait_for_ownership)
+
+    with pytest.raises(deploy.DeploymentError, match="worker ownership failed"):
+        deploy._start_legacy_consumers({}, evidence, config, require_markers=True)
+
+    assert started_services == ["worker"]
 
 
 def test_single_slot_rechecks_capacity_after_pull_and_backup(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Что исправлено

- принимается подтвержденный чистый exit worker как drain acknowledgement, если старая версия логгера скрывает marker;
- exit 137, OOM и ненулевой код по-прежнему блокируют deploy;
- локальный backend smoke использует production readiness timeout;
- rollback пытается восстановить backend, worker и bot независимо и затем строго проверяет результат.

## Production evidence

Deploy 33204584342 остановился безопасно: старый worker завершился с exit 0, но его logger записал marker как application_log. Rollback затем прервался на 10-секундном local smoke timeout и не дошел до consumers. Worker и bot восстановлены вручную на прежних контейнерах; worker healthy, bot polling started.

## Проверки

- 33 targeted pytest tests passed
- Ruff passed
- pre-commit passed
- git diff --check passed