### PR TITLE
Fix production news provider env migration

### DIFF
--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -84,6 +84,9 @@ python3 scripts/configure_production_auth.py .env
 echo "Enabling the production Open Food Facts search provider"
 python3 scripts/configure_production_food_search.py .env
 
+echo "Normalizing the production news image provider"
+python3 scripts/normalize_production_news_image_provider.py .env
+
 echo "Validating Compose configuration for $TARGET_SHA"
 docker compose config --quiet
 

--- a/scripts/normalize_production_news_image_provider.py
+++ b/scripts/normalize_production_news_image_provider.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+PROVIDER_KEY = "NEWS_IMAGE_PROVIDER"
+SUPPORTED_PROVIDERS = {"disabled", "cloudflare_workers_ai"}
+
+
+def normalize_production_news_image_provider(path: Path) -> str:
+    if not path.is_file():
+        raise FileNotFoundError(f"Environment file does not exist: {path}")
+
+    original = path.read_text(encoding="utf-8")
+    trailing_newline = original.endswith("\n")
+    lines = original.splitlines()
+    configured_values = [
+        value.strip()
+        for line in lines
+        for key, separator, value in [line.partition("=")]
+        if separator and key == PROVIDER_KEY
+    ]
+    configured = configured_values[-1] if configured_values else ""
+    normalized = configured if configured in SUPPORTED_PROVIDERS else "disabled"
+
+    seen = False
+    updated_lines: list[str] = []
+    for line in lines:
+        key, separator, _value = line.partition("=")
+        if separator and key == PROVIDER_KEY:
+            if not seen:
+                updated_lines.append(f"{PROVIDER_KEY}={normalized}")
+                seen = True
+            continue
+        updated_lines.append(line)
+
+    if not seen:
+        updated_lines.append(f"{PROVIDER_KEY}={normalized}")
+
+    content = "\n".join(updated_lines) + ("\n" if trailing_newline else "")
+    mode = path.stat().st_mode
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="\n",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary.write(content)
+            temporary_name = temporary.name
+        os.chmod(temporary_name, mode)
+        os.replace(temporary_name, path)
+    finally:
+        if temporary_name is not None:
+            Path(temporary_name).unlink(missing_ok=True)
+
+    return normalized
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: normalize_production_news_image_provider.py ENV_FILE")
+    provider = normalize_production_news_image_provider(Path(sys.argv[1]))
+    print(f"Production news image provider: {provider}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_normalize_production_news_image_provider.py
+++ b/tests/test_normalize_production_news_image_provider.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+import pytest
+from scripts.normalize_production_news_image_provider import (
+    normalize_production_news_image_provider,
+)
+
+
+def test_disables_unsupported_legacy_provider_without_changing_secrets(
+    tmp_path: Path,
+) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "SECRET_KEY=keep-this-secret\n"
+        "NEWS_IMAGE_PROVIDER=openai\n"
+        "NEWS_IMAGE_CLOUDFLARE_API_TOKEN=also-keep-this\n",
+        encoding="utf-8",
+    )
+
+    provider = normalize_production_news_image_provider(env_file)
+
+    assert provider == "disabled"
+    assert env_file.read_text(encoding="utf-8") == (
+        "SECRET_KEY=keep-this-secret\n"
+        "NEWS_IMAGE_PROVIDER=disabled\n"
+        "NEWS_IMAGE_CLOUDFLARE_API_TOKEN=also-keep-this\n"
+    )
+
+
+def test_preserves_supported_provider_and_removes_duplicates(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "NEWS_IMAGE_PROVIDER=disabled\nNEWS_IMAGE_PROVIDER=cloudflare_workers_ai\n",
+        encoding="utf-8",
+    )
+
+    first = normalize_production_news_image_provider(env_file)
+    second = normalize_production_news_image_provider(env_file)
+
+    assert first == second == "cloudflare_workers_ai"
+    assert env_file.read_text(encoding="utf-8") == ("NEWS_IMAGE_PROVIDER=cloudflare_workers_ai\n")
+
+
+def test_adds_safe_default_when_provider_is_missing(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("APP_ENV=prod\n", encoding="utf-8")
+
+    provider = normalize_production_news_image_provider(env_file)
+
+    assert provider == "disabled"
+    assert env_file.read_text(encoding="utf-8") == ("APP_ENV=prod\nNEWS_IMAGE_PROVIDER=disabled\n")
+
+
+def test_refuses_missing_environment_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        normalize_production_news_image_provider(tmp_path / ".env")
+
+
+def test_production_deploy_normalizes_provider_before_compose_validation() -> None:
+    root = Path(__file__).resolve().parents[1]
+    deploy = (root / "scripts" / "deploy_production.sh").read_text(encoding="utf-8")
+
+    normalize = "python3 scripts/normalize_production_news_image_provider.py .env"
+    assert normalize in deploy
+    assert deploy.index(normalize) < deploy.index("docker compose config --quiet")


### PR DESCRIPTION
## Release blocker
The first Task 113A stabilization deployment stopped during isolated image-config preflight because production `.env` contained an unsupported legacy `NEWS_IMAGE_PROVIDER` value.

## Forward fix
- preserve supported `cloudflare_workers_ai`
- normalize missing or unsupported legacy values to the fail-closed `disabled` default
- preserve credentials and all unrelated environment entries atomically
- run normalization before Compose/image validation

## Verification
- focused normalization/deploy tests: 15 passed
- Ruff, pre-commit and Bash syntax: passed
- dev CI exact head 74119ad65322aeab813acda5fa890c86ffa800a0: success

This PR only removes the confirmed release blocker; Task 114 is not started.