### PR TITLE
fix(news): allow previous calendar month

### DIFF
--- a/backend/fitminiapp_api/services/news_cli.py
+++ b/backend/fitminiapp_api/services/news_cli.py
@@ -5,7 +5,9 @@ import json
 from pathlib import Path
 from urllib.parse import urlparse
 
+from fitminiapp_api.core.config import settings
 from fitminiapp_api.db.session import get_session_context
+from fitminiapp_api.services.news_rescore import rescore_freshness_blocked_clusters
 from fitminiapp_api.services.news_sources import apply_source_allowlist, parse_source_allowlist
 
 MAX_ALLOWLIST_BYTES = 1_048_576
@@ -22,14 +24,31 @@ def _definitions(path: Path):
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Manage the Telegram news source allowlist")
+    parser = argparse.ArgumentParser(description="Manage the Telegram news pipeline")
     subparsers = parser.add_subparsers(dest="command", required=True)
-    for command in ("check", "apply"):
-        command_parser = subparsers.add_parser(command)
-        command_parser.add_argument("path", type=Path)
-        if command == "apply":
-            command_parser.add_argument("--disable-missing", action="store_true")
+
+    check_parser = subparsers.add_parser("check")
+    check_parser.add_argument("path", type=Path)
+
+    apply_parser = subparsers.add_parser("apply")
+    apply_parser.add_argument("path", type=Path)
+    apply_parser.add_argument("--disable-missing", action="store_true")
+
+    subparsers.add_parser(
+        "rescore-freshness",
+        help="Re-score stored clustered news blocked by the previous freshness window",
+    )
+
     args = parser.parse_args()
+    if args.command == "rescore-freshness":
+        with get_session_context() as db:
+            promoted = rescore_freshness_blocked_clusters(
+                db,
+                candidate_threshold=settings.news_candidate_score_threshold,
+            )
+        print(json.dumps({"status": "rescored", "promoted": promoted}))
+        return
+
     try:
         definitions = _definitions(args.path)
     except ValueError as exc:

--- a/backend/fitminiapp_api/services/news_freshness.py
+++ b/backend/fitminiapp_api/services/news_freshness.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 
 def _as_utc_naive(value: datetime) -> datetime:
@@ -25,12 +25,24 @@ def is_current_month_publication(
     *,
     now: datetime,
 ) -> bool:
+    """Return whether a source date is inside the current or previous calendar month.
+
+    The legacy function name is kept because it is part of the existing news pipeline
+    contract. The accepted freshness window now intentionally spans two calendar months.
+    """
     if published_at is None:
         return False
     current = _as_utc_naive(now)
     published = _as_utc_naive(published_at)
