### PR TITLE
[Task 120A] Release exercise catalog audit

### DIFF
--- a/docs/exercises/catalog-v2/COVERAGE_MATRIX.csv
+++ b/docs/exercises/catalog-v2/COVERAGE_MATRIX.csv
@@ -1,0 +1,195 @@
+record_type,slug_or_gap_id,display_name_ru,muscle_group,movement_pattern,equipment,equipment_variant,execution_variant,metric_type,priority,batch,status,evidence_note
+current,bench-press,Жим лежа,chest,chest_press,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,incline-bench-press,Жим штанги на наклонной скамье,chest,chest_press,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,decline-bench-press,Жим штанги вниз головой,chest,chest_press,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,close-grip-bench-press,Жим лежа узким хватом,triceps,chest_press,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,dumbbell-bench-press,Жим гантелей лежа,chest,chest_press,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,incline-dumbbell-press,Жим гантелей на наклонной скамье,chest,chest_press,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,decline-dumbbell-press,Жим гантелей вниз головой,chest,chest_press,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,dumbbell-fly,Разведение гантелей лежа,chest,chest_fly,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,incline-dumbbell-fly,Разведение гантелей на наклонной скамье,chest,chest_fly,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,cable-fly,Сведение рук в кроссовере,chest,chest_fly,cable,cable,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,low-to-high-cable-fly,Сведение снизу вверх в кроссовере,chest,chest_fly,cable,cable,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,pec-deck,Сведение рук в тренажере,chest,chest_fly,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,machine-chest-press,Жим от груди в тренажере,chest,chest_press,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,smith-bench-press,Жим лежа в Смите,chest,chest_press,machine,smith,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,push-up,Отжимания,chest,pushup_dip,bodyweight,bodyweight,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,weighted-dip,Отжимания на брусьях с весом,chest,pushup_dip,bodyweight,bodyweight,bilateral_or_unspecified,strength,covered,current,present,confirmed media mismatch: shared unweighted dip images; replace in 120D
+current,chest-dip,Отжимания на брусьях с наклоном,chest,pushup_dip,bodyweight,bodyweight,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,dumbbell-pullover,Пуловер с гантелью,chest,pullover,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,deadlift,Становая тяга,back,hinge,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,rack-pull,Тяга с плинтов,back,hinge,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,pull-up,Подтягивания,back,vertical_pull,bodyweight,bodyweight,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,chin-up,Подтягивания обратным хватом,back,vertical_pull,bodyweight,bodyweight,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,lat-pulldown,Вертикальная тяга,back,vertical_pull,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,reverse-grip-lat-pulldown,Вертикальная тяга обратным хватом,back,vertical_pull,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,close-grip-lat-pulldown,Вертикальная тяга узким хватом,back,vertical_pull,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,straight-arm-pulldown,Пуловер в кроссовере прямыми руками,back,pullover,cable,cable,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,barbell-row,Тяга штанги в наклоне,back,row,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,pendlay-row,Тяга Пендлея,back,row,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,confirmed media mismatch: shared hang-row images; replace in 120D
+current,t-bar-row,Тяга Т-грифа,back,row,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,one-arm-dumbbell-row,Тяга гантели одной рукой,back,row,dumbbell,dumbbell,unilateral,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,chest-supported-row,Тяга с упором грудью,back,row,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,seated-cable-row,Горизонтальная тяга блока,back,row,cable,cable,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,machine-row,Гребная тяга в тренажере,back,row,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,inverted-row,Австралийские подтягивания,back,row,bodyweight,bodyweight,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,meadows-row,Тяга Медоуза,back,row,barbell,barbell,unilateral,strength,covered,current,present,confirmed media mismatch: shared T-bar row images; replace in 120D
+current,cable-row-one-arm,Тяга блока одной рукой,back,row,cable,cable,unilateral,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,hyperextension,Гиперэкстензия,spinal_erectors,hinge,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,good-morning,Наклоны со штангой,posterior_chain,hinge,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,squat,Приседания,quadriceps,squat,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,front-squat,Фронтальные приседания,quadriceps,squat,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,hack-squat,Гакк-присед,quadriceps,squat,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,smith-squat,Приседания в Смите,quadriceps,squat,machine,smith,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,goblet-squat,Гоблет-присед,quadriceps,squat,kettlebell,kettlebell,bilateral_or_unspecified,strength,covered,current,present,exact media duplicate with kettlebell-goblet-squat; merge decision in 120D
+current,belt-squat,Поясной присед,quadriceps,squat,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,confirmed media mismatch: shared hack-squat images; replace in 120D
+current,leg-press,Жим ногами,quadriceps,squat,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,lunge,Выпады,legs,lunge,dumbbell,dumbbell,unilateral_or_alternating,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,walking-lunge,Выпады в ходьбе,legs,lunge,dumbbell,dumbbell,unilateral_or_alternating,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,reverse-lunge,Обратные выпады,legs,lunge,dumbbell,dumbbell,unilateral_or_alternating,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,bulgarian-split-squat,Болгарские сплит-приседания,legs,lunge,dumbbell,dumbbell,unilateral_or_alternating,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,split-squat,Сплит-присед,legs,lunge,dumbbell,dumbbell,unilateral_or_alternating,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,step-up,Зашагивания на тумбу,legs,lunge,dumbbell,dumbbell,unilateral_or_alternating,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,leg-extension,Разгибание ног,quadriceps,leg_isolation,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,sissy-squat,Сисси-присед,quadriceps,squat,bodyweight,bodyweight,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,wall-sit,Стульчик у стены,quadriceps,squat,bodyweight,bodyweight,isometric,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,romanian-deadlift,Румынская тяга,hamstrings,hinge,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,stiff-leg-deadlift,Тяга на прямых ногах,hamstrings,hinge,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,single-leg-rdl,Румынская тяга на одной ноге,hamstrings,hinge,dumbbell,dumbbell,unilateral,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,leg-curl,Сгибание ног лежа,hamstrings,leg_isolation,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,seated-leg-curl,Сгибание ног сидя,hamstrings,leg_isolation,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,standing-leg-curl,Сгибание ноги стоя,hamstrings,leg_isolation,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,nordic-curl,Нордические сгибания,hamstrings,leg_isolation,bodyweight,bodyweight,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,glute-ham-raise,Подъем корпуса GHD,hamstrings,hinge,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,hip-thrust,Ягодичный мост со штангой,glutes,glute,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,single-leg-hip-thrust,Ягодичный мост на одной ноге,glutes,glute,bodyweight,bodyweight,unilateral,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,barbell-glute-bridge,Ягодичный мост со штангой с пола,glutes,glute,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,cable-pull-through,Протяжка между ног в кроссовере,glutes,hinge,cable,cable,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,kettlebell-swing,Махи гирей,posterior_chain,hinge,kettlebell,kettlebell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,hip-abduction,Отведение бедра в тренажере,glutes,leg_isolation,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,hip-adduction,Сведение бедер в тренажере,adductors,leg_isolation,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,cable-kickback,Отведение ноги назад в кроссовере,glutes,leg_isolation,cable,cable,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,sumo-deadlift,Становая тяга сумо,legs,hinge,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,overhead-press,Жим стоя,shoulders,shoulder_press,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,seated-dumbbell-press,Жим гантелей сидя,shoulders,shoulder_press,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,arnold-press,Жим Арнольда,shoulders,shoulder_press,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,machine-shoulder-press,Жим плечами в тренажере,shoulders,shoulder_press,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,smith-shoulder-press,Жим сидя в Смите,shoulders,shoulder_press,machine,smith,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,landmine-press,Жим штанги в упоре,shoulders,shoulder_press,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,dumbbell-lateral-raise,Подъем гантелей через стороны,middle_deltoid,shoulder_raise,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,cable-lateral-raise,Подъем руки через сторону в кроссовере,middle_deltoid,shoulder_raise,cable,cable,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,machine-lateral-raise,Подъем через стороны в тренажере,middle_deltoid,shoulder_raise,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,dumbbell-front-raise,Подъем гантелей перед собой,anterior_deltoid,shoulder_raise,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,rear-delt-fly,Разведение гантелей в наклоне,posterior_deltoid,shoulder_raise,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,reverse-pec-deck,Обратная бабочка,posterior_deltoid,shoulder_raise,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,face-pull,Тяга каната к лицу,posterior_deltoid,row,cable,cable,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,upright-row,Тяга к подбородку,shoulders,row,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,barbell-shrug,Шраги со штангой,trapezius,shoulder_raise,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,dumbbell-shrug,Шраги с гантелями,trapezius,shoulder_raise,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,y-raise,Y-подъемы,lower_trapezius,shoulder_raise,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,barbell-curl,Подъем штанги на бицепс,biceps,arm_curl,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,ez-bar-curl,Подъем EZ-штанги на бицепс,biceps,arm_curl,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,dumbbell-curl,Подъем гантелей на бицепс,biceps,arm_curl,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,hammer-curl,Молотковые сгибания,biceps,arm_curl,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,incline-dumbbell-curl,Сгибания гантелей на наклонной скамье,biceps,arm_curl,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,preacher-curl,Сгибания на скамье Скотта,biceps,arm_curl,bench,bench,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,cable-curl,Сгибания рук в кроссовере,biceps,arm_curl,cable,cable,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,concentration-curl,Концентрированные сгибания,biceps,arm_curl,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,reverse-curl,Подъем штанги обратным хватом,forearms,arm_curl,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,spider-curl,Паучьи сгибания,biceps,arm_curl,bench,bench,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,machine-biceps-curl,Сгибание рук в тренажере,biceps,arm_curl,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,skull-crusher,Французский жим лежа,triceps,triceps,barbell,barbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,rope-pushdown,Разгибание рук с канатом,triceps,triceps,cable,cable,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,cable-pushdown,Разгибание рук на блоке,triceps,triceps,cable,cable,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,overhead-triceps-extension,Разгибание рук из-за головы в кроссовере,triceps,triceps,cable,cable,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,dumbbell-overhead-extension,Французский жим гантели сидя,triceps,triceps,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,lying-dumbbell-triceps-extension,Разгибание гантелей лежа,triceps,triceps,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,bench-dip,Обратные отжимания от скамьи,triceps,pushup_dip,bodyweight,bodyweight,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,triceps-kickback,Разгибание руки назад с гантелью,triceps,triceps,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,machine-dip,Отжимания в тренажере,triceps,pushup_dip,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,single-arm-cable-triceps-extension,Разгибание одной руки на блоке,triceps,triceps,cable,cable,unilateral,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,standing-calf-raise,Подъемы на носки стоя,calves,calf,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,seated-calf-raise,Подъемы на носки сидя,calves,calf,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,donkey-calf-raise,Ослиные подъемы на носки,calves,calf,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,calf-press,Жим носками в тренажере,calves,calf,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,single-leg-calf-raise,Подъем на носок одной ногой,calves,calf,bodyweight,bodyweight,unilateral,strength,covered,current,present,confirmed media mismatch: shared bilateral machine calf images; replace in 120D
+current,plank,Планка,core,core_static,bodyweight,bodyweight,isometric,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,side-plank,Боковая планка,core,core_static,bodyweight,bodyweight,isometric,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,crunch,Скручивания,abs,core_dynamic,bodyweight,bodyweight,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,reverse-crunch,Обратные скручивания,abs,core_dynamic,bodyweight,bodyweight,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,cable-crunch,Скручивания на блоке,abs,core_dynamic,cable,cable,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,hanging-leg-raise,Подъем ног в висе,abs,core_dynamic,bodyweight,bodyweight,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,captain-chair-leg-raise,Подъем ног в упоре,abs,core_dynamic,machine,unspecified_machine,bilateral_or_unspecified,strength,covered,current,present,confirmed media mismatch: shared free-hang images; replace in 120D
+current,ab-wheel,Ролик для пресса,core,core_dynamic,other,other,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,russian-twist,Русские повороты,obliques,core_rotation,other,other,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,pallof-press,Жим Палофа,core,core_rotation,cable,cable,isometric,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,woodchopper,Дровосек в кроссовере,obliques,core_rotation,cable,cable,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,mountain-climber,Альпинист,core,core_dynamic,bodyweight,bodyweight,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,hollow-hold,Холлоу-холд,core,core_static,bodyweight,bodyweight,isometric,strength,covered,current,present,confirmed media mismatch: shared plank images; replace in 120D
+current,dead-bug,Мертвый жук,core,core_static,bodyweight,bodyweight,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,bird-dog,Берд-дог,core,core_static,bodyweight,bodyweight,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,burpee,Берпи,full_body,conditioning,bodyweight,bodyweight,multi_stage_or_cyclic,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,box-jump,Запрыгивания на тумбу,legs,conditioning,other,other,multi_stage_or_cyclic,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,jump-rope,Скакалка,cardio,conditioning,cardio,cardio,cyclic,cardio,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,rowing-machine,Гребной тренажер,cardio,conditioning,machine,unspecified_machine,cyclic,cardio,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,treadmill-run,Беговая дорожка,cardio,running,machine,unspecified_machine,cyclic,cardio,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,assault-bike,Assault bike,cardio,conditioning,machine,unspecified_machine,cyclic,cardio,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,outdoor-run,Бег на улице,cardio,running,bodyweight,bodyweight,cyclic,cardio,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,elliptical-trainer,Эллиптический тренажёр,cardio,elliptical,cardio,cardio,cyclic,cardio,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,outdoor-cycling,Велосипед,cardio,cycling,cardio,cardio,cyclic,cardio,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,stationary-bike,Велотренажёр,cardio,cycling,cardio,cardio,cyclic,cardio,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,outdoor-walk,Ходьба,cardio,walking,bodyweight,bodyweight,cyclic,cardio,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,treadmill-walk,Ходьба на дорожке,cardio,walking,cardio,cardio,cyclic,cardio,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,stair-climber,Степпер / лестница,cardio,stair_climber,cardio,cardio,cyclic,cardio,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,swimming,Плавание,cardio,swimming,cardio,cardio,cyclic,cardio,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,ski-erg,Лыжный тренажёр,cardio,ski_erg,cardio,cardio,cyclic,cardio,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,battle-rope,Канаты,conditioning,conditioning,other,other,multi_stage_or_cyclic,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,sled-push,Толкание саней,legs,conditioning,other,other,multi_stage_or_cyclic,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,sled-pull,Тяга саней,posterior_chain,conditioning,other,other,multi_stage_or_cyclic,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,farmer-walk,Прогулка фермера,grip,carry,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,suitcase-carry,Чемоданная переноска,core,carry,kettlebell,kettlebell,unilateral,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,medicine-ball-slam,Броски медбола в пол,full_body,conditioning,other,other,multi_stage_or_cyclic,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,wall-ball,Броски мяча в стену,full_body,conditioning,other,other,multi_stage_or_cyclic,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,thruster,Трастер,full_body,conditioning,barbell,barbell,multi_stage_or_cyclic,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,kettlebell-clean,Взятие гири на грудь,full_body,conditioning,kettlebell,kettlebell,multi_stage_or_cyclic,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,kettlebell-snatch,Рывок гири,full_body,conditioning,kettlebell,kettlebell,multi_stage_or_cyclic,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,kettlebell-goblet-squat,Гоблет-присед с гирей,legs,squat,kettlebell,kettlebell,bilateral_or_unspecified,strength,covered,current,present,exact media duplicate with goblet-squat; merge decision in 120D
+current,turkish-get-up,Турецкий подъем,full_body,conditioning,kettlebell,kettlebell,multi_stage_or_cyclic,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,renegade-row,Ренегатская тяга,back,row,dumbbell,dumbbell,bilateral_or_unspecified,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+current,bear-crawl,Медвежья проходка,full_body,conditioning,bodyweight,bodyweight,multi_stage_or_cyclic,strength,covered,current,present,audit-derived pattern/variant; current DB does not store both axes
+gap,machine-incline-chest-press,Жим от груди вверх в тренажёре,chest,chest_press,machine,selectorized_or_lever,bilateral,strength,must,120B,missing,incline machine press absent
+gap,independent-lever-chest-press,Жим от груди в независимом рычажном тренажёре,chest,chest_press,machine,plate_loaded_lever_independent,bilateral_or_unilateral,strength,must,120B,missing,generic machine press does not cover independent lever setup
+gap,lever-high-row,Верхняя рычажная тяга с упором грудью,back,row,machine,plate_loaded_lever,bilateral_or_unilateral,strength,must,120B,missing,high row trajectory absent
+gap,lever-low-row,Нижняя рычажная тяга с упором грудью,back,row,machine,plate_loaded_lever,bilateral_or_unilateral,strength,must,120B,missing,low row trajectory absent
+gap,independent-lever-lat-pulldown,Вертикальная рычажная тяга независимыми руками,back,vertical_pull,machine,plate_loaded_lever_independent,bilateral_or_unilateral,strength,must,120B,missing,lever vertical pull absent
+gap,machine-pullover,Пуловер в тренажёре,back,pullover,machine,selectorized_or_lever,bilateral,strength,must,120B,missing,only dumbbell/cable pullovers present
+gap,independent-lever-shoulder-press,Жим над головой в независимом рычажном тренажёре,shoulders,shoulder_press,machine,plate_loaded_lever_independent,bilateral_or_unilateral,strength,must,120B,missing,independent lever shoulder press absent
+gap,machine-decline-chest-press,Жим от груди вниз в тренажёре,chest,chest_press,machine,selectorized_or_lever,bilateral,strength,should,120B,missing,distinct decline setup only if media confirms
+gap,machine-triceps-extension,Разгибание рук в тренажёре,triceps,triceps,machine,selectorized,bilateral,strength,should,120B,missing,machine dip is not elbow-extension machine
+gap,chest-supported-dumbbell-row,Тяга гантелей с упором грудью,back,row,dumbbell,bench_supported,bilateral,strength,should,120B_or_120D,missing,supported free-weight row absent
+gap,pendulum-squat,Маятниковый присед в тренажёре,quadriceps,squat,machine,plate_loaded_lever,bilateral,strength,must,120C,missing,distinct pendulum path absent
+gap,plate-loaded-leg-press,Жим ногами в тренажёре с дисками,quadriceps,squat,machine,plate_loaded,bilateral,strength,must,120C,missing,current leg press load/setup unspecified
+gap,unilateral-leg-press,Жим одной ногой в тренажёре,quadriceps,squat,machine,selectorized_or_plate_loaded,unilateral,strength,must,120C,missing,material unilateral execution absent
+gap,machine-hip-thrust,Ягодичный мост в рычажном тренажёре,glutes,glute,machine,plate_loaded_lever,bilateral,strength,must,120C,missing,glute-drive setup absent
+gap,smith-split-squat,Сплит-присед в машине Смита,legs,lunge,machine,smith,unilateral,strength,must,120C,missing,Smith unilateral squat/lunge absent
+gap,machine-glute-kickback,Разгибание бедра назад в тренажёре,glutes,leg_isolation,machine,selectorized_or_lever,unilateral,strength,must,120C,missing,only cable kickback present
+gap,v-squat-machine,V-присед в рычажном тренажёре,quadriceps,squat,machine,plate_loaded_lever,bilateral,strength,should,120C,missing,add only with distinct media from hack/pendulum
+gap,reverse-hyperextension,Обратная гиперэкстензия,posterior_chain,hinge,machine,lever_or_bodyweight,bilateral,strength,should,120C,missing,distinct posterior-chain setup absent
+gap,bodyweight-squat,Приседания с собственным весом,quadriceps,squat,bodyweight,bodyweight,bilateral,strength,must,120D,missing,beginner bodyweight squat absent
+gap,bodyweight-glute-bridge,Ягодичный мост с собственным весом,glutes,glute,bodyweight,bodyweight,bilateral,strength,must,120D,missing,basic unloaded bridge absent
+gap,barbell-wrist-curl,Сгибание кистей со штангой,forearms,wrist_flexion,barbell,barbell,bilateral,strength,must,120D,missing,forearm flexion coverage absent
+gap,barbell-wrist-extension,Разгибание кистей со штангой,forearms,wrist_extension,barbell,barbell,bilateral,strength,must,120D,missing,forearm extension coverage absent
+gap,dead-hang,Вис на перекладине,grip,carry_or_grip,bodyweight,bar,bilateral,strength,should,120D,missing,simple isometric grip item absent
+gap,high-to-low-cable-fly,Сведение рук сверху вниз в кроссовере,chest,chest_fly,cable,cable,bilateral,strength,should,120D,missing,distinct cable direction; merge as variant if media not distinct
+gap,recumbent-bike,Горизонтальный велотренажёр,cardio,cycling,cardio,cardio_machine,cyclic,cardio,should,120D,missing,distinct seated cardio setup absent
+decision,merge-goblet-squat,Merge goblet-squat и kettlebell-goblet-squat,legs,squat,kettlebell,kettlebell,bilateral,strength,must,120D,decision_required,confirmed duplicate; preserve history compatibility
+decision,rename-assault-bike,Воздушный велотренажёр,cardio,conditioning,cardio,cardio_machine,cyclic,cardio,must,120D,decision_required,keep stable slug; brand-like name becomes alias
+decision,cardio-equipment-reclass,Reclassify rower/treadmill/air bike equipment,cardio,cyclic,cardio,cardio_machine,cyclic,cardio,must,120D,decision_required,three cardio records currently normalize to broad machine
+decision,search-alias-layer,Shared versioned aliases/normalization/ranking,system,search,n/a,n/a,n/a,n/a,must,120D,missing,no alias model; catalog and ProgramBuilder use substring only
+decision,replace-media-pendlay-row,Replace visual for Pendlay row,back,row,barbell,barbell,bilateral,strength,must,120D,confirmed_blocker,current files exactly duplicate barbell-row and show hang start
+decision,replace-media-weighted-dip,Replace visual for weighted dip,chest,pushup_dip,bodyweight,external_load,bilateral,strength,must,120D,confirmed_blocker,current files exactly duplicate unweighted chest-dip
+decision,replace-media-single-leg-calf,Replace visual for single-leg calf raise,calves,calf,bodyweight,bodyweight,unilateral,strength,must,120D,confirmed_blocker,current files exactly duplicate bilateral machine standing calf raise
+decision,replace-media-hollow-hold,Replace visual for hollow hold,core,core_static,bodyweight,bodyweight,isometric,strength,must,120D,confirmed_blocker,current files exactly duplicate plank sequence
+decision,replace-media-meadows-row,Replace visual for Meadows row,back,row,barbell,landmine,unilateral,strength,must,120D,confirmed_blocker,current files exactly duplicate T-bar row
+decision,replace-media-captain-chair,Replace visual for captain-chair leg raise,abs,core_dynamic,machine,captain_chair,bilateral,strength,must,120D,confirmed_blocker,current files exactly duplicate free-hanging leg raise
+decision,replace-media-belt-squat,Replace visual for belt squat,quadriceps,squat,machine,belt_squat,bilateral,strength,must,120D,confirmed_blocker,current files exactly duplicate hack-squat machine

