### PR TITLE
[Task 114] Restore cross-browser barcode scanning

### DIFF
--- a/frontend/src/features/nutrition/BarcodeLookup.tsx
+++ b/frontend/src/features/nutrition/BarcodeLookup.tsx
@@ -170,7 +170,7 @@ export function BarcodeLookup({
           stopCamera();
         },
       });
-      if (!streamRef.current) {
+      if (cameraAttemptRef.current !== attempt || streamRef.current !== stream) {
         scanner.stop();
         return;
       }

--- a/frontend/src/features/nutrition/barcodeScanner.ts
+++ b/frontend/src/features/nutrition/barcodeScanner.ts
@@ -90,6 +90,7 @@ export async function startBarcodeScanner({
         if (!active) return;
         try {
           const found = await detector.detect(video);
+          if (!active) return;
           for (const candidate of found) {
             const value = normalizeDetectedBarcode(
               candidate.rawValue,

--- a/frontend/src/features/nutrition/barcodeScanner.ts
+++ b/frontend/src/features/nutrition/barcodeScanner.ts
@@ -73,8 +73,8 @@ export async function startBarcodeScanner({
       const supported = Detector.getSupportedFormats
         ? await Detector.getSupportedFormats()
         : NATIVE_FORMATS;
-      const formats = NATIVE_FORMATS.filter((format) => supported.includes(format));
-      if (formats.length > 0) detector = new Detector({ formats });
+      const supportsRetailContract = NATIVE_FORMATS.every((format) => supported.includes(format));
+      if (supportsRetailContract) detector = new Detector({ formats: NATIVE_FORMATS });
     } catch {
       detector = null;
     }

--- a/frontend/tests/unit/features/nutrition/BarcodeLookup.test.tsx
+++ b/frontend/tests/unit/features/nutrition/BarcodeLookup.test.tsx
@@ -68,6 +68,7 @@ describe('BarcodeLookup camera fallback', () => {
   beforeEach(() => {
     apiMock.mockReset();
     scannerMock.mockReset();
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
     Object.defineProperty(globalThis, 'BarcodeDetector', { configurable: true, value: undefined });
     vi.spyOn(HTMLMediaElement.prototype, 'play').mockResolvedValue();
   });
@@ -82,6 +83,7 @@ describe('BarcodeLookup camera fallback', () => {
     });
     Object.defineProperty(globalThis, 'BarcodeDetector', { configurable: true, value: undefined });
     if (originalVisibility) Object.defineProperty(document, 'visibilityState', originalVisibility);
+    else Reflect.deleteProperty(document, 'visibilityState');
   });
 
   it('offers a lazy local decoder without BarcodeDetector and selects the scanned local food', async () => {
@@ -171,6 +173,48 @@ describe('BarcodeLookup camera fallback', () => {
     await waitFor(() => expect(trackStop).toHaveBeenCalledOnce());
     expect(scannerMock).not.toHaveBeenCalled();
     expect(screen.getByRole('button', { name: 'Сканировать камерой' })).toBeEnabled();
+  });
+
+  it('discards stale scanner startup after a newer camera attempt becomes active', async () => {
+    const firstTrackStop = vi.fn();
+    const secondTrackStop = vi.fn();
+    const firstStream = {
+      getTracks: () => [{ stop: firstTrackStop }],
+    } as unknown as MediaStream;
+    const secondStream = {
+      getTracks: () => [{ stop: secondTrackStop }],
+    } as unknown as MediaStream;
+    let mediaAttempt = 0;
+    installTouchCamera(async () => (mediaAttempt++ === 0 ? firstStream : secondStream));
+    let resolveFirstScanner:
+      ((scanner: { strategy: 'native'; stop: () => void }) => void) | undefined;
+    const firstScanner = new Promise<{ strategy: 'native'; stop: () => void }>((resolve) => {
+      resolveFirstScanner = resolve;
+    });
+    const firstScannerStop = vi.fn();
+    const secondScannerStop = vi.fn();
+    scannerMock
+      .mockImplementationOnce(() => firstScanner)
+      .mockResolvedValueOnce({ strategy: 'zxing', stop: secondScannerStop });
+    renderLookup();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Сканировать камерой' }));
+    await waitFor(() => expect(scannerMock).toHaveBeenCalledOnce());
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'hidden' });
+    act(() => document.dispatchEvent(new Event('visibilitychange')));
+    Object.defineProperty(document, 'visibilityState', { configurable: true, value: 'visible' });
+    fireEvent.click(screen.getByRole('button', { name: 'Сканировать камерой' }));
+    expect(
+      await screen.findByText('Камера активна. Код распознаётся на устройстве.'),
+    ).toBeVisible();
+
+    await act(async () => resolveFirstScanner?.({ strategy: 'native', stop: firstScannerStop }));
+    await waitFor(() => expect(firstScannerStop).toHaveBeenCalledOnce());
+    fireEvent.click(screen.getByRole('button', { name: 'Остановить камеру' }));
+
+    expect(secondScannerStop).toHaveBeenCalledOnce();
+    expect(firstTrackStop).toHaveBeenCalledOnce();
+    expect(secondTrackStop).toHaveBeenCalledOnce();
   });
 
   it('keeps manual GTIN lookup primary when camera capture is unavailable', async () => {

--- a/frontend/tests/unit/features/nutrition/barcodeScanner.test.ts
+++ b/frontend/tests/unit/features/nutrition/barcodeScanner.test.ts
@@ -112,6 +112,43 @@ describe('barcode scanner strategy', () => {
     expect(onDetected).toHaveBeenCalledWith('012345000065');
   });
 
+  it('ignores a native detection that resolves after the session stops', async () => {
+    let scheduled: FrameRequestCallback | undefined;
+    let resolveDetection: ((barcodes: Array<{ rawValue: string }>) => void) | undefined;
+    const pendingDetection = new Promise<Array<{ rawValue: string }>>((resolve) => {
+      resolveDetection = resolve;
+    });
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        scheduled = callback;
+        return 19;
+      }),
+    );
+    Object.defineProperty(globalThis, 'BarcodeDetector', {
+      configurable: true,
+      value: class {
+        detect = vi.fn(() => pendingDetection);
+      },
+    });
+    const onDetected = vi.fn(() => true);
+
+    const session = await startBarcodeScanner({
+      stream,
+      video,
+      onDetected,
+      onFatalError: vi.fn(),
+    });
+    scheduled?.(0);
+    session.stop();
+    await vi.waitFor(() => expect(cancelAnimationFrame).toHaveBeenCalledWith(19));
+    resolveDetection?.([{ rawValue: '4006381333931' }]);
+    await pendingDetection;
+
+    expect(onDetected).not.toHaveBeenCalled();
+    expect(requestAnimationFrame).toHaveBeenCalledOnce();
+  });
+
   it('lazy-loads the local ZXing path without BarcodeDetector and retries decode misses', async () => {
     const onDetected = vi.fn(() => true);
     const onFatalError = vi.fn();

--- a/frontend/tests/unit/features/nutrition/barcodeScanner.test.ts
+++ b/frontend/tests/unit/features/nutrition/barcodeScanner.test.ts
@@ -144,12 +144,12 @@ describe('barcode scanner strategy', () => {
     expect(onDetected).toHaveBeenCalledWith('012345000065');
   });
 
-  it('falls back to ZXing when a partial native implementation rejects retail formats', async () => {
+  it('falls back to ZXing when native support covers only part of the retail formats', async () => {
     Object.defineProperty(globalThis, 'BarcodeDetector', {
       configurable: true,
       value: class {
         static getSupportedFormats() {
-          return Promise.resolve(['qr_code']);
+          return Promise.resolve(['ean_13']);
         }
       },
     });


### PR DESCRIPTION
Scoped Task 114 release from exact head 94e549e. Replaces closed PR #78 after fixing both blocking asynchronous lifecycle findings: stale scanner startup is rejected by attempt and stream identity, and native detection results are discarded after stop. Targeted regressions cover both races. All earlier UPC-E, partial native support, pending camera and cross-browser fixes remain included; concurrent Landing commits on dev are excluded.