-    month_start = current.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-    return month_start <= published <= current
+    current_month_start = current.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    previous_month_start = (current_month_start - timedelta(days=1)).replace(
+        day=1,
+        hour=0,
+        minute=0,
+        second=0,
+        microsecond=0,
+    )
+    return previous_month_start <= published <= current
 
 
 def source_metadata_is_current_month(

--- a/backend/fitminiapp_api/services/news_rescore.py
+++ b/backend/fitminiapp_api/services/news_rescore.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+
+from fitminiapp_api.models.news import NewsCluster, NewsItem, NewsSource
+from fitminiapp_api.services.news_freshness import is_current_month_publication
+from fitminiapp_api.services.news_ingestion import latest_items_by_source, score_candidate, utcnow
+from fitminiapp_api.services.news_state import transition_news_cluster
+
+
+def rescore_freshness_blocked_clusters(
+    db: Session,
+    *,
+    candidate_threshold: int,
+    now: datetime | None = None,
+    limit: int = 1000,
+) -> int:
+    """Re-evaluate clustered items that were blocked only by the old freshness window."""
+    current = now or utcnow()
+    promoted = 0
+    clusters = (
+        db.query(NewsCluster)
+        .filter(NewsCluster.status == "clustered", NewsCluster.primary_item_id.is_not(None))
+        .order_by(NewsCluster.updated_at.desc())
+        .limit(limit)
+        .all()
+    )
+    for cluster in clusters:
+        previous_risks = list(cluster.risk_flags or [])
+        if "source_not_current_month" not in previous_risks:
+            continue
+        primary = db.get(NewsItem, cluster.primary_item_id)
+        if primary is None or not is_current_month_publication(primary.published_at, now=current):
+            continue
+        source = db.get(NewsSource, primary.source_id)
+        if source is None:
+            continue
+        items = db.query(NewsItem).filter(NewsItem.cluster_id == cluster.id).all()
+        representative_items = latest_items_by_source(items)
+        score, topic, reasons, risks = score_candidate(
+            source,
+            primary,
+            supporting_source_count=max(0, len(representative_items) - 1),
+            uncertain_duplicate="possible_duplicate" in previous_risks,
+            now=current,
+        )
+        cluster.score = score
+        cluster.topic = topic
+        cluster.score_reasons = reasons
+        cluster.risk_flags = risks
+        if score >= candidate_threshold:
+            transition_news_cluster(
+                db,
+                cluster,
+                "candidate",
+                reason_code="freshness_window_recheck",
+            )
+            promoted += 1
+    return promoted

--- a/backend/tests/test_news_editorial.py
+++ b/backend/tests/test_news_editorial.py
@@ -373,20 +373,21 @@ def test_json_feed_parser_accepts_documented_metadata() -> None:
     assert items[0].published_at is not None
 
 
-def test_current_month_freshness_gate_rejects_old_missing_and_future_dates() -> None:
+def test_freshness_window_rejects_older_missing_and_future_dates() -> None:
     now = datetime(2026, 8, 26, 12, 0, 0)
 
+    assert is_current_month_publication(datetime(2026, 7, 1), now=now)
     assert is_current_month_publication(datetime(2026, 8, 1), now=now)
     assert is_current_month_publication(now, now=now)
-    assert not is_current_month_publication(datetime(2026, 7, 31, 23, 59, 59), now=now)
+    assert not is_current_month_publication(datetime(2026, 6, 30, 23, 59, 59), now=now)
     assert not is_current_month_publication(None, now=now)
     assert not is_current_month_publication(datetime(2026, 8, 26, 12, 0, 1), now=now)
 
 
-def test_ingestion_hard_gates_source_outside_current_month() -> None:
+def test_ingestion_hard_gates_source_outside_freshness_window() -> None:
     _create_source()
     current = datetime(2026, 8, 26, 12, 0, 0)
-    stale = replace(_parsed(), published_at=datetime(2026, 7, 31, 23, 59, 59))
+    stale = replace(_parsed(), published_at=datetime(2026, 6, 30, 23, 59, 59))
 
     with get_session_context() as db:
         source = db.get(NewsSource, "journal-one")
@@ -468,16 +469,18 @@ def test_stale_draft_is_not_enqueued_for_owner_review(monkeypatch) -> None:
         cluster = db.get(NewsCluster, cluster_id)
         assert cluster is not None
         draft = asyncio.run(create_draft_revision(db, cluster))
-        previous_month = utcnow().replace(
+        current_month_start = utcnow().replace(
             day=1,
             hour=0,
             minute=0,
             second=0,
             microsecond=0,
-        ) - timedelta(seconds=1)
+        )
+        previous_month_start = (current_month_start - timedelta(days=1)).replace(day=1)
+        stale = previous_month_start - timedelta(seconds=1)
         draft.evidence_metadata = {
             **draft.evidence_metadata,
-            "source_published_at": previous_month.isoformat(),
+            "source_published_at": stale.isoformat(),
         }
 
         assert enqueue_review_deliveries(db, {7001}) == 0

--- a/backend/tests/test_news_freshness_window.py
+++ b/backend/tests/test_news_freshness_window.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fitminiapp_api.services.news_freshness import is_current_month_publication
+
+
+def test_freshness_window_accepts_current_and_previous_calendar_month() -> None:
+    now = datetime(2026, 8, 30, 12, 0, 0)
+
+    assert is_current_month_publication(datetime(2026, 7, 1, 0, 0, 0), now=now)
+    assert is_current_month_publication(datetime(2026, 7, 31, 23, 59, 59), now=now)
+    assert is_current_month_publication(datetime(2026, 8, 1, 0, 0, 0), now=now)
+    assert is_current_month_publication(now, now=now)
+
+
+def test_freshness_window_rejects_older_missing_and_future_dates() -> None:
+    now = datetime(2026, 8, 30, 12, 0, 0)
+
+    assert not is_current_month_publication(datetime(2026, 6, 30, 23, 59, 59), now=now)
+    assert not is_current_month_publication(None, now=now)
+    assert not is_current_month_publication(datetime(2026, 8, 30, 12, 0, 1), now=now)
+
+
+def test_freshness_window_handles_year_boundary_and_timezone() -> None:
+    now = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+
+    assert is_current_month_publication(
+        datetime(2025, 12, 1, 0, 0, 0, tzinfo=UTC),
+        now=now,
+    )
+    assert not is_current_month_publication(
+        datetime(2025, 11, 30, 23, 59, 59, tzinfo=UTC),
+        now=now,
+    )

--- a/backend/tests/test_news_publishing.py
+++ b/backend/tests/test_news_publishing.py
@@ -168,29 +168,31 @@ def test_html_renderer_escapes_user_text_and_keeps_source_as_named_link() -> Non
     assert artifact.text.count("https://") == 1
 
 
-def test_review_artifact_blocks_source_outside_current_month() -> None:
+def test_review_artifact_blocks_source_outside_freshness_window() -> None:
     cluster_id = _source_and_candidate(external_id="stale-review")
     draft_id, _ = _draft(cluster_id)
     with get_session_context() as db:
         draft = db.get(NewsDraftRevision, draft_id)
         assert draft is not None
-        previous_month = utcnow().replace(
+        current_month_start = utcnow().replace(
             day=1,
             hour=0,
             minute=0,
             second=0,
             microsecond=0,
-        ) - timedelta(seconds=1)
+        )
+        previous_month_start = (current_month_start - timedelta(days=1)).replace(day=1)
+        stale = previous_month_start - timedelta(seconds=1)
         draft.evidence_metadata = {
             **draft.evidence_metadata,
-            "source_published_at": previous_month.isoformat(),
+            "source_published_at": stale.isoformat(),
         }
 
         review = compose_review_artifact(db, draft, channel_ready=True)
         assert "source_not_current_month" in review.blockers
 
 
-def test_scheduling_cannot_cross_source_freshness_month(monkeypatch) -> None:
+def test_scheduling_cannot_cross_source_freshness_window(monkeypatch) -> None:
     cluster_id = _source_and_candidate(external_id="cross-month-schedule")
     draft_id, _ = _draft(cluster_id)
     fixed_now = datetime(2026, 8, 26, 12, 0, 0)
@@ -204,7 +206,7 @@ def test_scheduling_cannot_cross_source_freshness_month(monkeypatch) -> None:
         enqueue_review_deliveries(db, {7001})
         draft.evidence_metadata = {
             **draft.evidence_metadata,
-            "source_published_at": "2026-08-04T00:00:00",
+            "source_published_at": "2026-07-04T00:00:00",
         }
 
         result = approve_publication(
@@ -223,7 +225,7 @@ def test_scheduling_cannot_cross_source_freshness_month(monkeypatch) -> None:
         assert db.query(NewsPublicationSnapshot).count() == 0
 
 
-def test_queued_publication_is_failed_after_month_rollover(monkeypatch) -> None:
+def test_queued_publication_is_failed_after_freshness_window_rollover(monkeypatch) -> None:
     cluster_id = _source_and_candidate(external_id="month-rollover")
     draft_id, _ = _draft(cluster_id)
     august_now = datetime(2026, 8, 26, 12, 0, 0)
@@ -237,7 +239,7 @@ def test_queued_publication_is_failed_after_month_rollover(monkeypatch) -> None:
         enqueue_review_deliveries(db, {7001})
         draft.evidence_metadata = {
             **draft.evidence_metadata,
-            "source_published_at": "2026-08-04T00:00:00",
+            "source_published_at": "2026-07-04T00:00:00",
         }
         approved = approve_publication(
             db,


### PR DESCRIPTION
## Что изменено
- окно свежести новостей расширено с текущего месяца до текущего + предыдущего календарного месяца;
- будущие даты и публикации старше предыдущего месяца по-прежнему блокируются;
- добавлен безопасный пересчёт уже сохранённых `clustered`-новостей, ранее заблокированных только `source_not_current_month`;
- добавлена CLI-команда `rescore-freshness` для одноразового восстановления таких кандидатов после выкладки;
- обновлены существующие freshness-тесты и добавлены отдельные проверки границ окна, включая переход года.

## Почему
После релиза материалы предыдущего месяца получали score=0 и не попадали в кандидаты. Уже сохранённые записи дополнительно не пересчитывались при повторном fetch из-за дедупликации/304, поэтому одного изменения фильтра недостаточно для имеющихся данных.

## После деплоя
Один раз выполнить в backend-контейнере:
`python -m fitminiapp_api.services.news_cli rescore-freshness`

Команда затрагивает только кластеры в статусе `clustered` с прежним флагом `source_not_current_month`.

## CI
- exact head: `af3e390d74a075a90fee386c27046df5e627f1ac`
- CI run: `33278644240`
- conclusion: success
- все три Python test shards, PostgreSQL stack, frontend, smoke, dependency audit, Python quality и container checks прошли успешно.