--- a/docs/exercises/catalog-v2/CURRENT_CATALOG_AUDIT.md
+++ b/docs/exercises/catalog-v2/CURRENT_CATALOG_AUDIT.md
@@ -1,0 +1,104 @@
+# Аудит текущего каталога упражнений
+
+Дата среза: 31.08.2026. База: `origin/dev` `0d46b6e4b9669006244ad4a73bd4eeee4a4c617e`, включающая Task 119 (`1c18e30`).
+
+## Методика и source of truth
+
+Инвентаризация построена по фактическим данным и consumers:
+
+- `backend/fitminiapp_api/services/program_seed_data.py` — 158 canonical seed-записей;
+- `backend/fitminiapp_api/services/exercise_domain.py` — мышцы, оборудование, alternatives и provenance;
+- `backend/fitminiapp_api/services/exercise_guides.py` — movement-profile proxy, техника и ошибки;
+- `backend/assets/exercise-guides/manifest.json` — локальные media-файлы и фазы;
+- `backend/fitminiapp_api/models/exercise.py` и `schemas/program.py` — фактический DB/API contract;
+- `frontend/src/features/exercises/ExerciseCatalog.tsx` и `features/programs/ProgramBuilder.tsx` — реальный поиск и выбор;
+- migrations `0064`–`0066` и `services/workout_metrics.py` — type-aware contract Task 119.
+
+`COVERAGE_MATRIX.csv` содержит строку для каждого текущего canonical slug и отдельные gap/decision строки для 120B–120D. Movement pattern и execution variant в этом CSV — audit-классификация по текущему guide profile/названию, а не уже существующие DB-поля.
+
+## Фактический состав
+
+| Срез | Результат |
+|---|---:|
+| Canonical exercises | 158 |
+| `strength` / `cardio` | 145 / 13 |
+| Beginner / intermediate / advanced | 67 / 53 / 38 |
+| Guide profiles | 158 из 158 |
+| Manifest coverage | 307 JPEG entries для 158 exercises; это presence, не semantic validation |
+| Exact cross-exercise duplicate sets | 8 пар slugs; 7 confirmed mismatches + 1 duplicate identity pair |
+| Curated alternative pairs | 37 |
+| Muscle identifiers | 26 |
+| Equipment identifiers | 9 |
+
+По broad equipment: 35 `machine`, 30 `dumbbell`, 26 `barbell`, 25 `bodyweight`, 17 `cable`, 8 `cardio`, 8 `other`, 7 `kettlebell`, 2 `bench`. Число `machine=35` завышает полезную machine coverage: в одну категорию попали selectorized, Smith, разные lever/plate-loaded движения и даже три cardio items.
+
+По основным muscle/category labels: back 19, chest 17, cardio 13, triceps 11, quadriceps 10, legs 10, biceps 10, core 9, full body 8, hamstrings 8; остальные группы имеют 1–7 записей. Количество не равно полноте: один generic machine item не доказывает coverage разных траекторий или независимых рычагов.
+
+## Что покрыто хорошо
+
+- Базовые horizontal/vertical press и pull, free weights, cable и bodyweight представлены.
+- Для ног есть squat/lunge/hinge, leg extension и три положения leg curl.
+- Calves, core, carries и 13 cardio types имеют рабочую базу.
+- Task 119 даёт только два валидных metric type: `strength` и `cardio`; legacy/null детерминированно считается `strength`.
+- Для всех 158 seed items есть guide profile и manifest media entry. Полная semantic visual coverage не подтверждена: exact-hash audit ниже нашёл неверные mappings.
+- Alternatives curated; совпадение основной мышцы само по себе не создаёт замену.
+
+## Подтверждённые gaps
+
+### Machine taxonomy
+
+Текущий `equipment=machine` не отвечает, является ли тренажёр selectorized, plate-loaded, lever, Smith, converging/diverging или independent-arm. `Машина Смита` также нормализуется в broad `machine`. Поэтому фильтр и search не могут доказать отдельно требуемую coverage.
+
+Must-gaps сосредоточены в реально отличающихся движениях: incline/independent lever chest press, high/low lever rows, independent lever pulldown/shoulder press, pendulum squat, plate-loaded/unilateral leg press, machine hip thrust и Smith split squat. Косметические grip/stance изменения не становятся отдельными canonical entities.
+
+### Search
+
+Alias model отсутствует. `ExerciseCatalog` делает case-insensitive substring по title, legacy muscle/equipment и названиям alternatives; `ProgramBuilder` — только по title, legacy muscle/equipment. Нет `ё -> е`, transliteration, token normalization, словоформ, slang, alias ranking или collision checks. Поэтому запросы `хаммер`, `рычажный`, `на блинах`, `plate loaded`, `lever` и `селекторный` не находят нужные generic canonical exercises, а alternative-title query ведёт себя неодинаково на двух surfaces.
+
+### Naming и duplicates
+
+- `goblet-squat` и `kettlebell-goblet-squat` описывают одну canonical связку «гоблет-присед + гиря» и требуют merge/redirect decision.
+- `assault-bike`/`Assault bike` использует brand-like name как canonical display. Стабильный slug нельзя ломать, но display должен стать generic `Воздушный велотренажёр`; `assault bike`/`аэробайк` остаются только search aliases.
+- `rowing-machine` (cardio) и `machine-row` (strength) по-русски слишком близки; выдача должна показывать metric/equipment context и не смешивать их по ambiguous alias.
+- `hip-thrust` и `barbell-glute-bridge` не дубликаты, но первое название должно явно указывать опору на скамью, чтобы отличие от моста с пола было найдено без открытия guide.
+
+### Cardio/equipment mismatch
+
+`rowing-machine`, `treadmill-run` и `assault-bike` имеют `metric_type=cardio`, но legacy `Тренажер` нормализует их в equipment `machine`, а не `cardio`. Metric type остаётся правильным; equipment classification требует исправления в 120D без изменения исторических workout results.
+
+### Semantic media audit
+
+Manifest builder подтверждает decode/размер/path, но не соответствие изображения exercise identity. SHA-256 scan 307 файлов нашёл восемь пар разных canonical slugs, где совпадают обе фазы. Ручная проверка setup/key positions дала следующий verdict:
+
+| Shared asset pair | Verdict | Must action |
+|---|---|---|
+| `barbell-row` / `pendlay-row` | Изображение показывает обычную тягу из виса; не Pendlay start с пола | заменить media `pendlay-row` |
+| `goblet-squat` / `kettlebell-goblet-squat` | Один и тот же goblet squat; подтверждает canonical duplicate | history-safe merge, один visual set |
+| `chest-dip` / `weighted-dip` | Внешнее отягощение не показано | заменить media `weighted-dip` либо merge только при product decision, не сейчас |
+| `single-leg-calf-raise` / `standing-calf-raise` | Показан bilateral machine calf raise | заменить media `single-leg-calf-raise` |
+| `hollow-hold` / `plank` | Показана plank sequence, не hollow hold | заменить media `hollow-hold` |
+| `meadows-row` / `t-bar-row` | Показана обычная T-bar row | заменить media `meadows-row` |
+| `captain-chair-leg-raise` / `hanging-leg-raise` | Показан свободный вис на перекладине, не captain chair | заменить media `captain-chair-leg-raise` |
+| `belt-squat` / `hack-squat` | Показан hack squat machine | заменить media `belt-squat` |
+
+Итого: 158/158 manifest presence, но минимум семь item-level visual mappings неверны; оставшиеся assets не объявляются полностью semantically reviewed только из-за отсутствия exact duplicate. Исправления входят must scope 120D и отражены отдельными decision rows matrix. Новый validator должен сочетать hash duplicate detection с human semantic review; один hash scan не доказывает корректность уникального файла.
+
+### Content granularity
+
+Текущие 158 entries переиспользуют 28 generic guide profiles. Это достаточная база для текущего каталога, но новые machine entries нельзя добавлять с автоматически скопированным generic текстом: setup, положение сиденья/опоры, траектория рычагов и key positions должны быть item-reviewed. Default safety cue не является медицинским обещанием и не заменяет specific common mistakes.
+
+## Data-contract verdict
+
+Existing fields достаточно для identity, display name, broad muscle/equipment, difficulty, metric type, базовой guide attribution и alternatives. Media provenance существующая только частично: manifest не хранит immutable upstream revision, file hash, reviewer/date и verification flags. Derivable без schema change: movement pattern, aliases и variant tags для global seed catalog, если они хранятся в одном versioned canonical record и возвращаются API. Missing-needs-decision: способ представления orthogonal machine/variant tags, file-level immutable provenance и lifecycle alias redirect после merge duplicate. Решение для 120B–D зафиксировано в `EXERCISE_DATA_CONTRACT.md`: сначала versioned code-owned catalog metadata без migration; DB expansion допускается только если implementer докажет, что custom/admin persistence или query plan реально её требует.
+
+## Compact-first UX boundary
+
+Новая taxonomy/media не меняет выбранный Task 115A `Command Stack`: catalog/program picker row остаётся компактной (name + key context + optional badges), guide и visual открываются по intent. Нельзя резервировать высоту под always-expanded technique/media или создавать вложенный accordion.
+
+## Ограничения аудита
+
+- Visual checkpoint: `N/A` — изменены только audit docs/CSV; production UI, layout, media assets и runtime не менялись.
+- Production DB не читалась: audited canonical seed/current code, а не пользовательские custom rows.
+- Реальный Telegram, физические устройства и viewports не проверялись: task не меняет UI/runtime.
+- Audit не утверждает биомеханическую эквивалентность по совпадению muscle/pattern; alternatives остаются curated.
+- External source verified для upstream repository/license, но текущий manifest не доказывает file-level immutable provenance или semantic correctness; новый asset проходит полный gate.

