### PR TITLE
chore: [Task 127] enforce global auto-continue contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,10 +177,11 @@ current task/backlog explicitly requires them. A read-only/no-code outcome does 
 manufactured commit.
 
 After that commit, apply the canonical release eligibility contract from
-`codex-backlog/TASK_EXECUTION_LIFECYCLE.md`. An `AUTO_RELEASE_ELIGIBLE` task proceeds through the
-normal `dev -> pull request -> master -> post-merge CI -> production deploy -> dev sync` path
-without another owner prompt. A task with a mandatory owner checkpoint, owner approval, human
-evidence or manual visual approval stops before release until that gate is actually completed.
+`codex-backlog/TASK_EXECUTION_LIFECYCLE.md`. If the current task has no explicitly declared owner
+checkpoint, human/device evidence gate, manual visual approval, legal-counsel gate,
+destructive/external authorization or terminal blocker, continue automatically through applicable
+review, QA, commit, PR, merge, CI and normal release stages without waiting for another owner
+prompt. Stop only at the declared gate and report its exact evidence/decision requirement.
 
 Do not read completed tasks or historical changelogs unless the current task explicitly requires
 them. Legacy `masters/` and `references/` were removed and are not sources of truth.
@@ -223,15 +224,16 @@ Before changing files for a backlog task, verify the branch with:
 The current backlog's `GLOBAL_RULES.md` defines the expected branch.
 
 For `codex-backlog/tasks/`, `codex-backlog/bugs/pending/` and
-`codex-backlog/telegram-core-release-backlog/tasks/`, the expected permanent implementation branch
-is `dev`. A temporary task branch/worktree is allowed only when the task or backlog explicitly
-requires real isolation; it must branch from current `dev` and be deleted after merge/close when it
-is not a recovery anchor.
+`codex-backlog/telegram-core-release-backlog/tasks/`, `dev` is the permanent integration branch.
+Every executable task uses exactly one `task/<ID>-<slug>` branch and one separate worktree created
+from a clean, verified exact `origin/dev` SHA. The main `dev` worktree is integration-only; feature
+implementation directly in it is forbidden. Delete a task branch/worktree only after merge/close
+and proof that it has no unique commits or unowned changes.
 
 Unless the current backlog rules or user explicitly permit otherwise:
 
-- do not create another branch;
-- do not switch/checkout another branch;
+- do not edit implementation files in the main `dev` worktree;
+- do not create a second branch/worktree for the same task;
 - do not merge or rebase unrelated branches;
 - do not modify another worktree;
 - do not push outside the current task's canonical release/remote-operation contract;
@@ -239,8 +241,10 @@ Unless the current backlog rules or user explicitly permit otherwise:
 
 If the expected branch is not active, stop before tracked changes and report the mismatch.
 
-Parallel write-agents/worktrees are allowed only when the current backlog rules, task or user
-explicitly permits them. Do not infer permission from the existence of multi-agent roles.
+Parallel read-only/research sessions are allowed only when task metadata permits them and each has
+its own lease. Parallel write branches may be prepared only when dependency/concurrency metadata
+explicitly marks them compatible; merge into `dev` is always serialized. Without explicit
+compatibility, keep one active writer and stop before creating another write lease.
 
 # Dependencies
 

--- a/codex-backlog/GLOBAL_RULES.md
+++ b/codex-backlog/GLOBAL_RULES.md
@@ -2,10 +2,10 @@
 
 Этот файл действует для завершённых и архивированных release tasks `75-80`, включая буквенные
 подзадачи, owner-approved Pulse concepts pilot `75C`, завершённую UX-reset gate `115A` и
-current/not-started implementation task `116`, а также
+completed implementation tasks `116-118`, current product task `119`, а также
 trigger-gated post-release pool `81-101` с буквенными подзадачами и owner-selected pending tasks
-`107-111`. Completed tasks `00-73A`, включая буквенные подзадачи, tasks `74A-75`, отдельно
-завершённые tasks `103-106` и owner-selected task `112` не переигрываются и хранятся в
+`107-111` и owner-selected governance task `127`. Completed tasks `00-73A`, включая буквенные
+подзадачи, tasks `74A-75`, отдельно завершённые tasks `103-106`, `112-118` не переигрываются и хранятся в
 `tasks/done/`.
 
 Tasks `109-111` остаются owner-selected pending: Landing offer использует только factual claims и
