### PR TITLE
Fix release smoke compatibility for new report route

### DIFF
--- a/backend/tests/test_deployment_smoke.py
+++ b/backend/tests/test_deployment_smoke.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from scripts.check_deployment import HttpResponse, check_deployment
@@ -24,7 +25,7 @@ def _response(
     )
 
 
-def test_deployment_smoke_covers_health_auth_tma_and_versioned_asset() -> None:
+def test_deployment_smoke_separates_compatible_preflight_from_release_contract() -> None:
     responses = {
         "/health/ready": _response(
             "/health/ready", body=b'{"status":"ok"}', content_type="application/json"
@@ -63,8 +64,11 @@ def test_deployment_smoke_covers_health_auth_tma_and_versioned_asset() -> None:
         ),
     }
 
+    requested_paths: list[str] = []
+
     def read(_base_url: str, path: str, *, timeout: float) -> HttpResponse:
         assert timeout == 3
+        requested_paths.append(path)
         return responses[path]
 
     assert (
@@ -72,10 +76,64 @@ def test_deployment_smoke_covers_health_auth_tma_and_versioned_asset() -> None:
             BASE_URL,
             timeout=3,
             expected_environment="prod",
+            require_progress_report_shell=True,
             read=read,
         )
         == "prod"
     )
+    assert "/app/report?period=days_30" in requested_paths
+
+    requested_paths.clear()
+    assert check_deployment(BASE_URL, timeout=3, expected_environment="prod", read=read) == "prod"
+    assert "/app/report?period=days_30" not in requested_paths
+
+
+def test_rollout_smoke_requires_new_contract_only_for_candidate_and_post_switch(
+    monkeypatch,
+) -> None:
+    from scripts import zero_downtime_deploy
+
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        zero_downtime_deploy,
+        "_run",
+        lambda args, **_kwargs: commands.append(list(args)),
+    )
+    config = SimpleNamespace(
+        base_url=BASE_URL,
+        public_base_url="https://public.example.test",
+        seo_timeout_seconds=4,
+    )
+
+    zero_downtime_deploy._public_smoke(config)
+    assert "--expect-progress-report-shell" not in commands[0]
+
+    commands.clear()
+    zero_downtime_deploy._public_smoke(config, require_progress_report_shell=True)
+    assert "--expect-progress-report-shell" in commands[0]
+
+    commands.clear()
+    zero_downtime_deploy._candidate_smoke("legacy")
+    assert "--expect-progress-report-shell" not in commands[0]
+
+    commands.clear()
+    zero_downtime_deploy._candidate_smoke("legacy", require_progress_report_shell=True)
+    assert "--expect-progress-report-shell" in commands[0]
+
+    source = (
+        Path(__file__).resolve().parents[2] / "scripts" / "zero_downtime_deploy.py"
+    ).read_text(encoding="utf-8")
+    single_preflight_start = source.index('with _stage(evidence, "single_slot_preflight")')
+    single_preflight_end = source.index(
+        'with _stage(evidence, "pull_and_verify")', single_preflight_start
+    )
+    single_preflight = source[single_preflight_start:single_preflight_end]
+    assert "_public_smoke(config)" in single_preflight
+    assert "require_progress_report_shell=True" not in single_preflight
+
+    application_start = source.index('with _stage(evidence, "application_start")')
+    application_end = source.index('with _stage(evidence, "verification")', application_start)
+    assert "require_progress_report_shell=True" in source[application_start:application_end]
 
 
 def test_deployment_smoke_rejects_origin_escape() -> None:

--- a/scripts/check_deployment.py
+++ b/scripts/check_deployment.py
@@ -72,6 +72,7 @@ def check_deployment(
     *,
     timeout: float,
     expected_environment: str | None = None,
+    require_progress_report_shell: bool = False,
     read=None,
 ) -> str:
     reader = read or _read
@@ -130,9 +131,10 @@ def check_deployment(
     _expect_same_origin(base_url, app, "application shell")
     _expect_frontend(app, "application shell")
 
-    report = reader(base_url, "/app/report?period=days_30", timeout=timeout)
-    _expect_same_origin(base_url, report, "progress report shell")
-    _expect_frontend(report, "progress report shell")
+    if require_progress_report_shell:
+        report = reader(base_url, "/app/report?period=days_30", timeout=timeout)
+        _expect_same_origin(base_url, report, "progress report shell")
+        _expect_frontend(report, "progress report shell")
 
     login = reader(base_url, "/login", timeout=timeout)
     _expect_same_origin(base_url, login, "browser auth shell")
@@ -169,6 +171,11 @@ def main() -> int:
         action="store_true",
         help="allow plain HTTP for a local/private smoke test",
     )