--- a/docs/exercises/catalog-v2/DUPLICATES_AND_ALIASES.md
+++ b/docs/exercises/catalog-v2/DUPLICATES_AND_ALIASES.md
@@ -1,0 +1,55 @@
+# Duplicates, naming и aliases
+
+## Confirmed duplicate/merge decisions
+
+| IDs | Severity | Решение | Проверка |
+|---|---|---|---|
+| `goblet-squat`, `kettlebell-goblet-squat` | must | Один canonical item `Гоблет-присед с гирей`; второй slug/ID не удалять destructively: определить canonical target, сохранить history compatibility и search redirect/alias | search даёт одну карточку; старые программы/история открываются |
+
+## Naming corrections без смены stable slug
+
+| Slug | Сейчас | Canonical display | Aliases |
+|---|---|---|---|
+| `assault-bike` | `Assault bike` | `Воздушный велотренажёр` | `air bike`, `аэробайк`, `assault bike` |
+| `hip-thrust` | `Ягодичный мост со штангой` | `Ягодичный мост со штангой с опорой на скамью` | `hip thrust`, `хип траст`, `ягодичный мост на скамье` |
+| `rowing-machine` | `Гребной тренажер` | `Гребля на кардиотренажёре` | `rowing machine`, `гребной эргометр` |
+| `machine-row` | `Гребная тяга в тренажере` | `Горизонтальная тяга в тренажёре` | `machine row`, `гребная тяга`, `горизонтальная тяга` |
+
+Изменение display name не меняет metric type, history или slug.
+
+## Similar, но не duplicates
+
+- `hip-thrust` (опора на скамью) и `barbell-glute-bridge` (с пола).
+- `lat-pulldown` selectorized/cable и новый independent lever pulldown.
+- `machine-chest-press` generic/selectorized и новый plate-loaded independent lever press.
+- `leg-press` generic current item и новый explicitly plate-loaded/unilateral item — только если media/setup подтверждают distinct execution.
+- `rowing-machine` cardio и `machine-row` strength.
+- `pec-deck` chest fly и `reverse-pec-deck` rear delt.
+
+## Required alias families
+
+### Generic machine language
+
+`тренажёр/тренажер`, `рычажный`, `lever`, `plate loaded`, `на блинах`, `селекторный`, `грузоблочный`, `независимые рычаги`, `конвергентный`, `дивергентный`.
+
+`Hammer Strength`/`хаммер` может помогать найти generic lever/plate-loaded entries, но не становится canonical category, title или обязательной маркировкой UI.
+
+### Script/transliteration
+
+Reviewed English names и распространённая русская транслитерация: `lat pulldown`, `high row`, `low row`, `chest press`, `shoulder press`, `leg press`, `hack squat`, `pendulum squat`, `hip thrust`, `glute drive`, `air bike`, `smith`.
+
+### Russian spelling/slang
+
+Нормализовать `ё/е`; хранить только устойчивые варианты вроде `гакк`, `смит`, `аэробайк`, `бабочка`, `кроссовер`, `скамья Скотта`. Не добавлять бесконечные inflections: token normalization и проверяемый corpus важнее количества aliases.
+
+## Collision risks
+
+- `хаммер` описывает бренд/целое семейство, не одну exercise: match должен учитывать движение.
+- `бабочка` может означать pec-deck или reverse pec-deck: без muscle/direction term выдавать обе компактные rows.
+- `гребля` может означать cardio rower; `гребная тяга` — strength row. Exact alias/ranking обязаны различать.
+- `ягодичный тренажёр` может означать hip thrust, kickback или abduction: это broad token, не unique alias.
+- `пуловер` разделяет dumbbell/cable/machine variants; equipment term обязателен для exact alias.
+
+## Validator rules
+
+Normalize every title/alias, reject empty values and duplicate aliases inside one record, flag cross-record exact collisions, require explicit `ambiguous=true` decision for allowed broad terms, and verify redirect target exists. Validator must not auto-merge based on string similarity.

