### PR TITLE
fix: keep news worker healthy during provider calls

### DIFF
--- a/backend/fitminiapp_api/services/news_ingestion.py
+++ b/backend/fitminiapp_api/services/news_ingestion.py
@@ -784,7 +784,8 @@ def prohibited_flags(text: str) -> list[str]:
 
 def _candidate_ref(item: ParsedNewsItem) -> str:
     identity = item.external_id.strip() or item.canonical_url
-    return hashlib.sha256(identity.encode("utf-8", errors="replace")).hexdigest()[:16]
+    digest = hashlib.sha256(identity.encode("utf-8", errors="replace")).hexdigest()[:16]
+    return f"candidate:{digest}"
 
 
 def _log_candidate(

--- a/backend/fitminiapp_api/services/worker.py
+++ b/backend/fitminiapp_api/services/worker.py
@@ -667,6 +667,18 @@ async def run_until_stopped(
             await asyncio.wait_for(stop_requested.wait(), timeout=settings.worker_poll_seconds)
 
 
+async def refresh_worker_heartbeat(
+    stop_requested: asyncio.Event,
+    *,
+    interval_seconds: float = 30,
+) -> None:
+    """Keep health tied to event-loop liveness while long async provider calls run."""
+    while not stop_requested.is_set():
+        WORKER_HEARTBEAT_PATH.touch()
+        with contextlib.suppress(TimeoutError):
+            await asyncio.wait_for(stop_requested.wait(), timeout=interval_seconds)
+
+
 async def main() -> None:
     configure_logging(
         debug=settings.app_debug,
@@ -696,12 +708,17 @@ async def main() -> None:
     for signal_name in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(signal_name, request_stop)
     logger.info("worker_started")
-    async with httpx.AsyncClient(timeout=15) as preflight_client:
-        news_publication_ready = await check_news_channel_rights(preflight_client)
-    await run_until_stopped(
-        stop_requested,
-        news_publication_ready=news_publication_ready,
-    )
+    heartbeat_task = asyncio.create_task(refresh_worker_heartbeat(stop_requested))
+    try:
+        async with httpx.AsyncClient(timeout=15) as preflight_client:
+            news_publication_ready = await check_news_channel_rights(preflight_client)
+        await run_until_stopped(
+            stop_requested,
+            news_publication_ready=news_publication_ready,
+        )
+    finally:
+        stop_requested.set()
+        await heartbeat_task
     logger.info("worker_stopped")
 
 

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -119,6 +119,26 @@ def test_news_cycle_summary_preserves_required_bounded_counters() -> None:
     assert {key: payload[key] for key in fields} == fields
 
 
+def test_candidate_reference_with_numeric_digest_remains_visible() -> None:
+    record = logging.LogRecord(
+        name="fitminiapp_api.services.news_ingestion",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="news_candidate_evaluated",
+        args=(),
+        exc_info=None,
+    )
+    record.candidate_ref = "candidate:0123456789abcdef"
+    record.pipeline_stage = "scoring"
+    record.outcome = "eligible"
+    record.reason = "score_threshold_met"
+
+    payload = json.loads(JsonFormatter(service="notification-worker").format(record))
+
+    assert payload["candidate_ref"] == "candidate:0123456789abcdef"
+
+
 def test_json_formatter_rejects_arbitrary_values_and_keeps_safe_diagnostics() -> None:
     markers = (
         "private_note_marker",

--- a/backend/tests/test_worker_delivery.py
+++ b/backend/tests/test_worker_delivery.py
@@ -657,3 +657,27 @@ def test_worker_finishes_current_cycle_before_graceful_stop(
     asyncio.run(scenario())
 
     assert events == ["cycle:True"]
+
+
+def test_worker_heartbeat_refreshes_during_long_async_cycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    touches = 0
+
+    async def scenario() -> None:
+        nonlocal touches
+        stop_requested = asyncio.Event()
+
+        class HeartbeatPath:
+            def touch(self) -> None:
+                nonlocal touches
+                touches += 1
+                if touches == 2:
+                    stop_requested.set()
+
+        monkeypatch.setattr(worker, "WORKER_HEARTBEAT_PATH", HeartbeatPath())
+        await worker.refresh_worker_heartbeat(stop_requested, interval_seconds=0.001)
+
+    asyncio.run(scenario())
+
+    assert touches == 2


### PR DESCRIPTION
## Summary
- refresh the worker heartbeat on an independent async task while news providers are awaited
- prefix news candidate references so structured logging preserves numeric-leading digests
- add focused regression tests for heartbeat freshness and candidate reference formatting

## Verification
- local targeted profile: 99 passed
- exact-file pre-commit: passed
- push CI checks: run 33317542397 succeeded

Expected head: 865c2d874f17011087d6c0ef3d288d15ca28b0f2