+    parser.add_argument(
+        "--expect-progress-report-shell",
+        action="store_true",
+        help="require the current release to serve the private /app/report SPA shell",
+    )
     args = parser.parse_args()
 
     if (
@@ -189,6 +196,7 @@ def main() -> int:
             args.base_url,
             timeout=args.timeout,
             expected_environment=expected_environment,
+            require_progress_report_shell=args.expect_progress_report_shell,
         )
     except (OSError, RuntimeError, urllib.error.URLError, json.JSONDecodeError) as exc:
         print(f"Deployment check failed: {exc}", file=sys.stderr)

--- a/scripts/zero_downtime_deploy.py
+++ b/scripts/zero_downtime_deploy.py
@@ -535,7 +535,15 @@ def _start_slot_consumers(
     return worker_lease, bot_lease
 
 
-def _candidate_smoke(slot: str, *, timeout_seconds: int = 10) -> None:
+def _candidate_smoke(
+    slot: str,
+    *,
+    timeout_seconds: int = 10,
+    require_progress_report_shell: bool = False,
+) -> None:
+    release_contract_args = (
+        ["--expect-progress-report-shell"] if require_progress_report_shell else []
+    )
     if slot == "legacy":
         _run(
             [
@@ -547,6 +555,7 @@ def _candidate_smoke(slot: str, *, timeout_seconds: int = 10) -> None:
                 "prod",
                 "--timeout",
                 str(timeout_seconds),
+                *release_contract_args,
             ]
         )
         return
@@ -560,10 +569,18 @@ def _candidate_smoke(slot: str, *, timeout_seconds: int = 10) -> None:
         "--allow-http",
         "--expected-environment",
         "prod",
+        *release_contract_args,
     )
 
 
-def _public_smoke(config: DeployConfig) -> None:
+def _public_smoke(
+    config: DeployConfig,
+    *,
+    require_progress_report_shell: bool = False,
+) -> None:
+    release_contract_args = (
+        ["--expect-progress-report-shell"] if require_progress_report_shell else []
+    )
     _run(
         [
             sys.executable,
@@ -571,6 +588,7 @@ def _public_smoke(config: DeployConfig) -> None:
             config.base_url,
             "--expected-environment",
             "prod",
+            *release_contract_args,
         ]
     )
     _run(
@@ -831,7 +849,7 @@ def deploy(config: DeployConfig) -> Evidence:
         if state.rollback_slot is not None:
             _compose("stop", "-t", "45", _slot_service("backend", state.rollback_slot))
         _atomic_text(config.state_root / "last-successful-revision", config.target_revision + "\n")
-        _public_smoke(config)
+        _public_smoke(config, require_progress_report_shell=True)
         print(f"Revision {config.target_revision} is already active; verified idempotent no-op")
         return Evidence(
             deployment_id=f"noop-{config.target_revision[:12]}",
@@ -963,7 +981,7 @@ def deploy(config: DeployConfig) -> Evidence:
             )
 
         with _stage(evidence, "candidate_smoke"):
-            _candidate_smoke(candidate_slot)
+            _candidate_smoke(candidate_slot, require_progress_report_shell=True)
             if probe.poll() is not None:
                 raise DeploymentError("public route failed while the candidate was prepared")
 
@@ -972,7 +990,7 @@ def deploy(config: DeployConfig) -> Evidence:
             switched = True
 
         with _stage(evidence, "external_verification"):
-            _public_smoke(config)
+            _public_smoke(config, require_progress_report_shell=True)
 
         with _stage(evidence, "consumer_handoff"):
             consumers_stopped = True
@@ -1245,7 +1263,7 @@ def single_slot_deploy(config: DeployConfig) -> Evidence:
 
     if active_revision == config.target_revision:
         _switch_gateway("legacy", "legacy")
-        _public_smoke(config)
+        _public_smoke(config, require_progress_report_shell=True)
         evidence.verdict = "active"
         _write_evidence(evidence_path, evidence)
         print(f"Revision {config.target_revision} is already active; verified single-slot no-op")
@@ -1349,7 +1367,7 @@ def single_slot_deploy(config: DeployConfig) -> Evidence:
 
         with _stage(evidence, "application_start"):
             _start_legacy_backend(target_env, config)
-            _public_smoke(config)
+            _public_smoke(config, require_progress_report_shell=True)
             consumer_leases = _start_legacy_consumers(
                 target_env,
                 evidence,
@@ -1363,7 +1381,7 @@ def single_slot_deploy(config: DeployConfig) -> Evidence:
                     raise DeploymentError(
                         f"{lease.service} lost current-run ownership after single-slot start"
                     )
-            _public_smoke(config)
+            _public_smoke(config, require_progress_report_shell=True)
             _atomic_text(active_revision_path, config.target_revision + "\n")
 
         evidence.verdict = "active"


### PR DESCRIPTION
Forward-fix for the fail-closed deployment of PR #67. The existing production revision is checked with the compatible baseline during preflight, while the candidate and all post-start/post-switch checks strictly require the new /app/report SPA shell. Rollback remains compatible with the prior revision. Local deployment smoke tests pass and exact dev CI run 33269600070 is green.