--- a/docs/exercises/catalog-v2/EXERCISE_DATA_CONTRACT.md
+++ b/docs/exercises/catalog-v2/EXERCISE_DATA_CONTRACT.md
@@ -1,0 +1,90 @@
+# Canonical exercise data contract v2
+
+## Цель
+
+Контракт задаёт минимальные данные для global canonical exercise в 120B–120D. Он не меняет schema в 120A и не требует заполнения неизвестных фактов для custom exercise.
+
+## Поля и текущая реализуемость
+
+| Поле | Статус | Источник/правило |
+|---|---|---|
+| stable `slug`/ID | existing | `Exercise.slug`, DB ID; существующие slug не переименовывать |
+| Russian display name | existing | `Exercise.title`; generic descriptive name |
+| aliases/search synonyms/transliteration | missing-needs-decision | versioned code-owned alias registry для global catalog; API/search consumer должны его использовать |
+| broad equipment | existing | legacy `equipment` + normalized `equipment_ids[]` |
+| machine/load/path tags | missing-needs-decision | controlled catalog metadata: `smith`, `selectorized`, `plate_loaded`, `lever`, `independent`, `converging`, `diverging`; не свободный текст |
+| primary muscles | existing | `exercise_muscles role=primary`; без fractional contribution |
+| secondary muscles | existing | `exercise_muscles role=secondary`; только reviewed guide data |
+| movement pattern | derivable | текущий `SLUG_TO_PROFILE`; вынести в canonical record/API, не выводить по title runtime |
+| execution variant | missing-needs-decision | controlled tags `bilateral`, `unilateral`, `alternating`, `isometric`, `cyclic`, `multi_stage` |
+| difficulty | existing | `beginner/intermediate/advanced`; product/editorial classification, не медицинская сложность |
+| metric type | existing | только `strength/cardio` по Task 119; snapshot в program/workout |
+| technique steps/breathing/mistakes | existing | reviewed guide profile; для нового item — item-specific проверка |
+| safety cues | existing | non-medical factual cues; acute pain means stop, без diagnosis/treatment claims |
+| visual example | partial existing | typed local media + manifest есть для 158 items, но 7 mappings подтверждённо неверны; semantic review обязателен |
+| alternatives | existing | curated symmetric pairs; no self/duplicate; muscle match недостаточен |
+| source/provenance/license | partial existing / missing-needs-decision | guide metadata + manifest/NOTICE есть; нет immutable upstream revision, asset SHA-256, reviewer/date и verification flags |
+
+## Canonical seed record для 120B–D
+
+Рекомендуемый deterministic baseline — один versioned code-owned record для global catalog:
+
+```text
+slug
+display_name_ru
+aliases[]
+primary_muscle_ids[]
+secondary_muscle_ids[]
+equipment_ids[]
+machine_variant_tags[]
+movement_pattern
+execution_variant_tags[]
+difficulty_level
+metric_type
+guide_profile/item_content
+media_reference
+alternative_slugs[]
+provenance
+```
+
+Его можно реализовать расширением текущего seed/catalog module и derived API payload без migration. Нельзя создавать второй расходящийся alias/media registry во frontend. Если 120B докажет необходимость редактировать эти поля для global catalog через DB/admin flow, это отдельное migration decision с backfill и validation, а не скрытое условие 120A.
+
+## Инварианты
+
+1. `slug` уникален и стабилен; rename display не ломает history/API.
+2. `metric_type` — `strength` или `cardio`; неизвестный legacy row безопасно остаётся `strength` по Task 119.
+3. `cardio` не получает strength prescription; `strength` не получает cardio result fields.
+4. Alias не создаёт новую exercise identity.
+5. Brand/trademark alias не становится canonical display name.
+6. Primary/secondary muscles не содержат придуманных коэффициентов.
+7. Movement/equipment/execution tags выбираются явно редактором, не строковой эвристикой runtime.
+8. Alternative требует movement/equipment/setup review и никогда не ссылается на себя.
+9. Новый canonical item без semantically reviewed media или проверяемой file-level provenance не включается в releasable batch. Наличие manifest row недостаточно.
+10. Missing metadata остаётся missing для custom rows; LLM/autofill не превращает предположение в факт.
+
+## Metric type и Task 119
+
+Все новые machine/free-weight/bodyweight items 120B–D имеют `strength`, кроме явно циклических cardio activities. `strength` здесь описывает форму workout logging, а не физиологическую категорию. Cardio items используют доступные Task 119 поля: duration, optional distance, average HR и zone; никакие calories/pace/power/cadence не добавляются этим audit.
+
+## Variant decisions
+
+- Grip, foot stance, seat micro-adjustment и обычная смена хвата — guide/alias metadata, не отдельный canonical item.
+- Unilateral item создаётся отдельно, только если setup, execution или logging/selection materially отличаются (например unilateral leg press).
+- Independent-arm machine может быть один canonical item с `bilateral` и `unilateral` execution tags, если то же оборудование поддерживает оба режима.
+- Converging/diverging — machine path tag; это не обещание превосходства и не отдельный item без иного materially distinct setup.
+- Selectorized/plate-loaded/lever — controlled equipment metadata. Не использовать `Hammer Strength` как required UI category.
+
+## Content quality
+
+Technique: setup, рабочая фаза, контролируемое возвращение/завершение. Common mistakes описывают наблюдаемое выполнение. Safety cues не обещают «безопасно для коленей/спины», не назначают ROM при боли и не заменяют консультацию специалиста.
+
+## Validation, требуемая в 120B–D
+
+- unique slug и normalized alias;
+- allowed muscle/equipment/variant/metric values;
+- no alias collision without explicit ranking decision;
+- guide steps/mistakes/safety present;
+- media reference exists, files decode, exact-duplicate scan выполнен, semantic reviewer подтвердил identity/setup/key positions, immutable provenance complete;
+- alternative endpoints exist, differ from source and pass curated compatibility;
+- every global item searchable by canonical name and required aliases;
+- current 158 IDs/history remain intact.