@@ -18,7 +18,12 @@ approved security baseline task `108`; avatar сохраняет private-media l
 
 Фраза владельца `полный task lifecycle` ссылается именно на этот контракт. Он выполняет только основную роль, core/conditional skills и дополнительные lifecycle-роли, которые явно применимы к текущей task, с конечными review/QA циклами и одним логическим commit.
 
-Lifecycle не расширяет scope task и не отменяет owner checkpoints, Trigger/evidence gates, conditional/skip conditions, security/privacy rules или запрет внешних production actions без разрешения.
+Lifecycle не расширяет scope task и не отменяет явно объявленные owner checkpoints, Trigger/evidence
+gates, conditional/skip conditions, security/privacy rules или запрет внешних production actions
+без разрешения. Если текущая task не содержит обязательного checkpoint, lifecycle автоматически
+продолжает следующий разрешённый шаг после terminal success и не ждёт дополнительного owner prompt.
+Нельзя создавать неявную остановку формулировкой «нужно подтверждение владельца» без конкретного
+gate, evidence и точки остановки в task-файле.
 
 ## Skills: обязательный контракт выбора
 
@@ -59,13 +64,15 @@ Lifecycle не расширяет scope task и не отменяет owner chec
 
 ## Главный процесс
 
-- Один executable task-файл = одна отдельная Codex-сессия = один законченный логический результат.
-  Umbrella `90`, `92`, `93`, `94`, `95`, `99`, `100` являются coordination contracts и отдельно не
-  выполняются.
-- Работать в постоянной development-ветке `dev`. Temporary branch/worktree от актуальной `dev`
-  допускается только при явной необходимости изоляции; после merge/close её нужно безопасно удалить,
-  если она не является recovery anchor и не содержит уникальную недостижимую историю.
-- Не переходить к следующему task автоматически.
+- Один executable task-файл = одна Codex-сессия = одна `task/<ID>-<slug>` ветка = один отдельный
+  worktree = один законченный логический результат. Umbrella `90`, `92`, `93`, `94`, `95`, `99`,
+  `100` являются coordination contracts и отдельно не выполняются.
+- `dev` используется только как интеграционная ветка. Task branch/worktree создаются от чистого,
+  проверенного exact `origin/dev` SHA; feature implementation непосредственно в основном `dev`
+  worktree запрещена.
+- Внутри текущей task после terminal success автоматически выполняются применимые review, QA,
+  commit, PR, serial merge в `dev`, CI и normal release шаги, если task явно не объявляет checkpoint
+  или blocker. Следующая product task автоматически не запускается.
 - Новая production revision попадает в remote `master` только через merged PR с обязательным green
   check `checks`; direct push, force-push и удаление `master` запрещены Ruleset. Merge PR является
   release authorization и без отдельного ручного approval запускает post-merge CI, exact-SHA
@@ -84,8 +91,10 @@ PR checks -> exact-head merge -> post-merge CI -> automatic production deploy ->
   запущенный параллельно с push-CI из-за открытого PR, считается нарушением lifecycle, а не допустимой
   оптимизацией. Если открытый PR нельзя однозначно идентифицировать как текущий release PR, агент
   ничего не закрывает автоматически и останавливается с точным blocker.
-- Task с обязательным owner checkpoint/approve/human evidence/manual visual approval останавливается
-  перед release до фактического прохождения gate. Task без tracked logical commit не создаёт PR.
+- Task с явно обязательным owner checkpoint/approve, human/device evidence, manual visual approval,
+  legal-counsel gate или destructive/external authorization останавливается ровно перед указанным
+  gate до фактического прохождения. Task без tracked logical commit не создаёт PR; отсутствие
+  checkpoint само по себе не является причиной ожидания.
 - Перед началом прочитать корневой `AGENTS.md`, этот файл, lifecycle и только текущую task.
 - Tasks `00-73A`, включая буквенные подзадачи, подтверждены владельцем как завершённые, перенесены в `tasks/done/` и не выполняются повторно.
 - Owner-selected task `103` завершена после owner approval и архивирована.

--- a/codex-backlog/TASK_EXECUTION_LIFECYCLE.md
+++ b/codex-backlog/TASK_EXECUTION_LIFECYCLE.md
@@ -248,6 +248,9 @@ Review/QA не могут сами по себе быть основанием �
 10. Выполнить разрешённый canonical release final либо остановиться на точном owner/blocker gate.
 11. Не переходить к следующей task автоматически; после eligible release сначала подтвердить
     terminal deploy success и синхронизацию `dev`.