--- a/docs/exercises/catalog-v2/EXPANSION_BATCHES.md
+++ b/docs/exercises/catalog-v2/EXPANSION_BATCHES.md
@@ -1,0 +1,101 @@
+# Expansion batches 120B–120D
+
+Приоритет означает coverage usefulness, а не quota. `Must` item входит в Definition of Done своего batch либо возвращается как конкретный media/data blocker. `Should` выполняется после must в пределах task. `Optional` не блокирует family.
+
+## Task 120B — upper-body machine
+
+### Must: новые canonical items
+
+| ID | Display name | Pattern / metadata | Почему gap |
+|---|---|---|---|
+| `machine-incline-chest-press` | Жим от груди вверх в тренажёре | chest press; machine; selectorized/lever | incline machine press отсутствует |
+| `independent-lever-chest-press` | Жим от груди в независимом рычажном тренажёре | horizontal press; plate-loaded lever; independent | generic `machine-chest-press` не описывает independent lever setup |
+| `lever-high-row` | Верхняя рычажная тяга с упором грудью | row; plate-loaded lever; independent/bilateral | high-row trajectory отсутствует |
+| `lever-low-row` | Нижняя рычажная тяга с упором грудью | row; plate-loaded lever; independent/bilateral | low-row trajectory отсутствует |
+| `independent-lever-lat-pulldown` | Вертикальная рычажная тяга независимыми руками | vertical pull; plate-loaded lever | current pulldown не различает cable/selectorized и lever |
+| `machine-pullover` | Пуловер в тренажёре | shoulder extension/pullover; machine | есть dumbbell/cable, machine gap подтверждён |
+| `independent-lever-shoulder-press` | Жим над головой в независимом рычажном тренажёре | vertical press; plate-loaded lever | current generic machine press не покрывает independent arms |
+
+### Should
+
+- `machine-decline-chest-press` — decline machine press, если media/setup действительно distinct.
+- `machine-triceps-extension` — selectorized elbow extension; не дублировать machine dip.
+- `chest-supported-dumbbell-row` — free-weight supported row; можно перенести в 120D, если media budget 120B исчерпан.
+
+### Alias/merge decisions в этом batch
+
+- `жим в хаммере`, `hammer press`, `рычажный жим`, `на блинах` ведут к generic lever items, но brand не показывается как category.
+- `high row`, `верхняя тяга хаммер`, `low row`, `нижняя тяга хаммер`, `iso-lateral` — reviewed aliases.
+- Existing `machine-biceps-curl` принимает `сгибание на скамье Скотта в тренажёре` как alias, если setup совпадает; отдельный canonical item без distinct media не создавать.
+
+### Representative gate
+
+Exact/alias search, one selectorized and one plate-loaded item, independent-arm execution, program add, strength logging, guide/media/alt, compact catalog row.
+
+## Task 120C — lower-body machine
+
+### Must: новые canonical items
+
+| ID | Display name | Pattern / metadata | Почему gap |
+|---|---|---|---|
+| `pendulum-squat` | Маятниковый присед в тренажёре | squat; plate-loaded lever; bilateral | distinct machine path отсутствует |
+| `plate-loaded-leg-press` | Жим ногами в тренажёре с дисками | squat/press; plate-loaded | current generic `leg-press` не подтверждает load type/setup |
+| `unilateral-leg-press` | Жим одной ногой в тренажёре | squat/press; machine; unilateral | materially distinct execution отсутствует |
+| `machine-hip-thrust` | Ягодичный мост в рычажном тренажёре | hip extension; lever; bilateral | current barbell/floor variants не покрывают glute-drive setup |
+| `smith-split-squat` | Сплит-присед в машине Смита | lunge; Smith; unilateral | Smith lower-body gap кроме bilateral squat |
+| `machine-glute-kickback` | Разгибание бедра назад в тренажёре | hip extension; machine; unilateral | есть cable variant, machine setup отсутствует |
+
+### Should
+
+- `v-squat-machine` — generic V-squat/lever squat, только с distinct media от hack/pendulum.
+- `reverse-hyperextension` — posterior-chain machine, не путать с current hyperextension.
+- Unilateral execution для current leg extension/curl хранить как variant/guide option, не создавать дубликат без distinct setup.
+
+### Alias/merge decisions в этом batch
+
+`жим ногами на блинах`, `pendulum squat`, `маятник`, `glute drive`, `ягодичный тренажёр`, `смит сплит`, `smith lunge`; foot stance aliases не создают отдельные entities.
+
+### Representative gate
+
+Plate-loaded vs selectorized context, Smith, unilateral, quads/hamstrings/glutes/calves coverage, program add, strength logging, guide/media/alt, compact row.
+
+## Task 120D — remaining coverage + search hardening
+
+### Must: content/data corrections
+
+1. Merge decision `goblet-squat` + `kettlebell-goblet-squat` с history-safe compatibility.
+2. Rename display `assault-bike` -> `Воздушный велотренажёр`; сохранить slug и aliases.
+3. Развести search/ranking `rowing-machine` cardio и `machine-row` strength.
+4. Reclassify `rowing-machine`, `treadmill-run`, `assault-bike` under cardio equipment while preserving `metric_type=cardio` and historical snapshots.
+5. Implement shared aliases/normalization/ranking and complete query corpus from `SEARCH_ALIAS_CONTRACT.md` in catalog и ProgramBuilder.
+6. Add deterministic catalog validator for required fields, allowed taxonomy, unique normalized aliases, existing media/provenance and valid metric type.
+7. Replace semantically wrong visual mappings for `pendlay-row`, `weighted-dip`, `single-leg-calf-raise`, `hollow-hold`, `meadows-row`, `captain-chair-leg-raise` and `belt-squat`; do not modify production assets in 120A.
+8. Extend media validation with exact cross-exercise hash detection plus recorded human identity/setup/key-position review. Unique hash alone is not a semantic pass.
+
+### Must: remaining canonical items
+
+| ID | Display name | Coverage |
+|---|---|---|
+| `bodyweight-squat` | Приседания с собственным весом | quads/glutes; squat; bodyweight; bilateral; strength |
+| `bodyweight-glute-bridge` | Ягодичный мост с собственным весом | glutes; hip extension; bodyweight; bilateral; strength |
+| `barbell-wrist-curl` | Сгибание кистей со штангой | forearms; wrist flexion; barbell; bilateral; strength |
+| `barbell-wrist-extension` | Разгибание кистей со штангой | forearms; wrist extension; barbell; bilateral; strength |
+
+### Should
+
+- `dead-hang` — grip/bodyweight/isometric.
+- `high-to-low-cable-fly` — distinct cable direction, если current guide/media не может быть variant текущего fly.
+- `recumbent-bike` — distinct cardio setup; Task 119 metric remains cardio.
+- `chest-supported-dumbbell-row`, если не вошёл в 120B.
+
+### Optional/deferred
+
+Arm ergometer, rare specialty machines, cosmetic grip/stance variations, manufacturer-specific machines and separate canonical items for every independent-arm mode. Они не блокируют matrix после must/should decisions.
+
+## Общие запреты
+
+- Не менять существующие stable slugs/IDs destructively.
+- Не добавлять item без reviewed technique, media и provenance.
+- Не добавлять `calories burned`, power/cadence/pace или новый metric type.
+- Не выводить alternative только из muscle match.
+- Не начинать 120B/120C/120D из этой task.

--- a/docs/exercises/catalog-v2/MEDIA_PROVENANCE_POLICY.md
+++ b/docs/exercises/catalog-v2/MEDIA_PROVENANCE_POLICY.md
@@ -1,0 +1,93 @@
+# Media provenance policy для каталога v2
+
+## Release gate
+
+Каждый новый global canonical exercise получает mobile-readable visual execution example до включения в releasable batch. Текстовая техника не заменяет visual. Отсутствие безопасного media — конкретный blocker для item, а не повод hotlink/copy.
+
+## Разрешённые источники
+
+1. Существующее repository-owned original media с подтверждаемой историей создания.
+2. Новые оригинальные YFC schematic/vector illustrations.
+3. Third-party media только после file-level проверки лицензии на commercial use, modification (если выполняется), bundling/redistribution и нужный способ attribution.
+
+Текущие third-party assets происходят из [`free-exercise-db`](https://github.com/yuhonas/free-exercise-db). На дату аудита upstream repository называет dataset public-domain, а [`LICENSE.md`](https://github.com/yuhonas/free-exercise-db/blob/main/LICENSE.md) содержит Unlicense и явно разрешает commercial/non-commercial use и distribution. Это подтверждает текущую policy, но не позволяет автоматически считать любой новый web asset частью того же набора: каждый файл должен быть сопоставлен с upstream path/revision и manifest record.
+
+### Current-state gap
+
+Текущий manifest фиксирует path, dimensions, byte size, phase и общий source/license, но не immutable upstream revision, SHA-256, reviewer/date и verification flags ниже. Exact-hash scan также нашёл восемь cross-exercise duplicate pairs; ручная проверка подтвердила семь неверных item mappings и одну duplicate identity pair. Поэтому current media имеет license-level baseline, но не полную file-level provenance/semantic validation. Их remediation — must scope 120D, а не скрытое утверждение 120A о полной coverage.
+
+## Запрещено
+
+- competitor screenshots/animations или их перерисовка один-в-один;
+- random web images и hotlink;
+- media без source URL/revision/license evidence;
+- packaging/logo/public-figure likeness и trademarks как decorative proxy;
+- generated anatomy/trajectory, представленная как проверенный факт без human domain review;
+- fake charts, ranges, joint angles или «идеальная техника» без источника;
+- autoplay со звуком или animation-only explanation.
+
+## Reusable visual format
+
+Baseline для 120B–D — две статические key positions `Начало` -> `Конечное положение` либо domain-reviewed phase labels. Для cyclic/multi-stage/cardio допускается одна schematic composition или несколько key positions с нейтральными labels.
+
+В guide это одна спокойная responsive composition: на ширине, где каждая позиция сохраняет читаемый размер, фазы стоят рядом; иначе они переходят в вертикальную последовательность без horizontal scroll. Короткий phase index/стрелка может использовать lime как YFC accent, но направление также выражено порядком и текстовой подписью. Visual не конкурирует с названием и шагами техники, а catalog row содержит только одно явное действие открытия guide.
+
+Требования:
+
+- локальные same-origin assets, без runtime CDN;
+- `image` baseline; video только отдельным validated pilot;
+- исходные width/height, `object-fit: contain`, lazy loading и async decoding;
+- readable при 360 px без обязательного zoom;
+- одинаковая framing/orientation для пары, если это не искажает движение;
+- no decorative crop body/joint landmarks;
+- stable `media_reference`, deterministic `sort_order`, poster/fallback;
+- reduced-motion не теряет информацию.
+
+## Alt/accessibility
+
+Alt описывает exercise, позицию и различимый action cue, а не имя файла: например `Рычажный жим от груди: исходное положение, рукояти у груди` и `... конечное положение, руки выпрямлены без жёсткой блокировки`. Подпись и текст техники остаются доступны при image error. Цвет/стрелка не являются единственным носителем направления.
+
+## Provenance record
+
+Для каждого файла/illustration хранить:
+
+```text
+exercise_slug
+asset_path
+asset_sha256
+source_kind: yfc_original | third_party
+source_name
+source_url
+source_revision_or_retrieved_at
+license_name
+license_url_or_local_notice
+commercial_use_verified: true
+redistribution_verified: true
+modification_verified: true|false|not_needed
+author_or_generator_record
+reviewer
+reviewed_at
+width/height/byte_size
+phase/sort_order/alt
+```
+
+`commercial_use_verified` — audit evidence, не юридическая гарантия. Неизвестное значение означает `blocked`, а не `false-but-ship`.
+
+## YFC original illustration workflow
+
+Brief фиксирует exact exercise/setup/key positions и запрещённые misleading детали. Создатель/генератор записывается. Fitness-domain reviewer проверяет movement identity, equipment setup, left/right consistency, load path и отсутствие unsafe/невозможной позиции. Затем media builder проверяет decode, размеры, manifest и unexpected files.
+
+AI-generated visual допустима только как YFC-owned draft при достаточных правах выбранного provider/workflow и human review; model output не является источником техники.
+
+## Third-party workflow
+
+1. Зафиксировать exact upstream file path и immutable revision/hash.
+2. Сохранить license text/URL и применимость к конкретному asset.
+3. Проверить commercial use и redistribution, а при crop/annotation — modification.
+4. Скопировать локально; hotlink запрещён.
+5. Заполнить manifest/NOTICE и attribution payload.
+6. Прогнать builder `--check` и representative visual review.
+
+## UI boundary
+
+Media открывается только по intent в guide/detail. Catalog row не резервирует media height и не становится always-expanded. Error state сохраняет text technique и честно сообщает недоступность изображения.

--- a/docs/exercises/catalog-v2/SEARCH_ALIAS_CONTRACT.md
+++ b/docs/exercises/catalog-v2/SEARCH_ALIAS_CONTRACT.md
@@ -1,0 +1,77 @@
+# Search alias contract v1
+
+## Проблема
+
+Текущий `ExerciseCatalog` фильтрует загруженный список простым substring по `title`, legacy muscle/equipment и alternative titles. `ProgramBuilder` использует только `title`, legacy muscle/equipment и поэтому не находит запись по названию alternative. Alias fields, transliteration, `ё/е` normalization, token matching и ranking отсутствуют на обеих surfaces.
+
+## Минимальный contract 120B–D
+
+Для global canonical exercise хранить versioned `aliases[]` рядом с canonical seed metadata и возвращать их обоим search consumers. Frontend-only hardcode запрещён: catalog и ProgramBuilder должны использовать один payload/normalizer.
+
+### Нормализация
+
+1. Unicode NFKC.
+2. Locale-independent case folding/lowercase.
+3. `ё -> е` для поиска, без изменения display string.
+4. Hyphen, slash и punctuation -> space; whitespace collapse.
+5. Latin/Cyrillic transliteration не генерировать автоматически: хранить reviewed variants.
+6. Query разбивается на tokens; все meaningful tokens должны присутствовать в одном canonical record.
+
+Полноценный fuzzy/stemming engine не нужен. Common typo добавляется явным alias только после query evidence. Отсутствие generic typo tolerance должно быть честно покрыто no-result state, а не случайным broad match.
+
+### Ranking
+
+Детерминированный порядок:
+
+1. exact canonical title;
+2. exact alias;
+3. canonical-title prefix;
+4. alias prefix;
+5. all-token substring;
+6. текущий difficulty/order tie-breaker.
+
+Один canonical entity выводится один раз, даже если совпали несколько aliases. Generic tokens `machine/тренажёр/рычажный` не должны вытеснять exact movement result.
+
+### Collision policy
+
+- Normalized alias уникален, если он обозначает конкретное упражнение.
+- Ambiguous gym term разрешён только как broad search token и обязан возвращать несколько явно различимых rows, а не скрыто выбирать одну.
+- После merge duplicate старый title/slug становится redirect/search alias canonical target; history ID не переписывается destructively.
+- Brand-like term допустим только как non-display alias при реальной findability ценности.
+
+## Обязательный query corpus
+
+| Query | Ожидание |
+|---|---|
+| `жим в хаммере` | generic independent/lever chest press; `хаммер` не display category |
+| `рычажный жим грудь` | lever chest press records |
+| `на блинах грудь` / `plate loaded chest press` | plate-loaded chest press |
+| `конвергентный жим` | converging/independent machine press |
+| `верхняя рычажная тяга` / `high row` | lever high row |
+| `нижняя рычажная тяга` / `low row` | lever low row |
+| `вертикальная рычажная тяга` | independent lever pulldown |
+| `смит присед` / `smith squat` | existing Smith squat |
+| `гакк` / `hack squat` | existing hack squat |
+| `маятниковый присед` / `pendulum squat` | new pendulum squat |
+| `жим ногами на блинах` | plate-loaded leg press |
+| `ягодичный тренажер` / `glute drive` | machine hip thrust |
+| `сгибание ног сидя/лежа/стоя` | ровно соответствующий current item |
+| `аэробайк` / `air bike` / `assault bike` | generic air bike canonical item |
+| `гребля тренажер` | cardio rower выше strength machine row |
+| `гребная тяга` | strength machine row выше cardio rower |
+| `подъем` и `подъём` | одинаковый result set |
+| `goblet squat` / `гоблет` | один canonical result после merge |
+
+120B/C добавляют aliases для своих новых/затронутых items и проверяют representative queries. 120D завершает общий corpus, collision validator и обе search surfaces.
+
+## API/UI boundary
+
+API payload получает `aliases: string[]`, `movement_pattern` и controlled variant tags, если они реализованы. Display row остаётся compact-first: title, muscle/equipment context, difficulty/metric badge. Alias/trademark не показывается как второе длинное название; при необходимости match reason можно показывать коротко и только для неочевидного результата.
+
+## Не входит
+
+- отдельный search engine;
+- AI/LLM query expansion;
+- runtime перевод названий;
+- SEO pages для каждого alias;
+- автосоздание canonical exercises из no-result query.


### PR DESCRIPTION
## Release candidate
- exact dev SHA: `eb362020ad549fd08c6976b20db9b9da2c57542c`;
- source task PR: #95;
- scope: Task 120A exercise catalog audit documentation only;
- exact merged-dev push CI: run 33358875869, success.

## Changes
Adds the exercise catalog coverage matrix, taxonomy and alias contracts, media provenance policy, duplicate/media remediation findings, and bounded expansion batches for Tasks 120B-120D.

No runtime, schema, dependency, configuration or UI behavior changes.