+12. Если task не содержит явно обязательного owner checkpoint, human/device evidence, legal-counsel
+    gate, destructive/external authorization или terminal blocker, не ждать отдельного сообщения
+    владельца: автоматически продолжать следующий разрешённый lifecycle step после terminal success.
 
 ## 9A. Release eligibility и автоматический normal path
 
@@ -258,7 +261,8 @@ Task является `AUTO_RELEASE_ELIGIBLE`, только если однов�
 3. незакрытых `BLOCKER`, `HIGH` и `MEDIUM` ровно ноль, а исправленные blocking/release-blocking
    findings имеют required targeted recheck evidence;
 4. `codex-backlog/bugs/FINDINGS.md` синхронизирован по действующей policy;
-5. task не содержит незавершённый owner checkpoint/approve, human evidence или manual visual gate;
+5. task не содержит незавершённый явно обязательный owner checkpoint/approve, human/device evidence,
+   legal-counsel gate или manual visual gate;
 6. нет unresolved production/recovery blocker;
 7. рабочая ветка `dev` содержит актуальный `origin/master`, worktree чист от accidental scope,
    secrets и debug artifacts.
@@ -329,8 +333,10 @@ ensure NO open release PR dev -> master
 новой стадией уже завершённого release.
 
 Автоматизация никогда не делает direct push в `master`, не обходит ruleset/required checks,
-PR provenance/exact-SHA guard и не запускает manual production command. Task с human/owner gate
-останавливается перед PR до фактического решения. Task-specific запрет release/deploy имеет приоритет.
+PR provenance/exact-SHA guard и не запускает manual production command. Task с явно объявленным
+human/owner gate останавливается перед указанным gate до фактического решения. Если такой gate не
+объявлен, ожидание общего «подтверждения владельца» запрещено: lifecycle продолжает normal path
+автоматически. Task-specific запрет release/deploy имеет приоритет.
 
 ## 10. Финальный отчёт
 

--- a/tests/test_release_safeguards.py
+++ b/tests/test_release_safeguards.py
@@ -117,16 +117,34 @@ def test_auto_release_contract_is_fail_closed_for_medium_and_human_gates() -> No
 
     for source in (agents, global_rules, lifecycle):
         assert "AUTO_RELEASE_ELIGIBLE" in source
-        assert "dev ->" in source
         assert "master" in source
 
+    assert "dev ->" in global_rules
+    assert "dev ->" in lifecycle
     assert "незакрытых `BLOCKER`, `HIGH` и `MEDIUM` ровно ноль" in lifecycle
-    assert "owner checkpoint/approve, human evidence или manual visual gate" in lifecycle
+    assert "явно обязательный owner checkpoint/approve, human/device evidence" in lifecycle
     assert "failure/rollback/manual-intervention verdict" in lifecycle.lower()
     assert "Direct push в `master` запрещён" in global_rules
     assert "expected PR head SHA" in lifecycle
     assert "required check `checks`" in lifecycle
     assert "fast-forward/sync `dev`" in lifecycle
+
+
+def test_task127_global_auto_continue_contract_has_no_implicit_wait() -> None:
+    agents, global_rules, lifecycle = _release_policy_sources()
+    sources = (agents, global_rules, lifecycle)
+
+    for source in sources:
+        assert "terminal success" in source
+        assert "не жд" in source or "не ждать" in source or "without waiting" in source
+    assert "do not start the next task automatically" in agents
+    assert "Следующая product task автоматически не запускается" in global_rules
+    assert "Не переходить к следующей task автоматически" in lifecycle
+
+    assert "Один executable task-файл = одна Codex-сессия = одна" in global_rules
+    assert "не ждёт дополнительного owner prompt" in global_rules
+    assert "integration-only" in agents
+    assert "serial merge в `dev`" in global_rules
 
 
 def test_compact_first_contract_is_canonical() -> None:


### PR DESCRIPTION
## Что изменено\n- закреплён контракт 1 task = 1 branch = 1 worktree и integration-only dev\n- явно описано auto-continue: без объявленного checkpoint lifecycle не ждёт owner prompt\n- добавлен fail-closed regression test на drift release-политики\n\n## Границы\n- live GitHub Rulesets/merge queue не изменялись; для них в Task 127 действует отдельный owner checkpoint\n- следующая product task не запускается автоматически\n\n## Проверка\n- tests/test_release_safeguards.py: 7 passed\n- pre-commit: passed