### PR TITLE
[Task 122] Simplify profile settings

### DIFF
--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -4444,11 +4444,11 @@ def test_tma_navigation_excludes_root_admin_entry():
     source = (
         Path(__file__).resolve().parents[2] / "frontend" / "src" / "app" / "AppShell.tsx"
     ).read_text(encoding="utf-8")
-    assert 'to="/coach"' in source
-    assert 'to="/admin"' in source
+    assert "to: '/coach'" in source
+    assert "to: '/admin'" in source
     assert "user.is_coach || user.is_admin" not in source
-    assert "{user?.is_coach && (" in source
-    assert "{user?.is_root && !isMiniApp && (" in source
+    assert "visible: Boolean(user?.is_coach)" in source
+    assert "visible: Boolean(user?.is_root) && !isMiniApp" in source
 
 
 def test_client_management_is_consolidated_in_coach_section():

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -7,10 +7,13 @@ import { useOptionalAuth } from './AuthProvider';
 import { useTelegramOverlayBackButton } from '../shared/telegram/useTelegramOverlayBackButton';
 import { useDocumentScrollLock } from '../shared/ui/useModalA11y';
 import { useMotionPresence } from '../shared/ui/useMotionPresence';
+import {
+  AccountAvatar,
+  AccountIdentity,
+  accountRoleLabel,
+} from '../shared/account/AccountIdentity';
 
 export type AppSection = 'today' | 'progress' | 'programs' | 'catalog' | 'nutrition' | 'profile';
-
-const AVATAR_EMOJIS = ['🏋️', '💪', '🏃', '🚴', '🥗', '⚡', '🎯', '🔥'] as const;
 
 const APP_DESTINATIONS: ReadonlyArray<{
   section: AppSection;
@@ -40,38 +43,26 @@ export interface DemoAppShellConfig {
   resetDisabled?: boolean;
 }
 
-function avatarFallback(name: string): string {
-  const hash = Array.from(name.trim()).reduce(
-    (value, character) => (value * 31 + (character.codePointAt(0) ?? 0)) >>> 0,
-    0,
-  );
-  return AVATAR_EMOJIS[hash % AVATAR_EMOJIS.length] ?? AVATAR_EMOJIS[0];
+function mobileNavigationMatches(): boolean {
+  return window.matchMedia?.('(max-width: 899px)').matches ?? window.innerWidth < 900;
 }
 
-function Avatar({ name, photoUrl }: { name: string; photoUrl?: string | null }) {
-  const [failedPhotoUrl, setFailedPhotoUrl] = useState<string | null>(null);
-  const photoFailed = Boolean(photoUrl && failedPhotoUrl === photoUrl);
+function useMobileNavigation(): boolean {
+  const [mobile, setMobile] = useState(mobileNavigationMatches);
 
-  return (
-    <span className="app-bottom-nav__avatar" aria-hidden="true">
-      {photoUrl && !photoFailed ? (
-        <img
-          src={photoUrl}
-          alt=""
-          referrerPolicy="no-referrer"
-          onError={() => setFailedPhotoUrl(photoUrl)}
-        />
-      ) : (
-        avatarFallback(name)
-      )}
-    </span>
-  );
-}
+  useEffect(() => {
+    const media = window.matchMedia?.('(max-width: 899px)');
+    const sync = () => setMobile(media?.matches ?? window.innerWidth < 900);
+    media?.addEventListener?.('change', sync);
+    window.addEventListener('resize', sync);
+    sync();
+    return () => {
+      media?.removeEventListener?.('change', sync);
+      window.removeEventListener('resize', sync);
+    };
+  }, []);
 
-function accountRole(isRoot: boolean, isCoach: boolean): string {
-  if (isRoot) return isCoach ? 'Root · Тренер' : 'Root · Личный режим';
-  if (isCoach) return 'Тренер';
-  return 'Клиент';
+  return mobile;
 }
 
 export function AppShell({
@@ -94,6 +85,7 @@ export function AppShell({
     closingAnimationName: 'app-more-backdrop-out',
     openingAnimationName: 'app-more-panel-in',
   });
+  const hideMorePresence = morePresence.hide;
   const morePanelRef = useRef<HTMLDivElement>(null);
   const moreTriggerRef = useRef<HTMLElement | null>(null);
   const displayName =
@@ -102,12 +94,51 @@ export function AppShell({
     user?.first_name ||
     user?.username ||
     'Пользователь';
+  const accountRole = accountRoleLabel(Boolean(user?.is_root), Boolean(user?.is_coach));
   const secondaryActive = section === 'catalog' || section === 'profile';
   const isMiniApp = Boolean(window.Telegram?.WebApp?.initData);
+  const mobileNavigation = useMobileNavigation();
   const shellDestinations = demo?.destinations ?? APP_DESTINATIONS;
   const brandTo = demo?.brandTo ?? '/app?section=today';
   const shellVisible = Boolean(user || demo);
   const morePresent = moreOpen || morePresence.present;
+  const moreSurfacePresent = morePresent && (Boolean(demo) || mobileNavigation);
+  const accountDestinations = [
+    {
+      key: 'catalog',
+      label: 'Упражнения',
+      to: '/app?section=catalog',
+      icon: 'catalog' as const,
+      desktopGroup: 'resources' as const,
+      visible: true,
+    },
+    {
+      key: 'profile',
+      label: 'Профиль и настройки',
+      to: '/app?section=profile',
+      icon: 'profile' as const,
+      desktopGroup: null,
+      visible: true,
+    },
+    {
+      key: 'coach',
+      label: 'Кабинет тренера',
+      desktopLabel: 'Тренер',
+      to: '/coach',
+      icon: 'coach' as const,
+      desktopGroup: 'workspaces' as const,
+      visible: Boolean(user?.is_coach),
+    },
+    {
+      key: 'admin',
+      label: 'Администрирование',
+      desktopLabel: 'Админ-панель',
+      to: '/admin',
+      icon: 'admin' as const,
+      desktopGroup: 'workspaces' as const,
+      visible: Boolean(user?.is_root) && !isMiniApp,
+    },
+  ].filter((destination) => destination.visible);
   const morePhase = moreOpen && morePresence.phase === 'closed' ? 'open' : morePresence.phase;
 
   const closeMore = (restoreFocus = false) => {
@@ -120,15 +151,33 @@ export function AppShell({
     setMoreOpen(true);
     morePresence.show();
   };
-  useTelegramOverlayBackButton(morePresent, () => closeMore(true));
+  useTelegramOverlayBackButton(moreSurfacePresent, () => closeMore(true));
 
-  useDocumentScrollLock(morePresent);
+  useDocumentScrollLock(moreSurfacePresent);
 
   useEffect(() => {
     if (moreOpen) {
       morePanelRef.current?.querySelector<HTMLElement>('button, a')?.focus();
     }
   }, [moreOpen]);
+
+  useEffect(() => {
+    if (demo) return;
+    const closeAtDesktopBreakpoint = () => {
+      if (mobileNavigationMatches() || !moreOpen) return;
+      setMoreOpen(false);
+      hideMorePresence();
+      window.requestAnimationFrame(() => {
+        const accountLink = document.getElementById('appAccountProfileLink');
+        const railBrand = document.querySelector<HTMLElement>(
+          '#appBottomNav .app-bottom-nav__brand',
+        );
+        (accountLink ?? railBrand)?.focus();
+      });
+    };
+    window.addEventListener('resize', closeAtDesktopBreakpoint);
+    return () => window.removeEventListener('resize', closeAtDesktopBreakpoint);
+  }, [demo, hideMorePresence, moreOpen]);
 
   if (!demo && !auth) {
     throw new Error('AppShell must be used inside AuthProvider unless demo config is provided');
@@ -158,7 +207,7 @@ export function AppShell({
 
   return (
     <div className="app-shell app-shell--design-v2">
-      {!demo && shellVisible && (
+      {!demo && shellVisible && mobileNavigation && (
         <header className="app-mobile-header">
           <AppLink
             className="app-mobile-header__brand"
@@ -176,7 +225,11 @@ export function AppShell({
             aria-label="Открыть профиль и настройки"
             onClick={(event) => (moreOpen ? closeMore() : openMore(event.currentTarget))}
           >
-            <Avatar name={displayName} photoUrl={user?.photo_url} />
+            <AccountAvatar
+              className="app-bottom-nav__avatar"
+              name={displayName}
+              photoUrl={user?.photo_url}
+            />
           </button>
         </header>
       )}
@@ -197,6 +250,26 @@ export function AppShell({
             >
               <BrandLockup markClassName="app-bottom-nav__brand-mark" />
             </AppLink>
+
+            {!demo && (
+              <div className="app-bottom-nav__profile-slot">
+                <AppLink
+                  id="appAccountProfileLink"
+                  to="/app?section=profile"
+                  className={`app-desktop-account-entry${path === '/app' && section === 'profile' ? ' is-active' : ''}`}
+                  aria-current={path === '/app' && section === 'profile' ? 'page' : undefined}
+                  aria-label="Профиль и настройки"
+                >
+                  <AccountIdentity
+                    avatarClassName="app-desktop-account-entry__avatar"
+                    className="app-desktop-account-entry__identity"
+                    name={displayName}
+                    photoUrl={user?.photo_url}
+                    role={accountRole}
+                  />
+                </AppLink>
+              </div>
+            )}
 
             <div className="app-bottom-nav__primary">
               {shellDestinations.map((destination) => {
@@ -240,80 +313,58 @@ export function AppShell({
                 role="group"
                 aria-label="Дополнительные разделы"
               >
-                <p className="app-bottom-nav__group-label">Мои данные</p>
-                <AppLink
-                  to="/app?section=catalog"
-                  className={`app-bottom-nav__btn${path === '/app' && section === 'catalog' ? ' is-active' : ''}`}
-                  aria-current={path === '/app' && section === 'catalog' ? 'page' : undefined}
-                >
-                  <AppNavigationIcon name="catalog" />
-                  <span className="app-bottom-nav__label">Упражнения</span>
-                </AppLink>
-                <AppLink
-                  to="/app?section=profile"
-                  className={`app-bottom-nav__btn${path === '/app' && section === 'profile' ? ' is-active' : ''}`}
-                  aria-current={path === '/app' && section === 'profile' ? 'page' : undefined}
-                >
-                  <AppNavigationIcon name="profile" />
-                  <span className="app-bottom-nav__label">Профиль</span>
-                </AppLink>
-                {user?.is_coach && (
-                  <>
-                    <p className="app-bottom-nav__group-label">Рабочие пространства</p>
-                    <AppLink
-                      to="/coach"
-                      className={`app-bottom-nav__btn${path === '/coach' ? ' is-active' : ''}`}
-                      aria-current={path === '/coach' ? 'page' : undefined}
-                    >
-                      <AppNavigationIcon name="coach" />
-                      <span className="app-bottom-nav__label">Тренер</span>
-                    </AppLink>
-                  </>
-                )}
-                {user?.is_root && !isMiniApp && (
-                  <AppLink
-                    to="/admin"
-                    className={`app-bottom-nav__btn${path === '/admin' ? ' is-active' : ''}`}
-                    aria-current={path === '/admin' ? 'page' : undefined}
-                    title="Администрирование"
-                  >
-                    <AppNavigationIcon name="admin" />
-                    <span className="app-bottom-nav__label">Админ-панель</span>
-                  </AppLink>
-                )}
+                {(['resources', 'workspaces'] as const).map((group) => {
+                  const destinations = accountDestinations.filter(
+                    (destination) => destination.desktopGroup === group,
+                  );
+                  if (!destinations.length) return null;
+                  return (
+                    <div className="app-bottom-nav__secondary-group" key={group}>
+                      <p className="app-bottom-nav__group-label">
+                        {group === 'resources' ? 'Ресурсы' : 'Рабочие пространства'}
+                      </p>
+                      {destinations.map((destination) => {
+                        const active =
+                          destination.to === '/coach'
+                            ? path === '/coach'
+                            : destination.to === '/admin'
+                              ? path === '/admin'
+                              : path === '/app' && section === destination.key;
+                        return (
+                          <AppLink
+                            key={destination.key}
+                            to={destination.to}
+                            className={`app-bottom-nav__btn${active ? ' is-active' : ''}`}
+                            aria-current={active ? 'page' : undefined}
+                          >
+                            <AppNavigationIcon name={destination.icon} />
+                            <span className="app-bottom-nav__label">
+                              {'desktopLabel' in destination
+                                ? destination.desktopLabel
+                                : destination.label}
+                            </span>
+                          </AppLink>
+                        );
+                      })}
+                    </div>
+                  );
+                })}
               </div>
             )}
 
             <div className="app-bottom-nav__utility">
               <AppThemeToggle navigation />
-              <div className="app-bottom-nav__account">
-                {demo ? (
-                  <Avatar name={displayName} photoUrl={user?.photo_url} />
-                ) : (
-                  <button
-                    type="button"
-                    className="app-bottom-nav__account-entry"
-                    aria-expanded={moreOpen}
-                    aria-controls="appMorePanel"
-                    aria-label="Открыть меню аккаунта"
-                    onClick={(event) => (moreOpen ? closeMore() : openMore(event.currentTarget))}
-                  >
-                    <Avatar name={displayName} photoUrl={user?.photo_url} />
-                    <span>
-                      <strong className="app-bottom-nav__account-name">{displayName}</strong>
-                      <small className="app-bottom-nav__account-role">
-                        {accountRole(Boolean(user?.is_root), Boolean(user?.is_coach))}
-                      </small>
-                    </span>
-                  </button>
-                )}
-                {demo && (
+              {demo ? (
+                <div className="app-bottom-nav__account">
+                  <AccountAvatar
+                    className="app-bottom-nav__avatar"
+                    name={displayName}
+                    photoUrl={user?.photo_url}
+                  />
                   <>
                     <strong className="app-bottom-nav__account-name">{displayName}</strong>
                     <small className="app-bottom-nav__account-role">Отдельная сессия</small>
                   </>
-                )}
-                {demo ? (
                   <AppLink
                     className="app-bottom-nav__logout"
                     to={demo.exitTo}
@@ -322,22 +373,23 @@ export function AppShell({
                   >
                     <AppNavigationIcon name="logout" />
                   </AppLink>
-                ) : (
-                  <button
-                    type="button"
-                    className="app-bottom-nav__logout"
-                    onClick={() => void logout?.()}
-                    aria-label="Выйти из аккаунта"
-                    title="Выйти"
-                  >
-                    <AppNavigationIcon name="logout" />
-                  </button>
-                )}
-              </div>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  className="app-bottom-nav__btn app-bottom-nav__logout app-bottom-nav__utility-action"
+                  onClick={() => void logout?.()}
+                  aria-label="Выйти из аккаунта"
+                  title="Выйти из аккаунта"
+                >
+                  <AppNavigationIcon name="logout" />
+                  <span className="app-bottom-nav__label">Выйти</span>
+                </button>
+              )}
             </div>
           </nav>
 
-          {morePresent && (
+          {moreSurfacePresent && (
             <div
               className="app-more-layer"
               data-motion-phase={morePhase}
@@ -360,16 +412,15 @@ export function AppShell({
               >
                 <header className="app-more-panel__header">
                   <div className="app-more-panel__account">
-                    <Avatar name={displayName} photoUrl={user?.photo_url} />
-                    <span>
-                      <strong id="appMoreTitle">
-                        {demo?.menuTitle ?? (demo ? displayName : 'Профиль и настройки')}
-                      </strong>
-                      <small>
-                        {demo
-                          ? 'Отдельная сессия'
-                          : accountRole(Boolean(user?.is_root), Boolean(user?.is_coach))}
-                      </small>
+                    <AccountIdentity
+                      avatarClassName="app-bottom-nav__avatar"
+                      className="app-more-panel__identity"
+                      name={demo?.menuTitle ?? displayName}
+                      photoUrl={user?.photo_url}
+                      role={demo ? 'Отдельная сессия' : accountRole}
+                    />
+                    <span className="sr-only" id="appMoreTitle">
+                      {demo?.menuTitle ?? (demo ? displayName : 'Профиль и настройки')}
                     </span>
                   </div>
                   <button
@@ -395,50 +446,27 @@ export function AppShell({
                         <span>{item.label}</span>
                       </AppLink>
                     ))}
-                  {!demo && (
-                    <>
-                      <AppLink
-                        to="/app?section=catalog"
-                        className="app-more-panel__item"
-                        aria-current={path === '/app' && section === 'catalog' ? 'page' : undefined}
-                        onClick={() => closeMore()}
-                      >
-                        <AppNavigationIcon name="catalog" />
-                        <span>Упражнения</span>
-                      </AppLink>
-                      <AppLink
-                        to="/app?section=profile"
-                        className="app-more-panel__item"
-                        aria-current={path === '/app' && section === 'profile' ? 'page' : undefined}
-                        onClick={() => closeMore()}
-                      >
-                        <AppNavigationIcon name="profile" />
-                        <span>Профиль и настройки</span>
-                      </AppLink>
-                      {user?.is_coach && (
+                  {!demo &&
+                    accountDestinations.map((destination) => {
+                      const active =
+                        destination.to === '/coach'
+                          ? path === '/coach'
+                          : destination.to === '/admin'
+                            ? path === '/admin'
+                            : path === '/app' && section === destination.key;
+                      return (
                         <AppLink
-                          to="/coach"
+                          key={destination.key}
+                          to={destination.to}
                           className="app-more-panel__item"
-                          aria-current={path === '/coach' ? 'page' : undefined}
+                          aria-current={active ? 'page' : undefined}
                           onClick={() => closeMore()}
                         >
-                          <AppNavigationIcon name="coach" />
-                          <span>Кабинет тренера</span>
+                          <AppNavigationIcon name={destination.icon} />
+                          <span>{destination.label}</span>
                         </AppLink>
-                      )}
-                      {user?.is_root && !isMiniApp && (
-                        <AppLink
-                          to="/admin"
-                          className="app-more-panel__item"
-                          aria-current={path === '/admin' ? 'page' : undefined}
-                          onClick={() => closeMore()}
-                        >
-                          <AppNavigationIcon name="admin" />
-                          <span>Администрирование</span>
-                        </AppLink>
-                      )}
-                    </>
-                  )}
+                      );
+                    })}
                 </nav>
 
                 <div className="app-more-panel__actions">

--- a/frontend/src/features/account/AccountPrivacy.tsx
+++ b/frontend/src/features/account/AccountPrivacy.tsx
@@ -13,6 +13,7 @@ import { useFeedback } from '../../shared/ui/FeedbackProvider';
 import { useModalA11y } from '../../shared/ui/useModalA11y';
 import { Icon } from '../../shared/ui/Icon';
 import { downloadAccountExport } from './downloadAccountExport';
+import { OAuthProviderButton } from '../auth/OAuthButtons';
 
 const PROVIDER_LABELS: Record<string, string> = {
   telegram: 'Telegram',
@@ -230,22 +231,22 @@ export function AccountPrivacy() {
                       </Button>
                     </>
                   ) : telegramLink ? (
-                    <a
-                      className="button-link"
+                    <OAuthProviderButton
+                      provider={provider}
                       href={telegramLink.telegram_url}
                       target="_blank"
                       rel="noreferrer"
                     >
                       Открыть Telegram
-                    </a>
+                    </OAuthProviderButton>
                   ) : oauthLink ? (
-                    <a className="button-link" href={oauthLink.oauth_url}>
+                    <OAuthProviderButton provider={provider} href={oauthLink.oauth_url}>
                       Продолжить с {label}
-                    </a>
+                    </OAuthProviderButton>
                   ) : (
-                    <Button
-                      type="button"
-                      variant="secondary"
+                    <OAuthProviderButton
+                      provider={provider}
+                      busy={linkingPending}
                       disabled={telegramLinkMutation.isPending || oauthLinkMutation.isPending}
                       onClick={() =>
                         provider === 'telegram'
@@ -254,7 +255,7 @@ export function AccountPrivacy() {
                       }
                     >
                       {linkingPending ? 'Готовим переход…' : `Привязать ${label}`}
-                    </Button>
+                    </OAuthProviderButton>
                   )}
                 </div>
                 {lastIdentity && (

--- a/frontend/src/features/account/NotificationsPanel.tsx
+++ b/frontend/src/features/account/NotificationsPanel.tsx
@@ -334,96 +334,115 @@ export function NotificationsPanel({ onNavigate }: { onNavigate?: (path: string)
         )}
       </section>
 
-      <section className="notification-center" aria-labelledby="notification-center-title">
-        <header className="notification-center__head">
-          <div>
-            <span className="eyebrow">Центр уведомлений</span>
+      <details className="notification-center profile-disclosure">
+        <summary>
+          <span>
+            <strong>Центр уведомлений</strong>
+            <small>
+              {notifications.isLoading
+                ? 'Загружаем события…'
+                : notifications.error
+                  ? 'Не удалось загрузить · можно повторить после раскрытия'
+                  : unreadCount
+                    ? `Непрочитанные · ${unreadCount}`
+                    : notifications.data?.length
+                      ? 'Всё прочитано'
+                      : 'Уведомлений пока нет'}
+            </small>
+          </span>
+          <DisclosureIcon />
+        </summary>
+        <div className="profile-disclosure__body">
+          <header className="notification-center__head">
             <h3 id="notification-center-title">
-              {unreadCount ? `Непрочитанные · ${unreadCount}` : 'Всё прочитано'}
+              {unreadCount ? `Непрочитанные · ${unreadCount}` : 'Последние события'}
             </h3>
-          </div>
-          {unreadCount > 0 && (
-            <button
-              type="button"
-              className="secondary"
-              disabled={readAllMutation.isPending}
-              onClick={() => readAllMutation.mutate()}
-            >
-              Отметить всё
-            </button>
-          )}
-        </header>
-        {notifications.isLoading ? (
-          <LoadingState />
-        ) : notifications.error ? (
-          <ErrorState message={(notifications.error as Error).message} />
-        ) : !notifications.data?.length ? (
-          <EmptyState
-            title="Уведомлений пока нет"
-            text="Здесь появятся напоминания и важные изменения от тренера."
-          />
-        ) : (
-          <div className="notification-list">
-            {notifications.data.map((item) => {
-              const canOpen = navigableCategories.has(item.category);
-              const copy = (
-                <>
-                  <span className="notification-row__meta">
-                    {categoryLabels[item.category] ?? 'Событие'}
-                    {!item.read_at && <span>Новое</span>}
-                  </span>
-                  <strong>{item.title}</strong>
-                  <span>{item.body}</span>
-                  <span className="muted">
-                    {item.event_kind === 'reminder' ? 'Запланировано' : 'Создано'}:{' '}
-                    {formatWallTime(item.scheduled_for)}
-                  </span>
-                </>
-              );
-              return (
-                <article
-                  className={`notification-row ${item.read_at ? '' : 'notification-row--unread'}`}
-                  key={item.id}
-                >
-                  {canOpen && onNavigate ? (
+            {unreadCount > 0 && (
+              <button
+                type="button"
+                className="secondary"
+                disabled={readAllMutation.isPending}
+                onClick={() => readAllMutation.mutate()}
+              >
+                Отметить всё
+              </button>
+            )}
+          </header>
+          {notifications.isLoading ? (
+            <LoadingState />
+          ) : notifications.error ? (
+            <ErrorState
+              message={(notifications.error as Error).message}
+              retry={() => void notifications.refetch()}
+            />
+          ) : !notifications.data?.length ? (
+            <EmptyState
+              title="Уведомлений пока нет"
+              text="Здесь появятся напоминания и важные изменения от тренера."
+            />
+          ) : (
+            <div className="notification-list">
+              {notifications.data.map((item) => {
+                const canOpen = navigableCategories.has(item.category);
+                const copy = (
+                  <>
+                    <span className="notification-row__meta">
+                      {categoryLabels[item.category] ?? 'Событие'}
+                      {!item.read_at && <span>Новое</span>}
+                    </span>
+                    <strong>{item.title}</strong>
+                    <span>{item.body}</span>
+                    <span className="muted">
+                      {item.event_kind === 'reminder' ? 'Запланировано' : 'Создано'}:{' '}
+                      {formatWallTime(item.scheduled_for)}
+                    </span>
+                  </>
+                );
+                return (
+                  <article
+                    className={`notification-row ${item.read_at ? '' : 'notification-row--unread'}`}
+                    key={item.id}
+                  >
+                    {canOpen && onNavigate ? (
+                      <button
+                        type="button"
+                        className="notification-row__main text-button notification-action"
+                        aria-label={`Открыть: ${item.title}`}
+                        disabled={openMutation.isPending}
+                        onClick={() => openMutation.mutate(item.id)}
+                      >
+                        {copy}
+                      </button>
+                    ) : (
+                      <div className="notification-row__main">{copy}</div>
+                    )}
                     <button
                       type="button"
-                      className="notification-row__main text-button notification-action"
-                      aria-label={`Открыть: ${item.title}`}
-                      disabled={openMutation.isPending}
-                      onClick={() => openMutation.mutate(item.id)}
+                      className="notification-row__delete"
+                      onClick={async () => {
+                        if (
+                          await confirm({
+                            title: 'Удалить уведомление?',
+                            message: item.title,
+                            confirmText: 'Удалить',
+                          })
+                        ) {
+                          listMutation.mutate({
+                            path: `/api/v1/notifications/${item.id}`,
+                            method: 'DELETE',
+                          });
+                        }
+                      }}
                     >
-                      {copy}
+                      Удалить
                     </button>
-                  ) : (
-                    <div className="notification-row__main">{copy}</div>
-                  )}
-                  <button
-                    type="button"
-                    className="notification-row__delete"
-                    onClick={async () => {
-                      if (
-                        await confirm({
-                          title: 'Удалить уведомление?',
-                          message: item.title,
-                          confirmText: 'Удалить',
-                        })
-                      ) {
-                        listMutation.mutate({
-                          path: `/api/v1/notifications/${item.id}`,
-                          method: 'DELETE',
-                        });
-                      }
-                    }}
-                  >
-                    Удалить
-                  </button>
-                </article>
-              );
-            })}
-          </div>
-        )}
-      </section>
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </details>
 
       <details className="notification-personal profile-disclosure">
         <summary>

--- a/frontend/src/features/auth/OAuthButtons.tsx
+++ b/frontend/src/features/auth/OAuthButtons.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type MouseEventHandler, type ReactNode } from 'react';
 import { safeAuthNextPath } from '../../shared/auth/redirects';
 import { markProductLoginStarted } from '../../shared/analytics/productEvents';
 import { Icon } from '../../shared/ui/Icon';
@@ -46,6 +46,73 @@ function ProviderIcon({ provider }: { provider: string }) {
   );
 }
 
+export function OAuthProviderButton({
+  busy = false,
+  children,
+  disabled = false,
+  href,
+  onClick,
+  provider,
+  rel,
+  target,
+}: {
+  busy?: boolean;
+  children: ReactNode;
+  disabled?: boolean;
+  href?: string;
+  onClick?: MouseEventHandler<HTMLAnchorElement | HTMLButtonElement>;
+  provider: string;
+  rel?: string;
+  target?: string;
+}) {
+  const content = (
+    <>
+      <span className="oauth-button__icon" aria-hidden="true">
+        <ProviderIcon provider={provider} />
+      </span>
+      <span className="oauth-button__label">{children}</span>
+      <Icon className="oauth-button__arrow" name="arrow-right" size={16} />
+    </>
+  );
+  const className = `oauth-button oauth-button--${provider}`;
+
+  if (href) {
+    return (
+      <a
+        className={className}
+        href={href}
+        target={target}
+        rel={rel}
+        aria-disabled={disabled || undefined}
+        aria-busy={busy || undefined}
+        data-motion-feedback={busy ? 'busy' : undefined}
+        onClick={(event) => {
+          if (disabled) {
+            event.preventDefault();
+            return;
+          }
+          onClick?.(event);
+        }}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      className={className}
+      type="button"
+      disabled={disabled}
+      aria-busy={busy || undefined}
+      data-motion-feedback={busy ? 'busy' : undefined}
+      onClick={onClick as MouseEventHandler<HTMLButtonElement> | undefined}
+    >
+      {content}
+    </button>
+  );
+}
+
 export function OAuthButtons({
   providers,
   nextPath,
@@ -64,13 +131,12 @@ export function OAuthButtons({
       <p className="muted">Войти с помощью</p>
       <div className="oauth-auth__grid">
         {configuredProviders.map((provider) => (
-          <a
+          <OAuthProviderButton
             key={provider}
-            className={`oauth-button oauth-button--${provider}`}
+            provider={provider}
             href={`/api/v1/auth/oauth/${provider}/start${safeNext ? `?next=${encodeURIComponent(safeNext)}` : ''}`}
-            aria-disabled={redirectingProvider !== null}
-            aria-busy={redirectingProvider === provider || undefined}
-            data-motion-feedback={redirectingProvider === provider ? 'busy' : undefined}
+            disabled={redirectingProvider !== null}
+            busy={redirectingProvider === provider}
             onClick={(event) => {
               if (redirectingProvider !== null) {
                 event.preventDefault();
@@ -80,12 +146,8 @@ export function OAuthButtons({
               markProductLoginStarted();
             }}
           >
-            <span className="oauth-button__icon" aria-hidden="true">
-              <ProviderIcon provider={provider} />
-            </span>
             {redirectingProvider === provider ? 'Переходим…' : PROVIDER_LABELS[provider]}
-            <Icon className="oauth-button__arrow" name="arrow-right" size={16} />
-          </a>
+          </OAuthProviderButton>
         ))}
       </div>
     </section>

--- a/frontend/src/features/profile/CoachInvites.tsx
+++ b/frontend/src/features/profile/CoachInvites.tsx
@@ -86,6 +86,7 @@ export function CoachInvites({
     <Card
       title="Мой тренер"
       description="Подключение происходит только после того, как вы проверите имя и подтвердите приглашение."
+      collapsible={false}
     >
       <div className="metric top-gap">
         <span>Текущий тренер</span>

--- a/frontend/src/features/profile/ProfileForm.tsx
+++ b/frontend/src/features/profile/ProfileForm.tsx
@@ -247,7 +247,9 @@ export function ProfileForm() {
         >
           <section className="profile-form-section" aria-labelledby="profile-personal-title">
             <div className="profile-form-section__head">
-              <h3 id="profile-personal-title">Личные данные</h3>
+              <h3 id="profile-personal-title">
+                <Icon name="nav-profile" size={20} /> Личные данные
+              </h3>
               <p>
                 Имя, дата рождения и часовой пояс используются только в вашем рабочем контексте.
               </p>
@@ -314,7 +316,9 @@ export function ProfileForm() {
             aria-labelledby="profile-fitness-title"
           >
             <div className="profile-form-section__head">
-              <h3 id="profile-fitness-title">Цели и параметры</h3>
+              <h3 id="profile-fitness-title">
+                <Icon name="nav-plan" size={20} /> Цели и параметры
+              </h3>
               <p>Цель, уровень и частота тренировок участвуют в рекомендации программы.</p>
             </div>
             <div className="form-grid profile-form-grid profile-form-grid--fitness">

--- a/frontend/src/features/profile/TrainerCapabilityCard.tsx
+++ b/frontend/src/features/profile/TrainerCapabilityCard.tsx
@@ -71,6 +71,7 @@ export function TrainerCapabilityCard() {
     <Card
       title="Режим тренера"
       description="Дополнительный рабочий режим внутри вашего обычного аккаунта."
+      collapsible={false}
     >
       {capability.isLoading ? (
         <LoadingState label="Проверяем режим тренера…" />

--- a/frontend/src/features/profile/TrainingPreferencesForm.tsx
+++ b/frontend/src/features/profile/TrainingPreferencesForm.tsx
@@ -251,11 +251,11 @@ export function TrainingPreferencesFields({
         )}
       </div>
 
-      <details className="training-preferences-disclosure" open>
+      <details className="training-preferences-disclosure">
         <summary>
           <span>
-            <strong>Длительность и расписание</strong>
-            <small>Необязательно · ориентир для проверки программы</small>
+            <strong>Расписание</strong>
+            <small>Дни и длительность · необязательно</small>
           </span>
           <DisclosureIcon />
         </summary>

--- a/frontend/src/pages/miniapp/MiniAppPage.tsx
+++ b/frontend/src/pages/miniapp/MiniAppPage.tsx
@@ -243,7 +243,6 @@ export default function MiniAppPage() {
       `${window.location.pathname}${query ? `?${query}` : ''}${window.location.hash}`,
     );
   }, [toast]);
-  const role = user?.is_coach ? 'Тренер' : 'Клиент';
   const programStart = section === 'programs' ? requestedProgramStart(search) : null;
   const profileReadiness = programProfileReadiness(user?.profile);
   const profileFormKey = JSON.stringify([
@@ -307,9 +306,6 @@ export default function MiniAppPage() {
                     ? 'Текущая программа, тренировочные дни и создание своего плана.'
                     : 'Тренировки, питание и прогресс в одном месте.'}
               </p>
-            </div>
-            <div className="hero-card__meta">
-              <Badge>{role}</Badge>
             </div>
           </header>
         )}

--- a/frontend/src/shared/account/AccountIdentity.tsx
+++ b/frontend/src/shared/account/AccountIdentity.tsx
@@ -1,0 +1,69 @@
+import { useState } from 'react';
+
+const AVATAR_EMOJIS = ['🏋️', '💪', '🏃', '🚴', '🥗', '⚡', '🎯', '🔥'] as const;
+
+function avatarFallback(name: string): string {
+  const hash = Array.from(name.trim()).reduce(
+    (value, character) => (value * 31 + (character.codePointAt(0) ?? 0)) >>> 0,
+    0,
+  );
+  return AVATAR_EMOJIS[hash % AVATAR_EMOJIS.length] ?? AVATAR_EMOJIS[0];
+}
+
+export function accountRoleLabel(isRoot: boolean, isCoach: boolean): string {
+  if (isRoot) return isCoach ? 'Root · Тренер' : 'Root · Личный режим';
+  if (isCoach) return 'Тренер';
+  return 'Клиент';
+}
+
+export function AccountAvatar({
+  className = 'account-identity__avatar',
+  name,
+  photoUrl,
+}: {
+  className?: string;
+  name: string;
+  photoUrl?: string | null;
+}) {
+  const [failedPhotoUrl, setFailedPhotoUrl] = useState<string | null>(null);
+  const photoFailed = Boolean(photoUrl && failedPhotoUrl === photoUrl);
+
+  return (
+    <span className={className} aria-hidden="true">
+      {photoUrl && !photoFailed ? (
+        <img
+          src={photoUrl}
+          alt=""
+          referrerPolicy="no-referrer"
+          onError={() => setFailedPhotoUrl(photoUrl)}
+        />
+      ) : (
+        avatarFallback(name)
+      )}
+    </span>
+  );
+}
+
+export function AccountIdentity({
+  avatarClassName,
+  className = 'account-identity',
+  name,
+  photoUrl,
+  role,
+}: {
+  avatarClassName?: string;
+  className?: string;
+  name: string;
+  photoUrl?: string | null;
+  role: string;
+}) {
+  return (
+    <span className={className}>
+      <AccountAvatar className={avatarClassName} name={name} photoUrl={photoUrl} />
+      <span className="account-identity__copy">
+        <strong className="account-identity__name">{name}</strong>
+        <small className="account-identity__role">{role}</small>
+      </span>
+    </span>
+  );
+}

--- a/frontend/src/styles/design-v2.css
+++ b/frontend/src/styles/design-v2.css
@@ -653,6 +653,10 @@ body:has(.app-shell--design-v2) {
   border-color: var(--v2-border);
 }
 
+.app-shell--design-v2 .app-bottom-nav__secondary-group {
+  display: contents;
+}
+
 .app-shell--design-v2 .app-bottom-nav__group-label,
 .app-shell--design-v2 .app-bottom-nav__account-role {
   color: var(--v2-text-secondary);
@@ -679,6 +683,23 @@ body:has(.app-shell--design-v2) {
   background: var(--v2-surface-secondary);
 }
 
+.app-shell--design-v2 .app-more-panel__identity {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--v2-space-3);
+}
+
+.app-shell--design-v2 .account-identity__copy {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.app-shell--design-v2 .app-bottom-nav__profile-slot {
+  display: none;
+}
+
 .app-shell--design-v2 .telegram-link-prompt {
   border-color: var(--v2-border);
   border-radius: var(--v2-region-radius);
@@ -686,7 +707,13 @@ body:has(.app-shell--design-v2) {
   box-shadow: none;
 }
 
-.app-shell--design-v2 :where(.app-bottom-nav__btn, .app-bottom-nav__logout):focus-visible,
+.app-shell--design-v2
+  :where(
+    .app-bottom-nav__btn,
+    .app-bottom-nav__logout,
+    .app-bottom-nav__account-entry,
+    .app-desktop-account-entry
+  ):focus-visible,
 .today-dashboard--design-v2 :where(button, a):focus-visible,
 .nutrition-diary--design-v2 :where(button, a, input, select):focus-visible,
 .active-workout--design-v2 :where(button, a, input, select, summary):focus-visible,
@@ -2462,9 +2489,78 @@ body.public-shell-mode.public-shell-mode:has(.auth-public-shell--design-v2) {
     scrollbar-gutter: stable both-edges;
   }
 
+  .app-shell--design-v2 .app-bottom-nav__profile-slot {
+    display: block;
+    margin-bottom: var(--v2-space-5);
+    padding-bottom: var(--v2-space-4);
+    border-bottom: 1px solid var(--v2-border);
+  }
+
+  .app-shell--design-v2 .app-desktop-account-entry {
+    display: block;
+    width: 100%;
+    min-width: 0;
+    border: 1px solid transparent;
+    border-radius: var(--v2-control-radius);
+    background: transparent;
+    color: var(--v2-text-primary);
+    text-decoration: none;
+  }
+
+  .app-shell--design-v2 .app-desktop-account-entry:hover,
+  .app-shell--design-v2 .app-desktop-account-entry.is-active {
+    border-color: var(--v2-border-strong);
+    background: var(--v2-surface-secondary);
+  }
+
+  .app-shell--design-v2 .app-desktop-account-entry__identity {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 4px;
+  }
+
+  .app-shell--design-v2 .app-desktop-account-entry__avatar {
+    overflow: hidden;
+    display: grid;
+    width: 30px;
+    height: 30px;
+    flex: 0 0 30px;
+    place-items: center;
+    border: 2px solid var(--v2-lime);
+    border-radius: 50%;
+    background: var(--v2-lime-soft);
+    color: var(--v2-accent-text);
+  }
+
+  .app-shell--design-v2 .app-desktop-account-entry__avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .app-shell--design-v2 .app-desktop-account-entry .account-identity__name,
+  .app-shell--design-v2 .app-desktop-account-entry .account-identity__role {
+    overflow: hidden;
+    display: block;
+    max-width: 18ch;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .app-shell--design-v2 .app-desktop-account-entry .account-identity__name {
+    font-size: 0.75rem;
+  }
+
+  .app-shell--design-v2 .app-desktop-account-entry .account-identity__role {
+    color: var(--v2-text-secondary);
+    font-size: 0.72rem;
+  }
+
   .app-shell--design-v2 .app-bottom-nav__brand {
     justify-content: center;
-    margin-bottom: var(--v2-space-6);
+    margin-bottom: var(--v2-space-4);
     padding: 0;
   }
 
@@ -2522,7 +2618,9 @@ body.public-shell-mode.public-shell-mode:has(.auth-public-shell--design-v2) {
     margin-top: var(--v2-space-4);
   }
 
-  .app-shell--design-v2 .app-bottom-nav__secondary > .app-bottom-nav__group-label:first-child {
+  .app-shell--design-v2
+    .app-bottom-nav__secondary-group:first-child
+    > .app-bottom-nav__group-label:first-child {
     white-space: nowrap;
   }
 
@@ -2575,6 +2673,15 @@ body.public-shell-mode.public-shell-mode:has(.auth-public-shell--design-v2) {
     text-align: left;
   }
 
+  .app-shell--design-v2 .app-bottom-nav__account-entry:hover,
+  .app-shell--design-v2 .app-bottom-nav__account-entry.is-active {
+    background: var(--v2-surface-secondary);
+  }
+
+  .app-shell--design-v2 .app-bottom-nav__account-entry.is-active {
+    box-shadow: inset 3px 0 var(--v2-lime);
+  }
+
   .app-shell--design-v2 .app-bottom-nav__account-entry > span:last-child {
     display: grid;
     min-width: 0;
@@ -2590,8 +2697,12 @@ body.public-shell-mode.public-shell-mode:has(.auth-public-shell--design-v2) {
     border-radius: 50%;
   }
 
-  .app-shell--design-v2 .app-bottom-nav__utility > .app-theme-toggle--nav {
+  .app-shell--design-v2
+    .app-bottom-nav__utility
+    > :where(.app-theme-toggle--nav, .app-bottom-nav__utility-action) {
     display: grid;
+    width: 100%;
+    min-height: 42px;
     grid-template-columns: 18px max-content;
     align-items: center;
     justify-content: center;
@@ -2600,10 +2711,21 @@ body.public-shell-mode.public-shell-mode:has(.auth-public-shell--design-v2) {
     background: transparent;
   }
 
-  .app-shell--design-v2 .app-bottom-nav__utility > .app-theme-toggle--nav .app-bottom-nav__icon {
+  .app-shell--design-v2
+    .app-bottom-nav__utility
+    > :where(.app-theme-toggle--nav, .app-bottom-nav__utility-action)
+    .app-bottom-nav__icon {
     width: 18px;
     height: 24px;
     flex-basis: 18px;
+  }
+
+  .app-shell--design-v2 .app-bottom-nav__utility > .app-bottom-nav__utility-action {
+    grid-column: auto;
+    grid-row: auto;
+    justify-self: stretch;
+    padding: 6px 9px;
+    color: var(--v2-text-secondary);
   }
 
   .app-shell--design-v2 .app-bottom-nav__account-name {
@@ -3451,7 +3573,7 @@ body:has(.standalone-page--design-v2) {
   min-height: 52px;
   padding: var(--v2-space-3);
   border-right: 1px solid var(--v2-border);
-  color: var(--v2-text-secondary);
+  color: var(--v2-text-primary);
   font-size: 0.82rem;
   font-weight: 750;
   line-height: 1.25;
@@ -3486,6 +3608,12 @@ body:has(.standalone-page--design-v2) {
 .profile-settings-nav a:hover {
   background: var(--v2-surface-secondary);
   color: var(--v2-text-primary);
+}
+
+.profile-settings-nav a:focus-visible,
+.app-section--profile summary:focus-visible {
+  outline: 3px solid var(--v2-lime);
+  outline-offset: 3px;
 }
 
 .profile-primary-card,
@@ -3710,6 +3838,9 @@ body:has(.standalone-page--design-v2) {
 }
 
 .profile-form-section__head h3 {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--v2-space-2);
   font-size: 1.1rem;
   letter-spacing: -0.01em;
 }
@@ -4096,10 +4227,19 @@ button.notification-row__main:focus-visible {
   margin: 0;
 }
 
-#profile-notifications,
-.profile-settings-group.profile-settings-group--security {
-  gap: var(--v2-space-3);
-  padding-top: var(--v2-space-4);
+.app-section--profile .profile-settings > details.card-disclosure {
+  gap: 0;
+  padding: var(--v2-space-5);
+}
+
+@media (min-width: 900px) {
+  .app-section--profile .profile-settings > details.card-disclosure:not([open]) {
+    min-block-size: 108px;
+  }
+
+  .app-section--profile .profile-settings > details.card-disclosure:not([open]) > summary {
+    min-block-size: 66px;
+  }
 }
 
 .profile-data-export {
@@ -4186,6 +4326,42 @@ button.notification-row__main:focus-visible {
 
 .auth-method-row .list-row__actions {
   flex-wrap: wrap;
+}
+
+.app-section--profile .auth-method-row .oauth-button {
+  justify-content: flex-start;
+  min-width: min(100%, 240px);
+  min-height: 44px;
+  padding: 7px 12px;
+  border-color: var(--v2-border);
+  border-radius: var(--v2-control-radius);
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+  text-align: left;
+}
+
+.app-section--profile .auth-method-row .oauth-button:hover:not(:disabled) {
+  border-color: var(--v2-border-strong);
+  background: var(--v2-surface-secondary);
+}
+
+.app-section--profile .auth-method-row .oauth-button__label {
+  min-width: 0;
+  flex: 1;
+}
+
+.app-section--profile .auth-method-row .oauth-button__arrow {
+  margin-left: auto;
+  color: var(--v2-accent-text);
+}
+
+.notification-center.profile-disclosure {
+  padding-block: var(--v2-space-3);
+  border-block: 1px solid var(--v2-border);
+}
+
+.notification-center.profile-disclosure > .profile-disclosure__body {
+  margin-top: var(--v2-space-3);
 }
 
 .account-delete-modal__panel {
@@ -6483,6 +6659,18 @@ body.public-shell-mode:has(.public-shell.public-shell--design-v2) {
   .app-section--profile .profile-primary-card,
   .app-section--profile .training-preferences-card {
     padding: var(--v2-space-4);
+  }
+
+  .app-section--profile .profile-settings > details.card-disclosure {
+    padding: var(--v2-space-4);
+  }
+
+  .app-section--profile .profile-settings > details.card-disclosure:not([open]) {
+    min-block-size: 124px;
+  }
+
+  .app-section--profile .profile-settings > details.card-disclosure:not([open]) > summary {
+    min-block-size: 90px;
   }
 
   .app-section--profile .profile-form-grid,

--- a/frontend/tests/e2e/app.spec.ts
+++ b/frontend/tests/e2e/app.spec.ts
@@ -4,8 +4,9 @@ async function openCard(page: Page, title: string) {
   const card = page
     .getByRole('heading', { name: title, exact: true })
     .locator('xpath=ancestor::details[1]');
-  await expect(card).not.toHaveAttribute('open');
-  await card.locator(':scope > summary').click();
+  if ((await card.getAttribute('open')) === null) {
+    await card.locator(':scope > summary').click();
+  }
   await expect(card).toHaveAttribute('open');
 }
 
@@ -1610,8 +1611,11 @@ test('app shell сохраняет композицию и доступност�
       const accountNameSize = await accountName.evaluate((element) => ({
         clientWidth: element.clientWidth,
         scrollWidth: element.scrollWidth,
+        textOverflow: window.getComputedStyle(element).textOverflow,
       }));
-      expect(accountNameSize.scrollWidth).toBeLessThanOrEqual(accountNameSize.clientWidth);
+      expect(accountNameSize.clientWidth).toBeGreaterThan(0);
+      expect(accountNameSize.scrollWidth).toBeGreaterThanOrEqual(accountNameSize.clientWidth);
+      expect(accountNameSize.textOverflow).toBe('ellipsis');
       await expect(logout).toHaveText('Выйти');
     }
     expect(
@@ -1865,6 +1869,9 @@ test('notification settings explain unavailable Telegram and stale targets recov
   await page.getByRole('button', { name: 'Клиент' }).click();
   await openAppDestination(page, 'Профиль');
   await page.getByRole('link', { name: 'Уведомления' }).click();
+  const notificationCenter = page.locator('details.notification-center');
+  await notificationCenter.locator(':scope > summary').click();
+  await expect(notificationCenter).toHaveAttribute('open');
 
   for (const viewport of [
     { width: 360, height: 800 },

--- a/frontend/tests/e2e/app.spec.ts
+++ b/frontend/tests/e2e/app.spec.ts
@@ -13,7 +13,7 @@ type AppDestination = 'Сегодня' | 'Программа' | 'Прогрес�
 
 async function openAppDestination(page: Page, destination: AppDestination) {
   await expect(page.getByRole('navigation', { name: 'Основная навигация' })).toBeVisible();
-  const desktopLabel = destination;
+  const desktopLabel = destination === 'Профиль' ? 'Профиль и настройки' : destination;
   const mobileLabel = destination === 'Профиль' ? 'Профиль и настройки' : destination;
   const directLink = page.getByRole('link', { name: desktopLabel, exact: true });
   for (let index = 0; index < (await directLink.count()); index += 1) {
@@ -1456,23 +1456,10 @@ test('desktop app shell centers the brand lockup and navigation surfaces', async
         return Math.abs(referenceBox.left + referenceBox.width / 2 - (left + right) / 2);
       };
       const lockup = element.querySelector('.yfc-lockup');
-      const account = element.querySelector<HTMLElement>('.app-bottom-nav__account');
-      const accountName = element.querySelector<HTMLElement>('.app-bottom-nav__account-name');
-      const accountRole = element.querySelector<HTMLElement>('.app-bottom-nav__account-role');
       const groupLabel = element.querySelector<HTMLElement>('.app-bottom-nav__group-label');
       const themeButton = element.querySelector('.app-theme-toggle--nav');
+      const logoutButton = element.querySelector('.app-bottom-nav__logout');
       return {
-        accountOffset: centerOffset(account),
-        accountWidth: account?.getBoundingClientRect().width ?? 0,
-        accountNameFits: accountName ? accountName.scrollWidth <= accountName.clientWidth : false,
-        accountTextEdgeOffset:
-          accountName && accountRole
-            ? Math.abs(
-                accountName.getBoundingClientRect().left - accountRole.getBoundingClientRect().left,
-              )
-            : Number.POSITIVE_INFINITY,
-        accountTextAlignment: accountName ? window.getComputedStyle(accountName).textAlign : null,
-        accountNameSize: accountName ? window.getComputedStyle(accountName).fontSize : null,
         buttonOffsets: Array.from(
           element.querySelectorAll<HTMLElement>(
             '.app-bottom-nav__primary .app-bottom-nav__btn, .app-bottom-nav__secondary .app-bottom-nav__btn',
@@ -1498,9 +1485,9 @@ test('desktop app shell centers the brand lockup and navigation surfaces', async
         secondaryLabelSize: window.getComputedStyle(
           element.querySelector('.app-bottom-nav__secondary .app-bottom-nav__label')!,
         ).fontSize,
-        accountRoleSize: window.getComputedStyle(
-          element.querySelector('.app-bottom-nav__account-role')!,
-        ).fontSize,
+        logoutButtonHeight: logoutButton?.getBoundingClientRect().height ?? 0,
+        logoutButtonOffset: centerOffset(logoutButton),
+        logoutButtonWidth: logoutButton?.getBoundingClientRect().width ?? 0,
         themeContentOffset: themeButton
           ? groupCenterOffset(
               Array.from(
@@ -1511,7 +1498,9 @@ test('desktop app shell centers the brand lockup and navigation surfaces', async
           : Number.POSITIVE_INFINITY,
         themeBorderStyle: themeButton ? window.getComputedStyle(themeButton).borderTopStyle : null,
         themeBorderWidth: themeButton ? window.getComputedStyle(themeButton).borderTopWidth : null,
+        themeButtonHeight: themeButton?.getBoundingClientRect().height ?? 0,
         themeButtonOffset: centerOffset(themeButton),
+        themeButtonWidth: themeButton?.getBoundingClientRect().width ?? 0,
         themeLabelSize: window.getComputedStyle(
           element.querySelector('.app-theme-toggle--nav .app-bottom-nav__label')!,
         ).fontSize,
@@ -1533,14 +1522,6 @@ test('desktop app shell centers the brand lockup and navigation surfaces', async
     expect(desktopAlignment.markOffset).toBeLessThanOrEqual(1);
     expect(desktopAlignment.fitnessOffset).toBeLessThanOrEqual(1);
     expect(desktopAlignment.coachOffset).toBeLessThanOrEqual(1);
-    expect(desktopAlignment.accountOffset).toBeLessThanOrEqual(1);
-    expect(desktopAlignment.accountWidth).toBeGreaterThanOrEqual(160);
-    expect(desktopAlignment.accountWidth).toBeLessThanOrEqual(196);
-    expect(desktopAlignment.accountNameFits).toBe(true);
-    expect(desktopAlignment.accountTextEdgeOffset).toBeLessThanOrEqual(1);
-    expect(desktopAlignment.accountTextAlignment).toBe('left');
-    expect(desktopAlignment.accountNameSize).toBe('11.2px');
-    expect(desktopAlignment.accountRoleSize).toBe('11.52px');
     expect(desktopAlignment.groupLabelFits).toBe(true);
     expect(desktopAlignment.labelsFit).toBe(true);
     expect(desktopAlignment.primaryLabelSize).toBe('13px');
@@ -1552,6 +1533,9 @@ test('desktop app shell centers the brand lockup and navigation surfaces', async
     expect(desktopAlignment.themeBorderWidth).toBe('1px');
     expect(desktopAlignment.themeButtonOffset).toBeLessThanOrEqual(1);
     expect(desktopAlignment.themeLabelSize).toBe('12.8px');
+    expect(desktopAlignment.logoutButtonOffset).toBeLessThanOrEqual(1);
+    expect(desktopAlignment.logoutButtonWidth).toBe(desktopAlignment.themeButtonWidth);
+    expect(desktopAlignment.logoutButtonHeight).toBe(desktopAlignment.themeButtonHeight);
     expect(contentAlignment).not.toBeNull();
     expect(Math.abs(contentAlignment!.leftGap - contentAlignment!.rightGap)).toBeLessThanOrEqual(1);
 
@@ -1610,9 +1594,13 @@ test('app shell сохраняет композицию и доступност�
         page.getByRole('button', { name: 'Открыть профиль и настройки', exact: true }),
       ).not.toBeVisible();
       await expect(page.getByRole('link', { name: 'Упражнения', exact: true })).toBeVisible();
-      await expect(page.getByRole('link', { name: 'Профиль', exact: true })).toBeVisible();
+      await expect(
+        page.getByRole('link', { name: 'Профиль и настройки', exact: true }),
+      ).toBeVisible();
+      await expect(page.getByRole('link', { name: 'Профиль', exact: true })).not.toBeAttached();
+      await expect(page.getByText('Ресурсы', { exact: true })).toBeVisible();
       await expect(page.getByRole('link', { name: 'База знаний', exact: true })).not.toBeAttached();
-      const accountName = page.locator('.app-bottom-nav__account-name');
+      const accountName = page.locator('.app-desktop-account-entry .account-identity__name');
       const logout = page
         .getByRole('navigation', { name: 'Основная навигация' })
         .getByRole('button', {
@@ -1624,13 +1612,7 @@ test('app shell сохраняет композицию и доступност�
         scrollWidth: element.scrollWidth,
       }));
       expect(accountNameSize.scrollWidth).toBeLessThanOrEqual(accountNameSize.clientWidth);
-      const [nameBox, logoutBox] = await Promise.all([
-        accountName.boundingBox(),
-        logout.boundingBox(),
-      ]);
-      expect(nameBox).not.toBeNull();
-      expect(logoutBox).not.toBeNull();
-      expect(logoutBox!.y).toBeGreaterThanOrEqual(nameBox!.y + nameBox!.height);
+      await expect(logout).toHaveText('Выйти');
     }
     expect(
       await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
@@ -1684,7 +1666,7 @@ test('desktop sidebar keeps long client names contained and logout reachable', a
   await page.getByRole('button', { name: 'Клиент' }).click();
 
   const navigation = page.getByRole('navigation', { name: 'Основная навигация' });
-  const accountName = navigation.locator('.app-bottom-nav__account-name');
+  const accountName = page.locator('.app-desktop-account-entry .account-identity__name');
   const logout = navigation.getByRole('button', { name: 'Выйти из аккаунта' });
 
   await expect(accountName).toHaveText('Александра Константинопольская-Северная');
@@ -1937,7 +1919,12 @@ test('notification empty and error states keep compact profile rhythm', async ({
   await openAppDestination(page, 'Профиль');
   await page.getByRole('link', { name: 'Уведомления' }).click();
   await expect(page.getByText('Настройки временно недоступны')).toBeVisible();
-  await expect(page.getByText('Уведомлений пока нет')).toBeVisible();
+  const notificationCenter = page.locator('details.notification-center');
+  await expect(
+    notificationCenter.locator('summary').getByText('Уведомлений пока нет'),
+  ).toBeVisible();
+  await notificationCenter.locator(':scope > summary').click();
+  await expect(notificationCenter.locator('.ui-state__title')).toHaveText('Уведомлений пока нет');
 
   const stateHeights = await page
     .locator('#profile-notifications .ui-state')
@@ -2146,6 +2133,7 @@ test('training preferences сохраняют Mobile Web/TMA композици�
     await card.getByText('Упражнения и движения, которых хотите избегать').click();
     await expect(card.getByText(/Это не медицинская оценка/)).toBeVisible();
     if (current.surface === 'tma-mock') {
+      await card.getByText('Расписание', { exact: true }).click();
       const durationMax = card.getByLabel('До, минут');
       await durationMax.fill('75');
       await durationMax.blur();
@@ -2252,12 +2240,11 @@ test('пользователь напрямую включает режим тр
   await page.getByRole('button', { name: 'Клиент' }).click();
   await openAppDestination(page, 'Профиль');
   await openCard(page, 'Тренер и приглашения');
-  await openCard(page, 'Режим тренера');
 
   const activate = page.getByRole('button', { name: 'Включить режим тренера' });
   const trainerCard = page
     .getByRole('heading', { name: 'Режим тренера', exact: true })
-    .locator('xpath=ancestor::details[1]');
+    .locator('xpath=ancestor::*[contains(concat(" ", normalize-space(@class), " "), " card ")][1]');
   await expect(activate).toBeDisabled();
   await trainerCard.screenshot({
     path: '../.artifacts/screenshots/task-70/01-pre-activation-mobile-light.png',
@@ -2317,7 +2304,6 @@ test('пользователь напрямую включает режим тр
   await page.reload();
   await expect(page.locator('html')).toHaveAttribute('data-color-scheme', 'dark');
   await openCard(page, 'Тренер и приглашения');
-  await openCard(page, 'Режим тренера');
   await modeSwitch.getByRole('link', { name: 'Клиенты' }).click();
   await expect(page.getByRole('heading', { name: 'Кабинет тренера' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Клиенты', exact: true }).first()).toHaveAttribute(

--- a/frontend/tests/e2e/profile-settings-simplification.spec.ts
+++ b/frontend/tests/e2e/profile-settings-simplification.spec.ts
@@ -1,0 +1,219 @@
+import { expect, test } from '@playwright/test';
+import { installPlatformApi } from './fixtures/platform-api';
+
+async function openProfileSection(page: import('@playwright/test').Page, name: string) {
+  await page.getByRole('link', { name, exact: true }).click();
+}
+
+test('desktop account entry stays available across primary sections and never opens the mobile sheet', async ({
+  browser,
+}) => {
+  const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  const page = await context.newPage();
+  await installPlatformApi(page, { browserSession: true, authProviders: ['telegram', 'google'] });
+  await page.goto('/app?section=profile');
+
+  const accountEntry = page.getByRole('link', { name: 'Профиль и настройки', exact: true });
+  await expect(accountEntry).toBeVisible();
+  await expect(accountEntry).toHaveClass(/app-desktop-account-entry/);
+  await expect(accountEntry).toHaveAttribute('aria-current', 'page');
+  await expect(
+    page.locator(
+      '.app-bottom-nav__brand + .app-bottom-nav__profile-slot > .app-desktop-account-entry',
+    ),
+  ).toBeVisible();
+  await expect(page.locator('.app-desktop-account-bar')).not.toBeAttached();
+  await expect(page.locator('.app-bottom-nav__account-entry')).not.toBeAttached();
+  await expect(page.getByRole('link', { name: 'Профиль', exact: true })).not.toBeAttached();
+  await expect(page.getByText('Ресурсы', { exact: true })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Упражнения', exact: true })).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'Открыть профиль и настройки', exact: true }),
+  ).not.toBeAttached();
+  await expect(page.locator('#appMorePanel')).not.toBeAttached();
+
+  for (const section of ['today', 'programs', 'nutrition', 'progress']) {
+    await page.goto(`/app?section=${section}`);
+    await expect(accountEntry).toBeVisible();
+    await expect(accountEntry).toHaveAttribute('href', '/app?section=profile');
+    await expect(accountEntry).not.toHaveAttribute('aria-current', 'page');
+  }
+  await page.goto('/app?section=profile');
+  await expect(accountEntry).toHaveAttribute('aria-current', 'page');
+
+  const navigation = page.getByRole('navigation', { name: 'Основная навигация' });
+  const theme = navigation.getByRole('button', { name: /Включить .* тему/ });
+  const logout = navigation.getByRole('button', { name: 'Выйти из аккаунта' });
+  const [themeBox, logoutBox] = await Promise.all([theme.boundingBox(), logout.boundingBox()]);
+  expect(themeBox).not.toBeNull();
+  expect(logoutBox).not.toBeNull();
+  expect(Math.abs(themeBox!.width - logoutBox!.width)).toBeLessThanOrEqual(1);
+  expect(Math.abs(themeBox!.height - logoutBox!.height)).toBeLessThanOrEqual(1);
+
+  const cardHeights = await page
+    .locator('.profile-settings > details.card-disclosure')
+    .evaluateAll((cards) => cards.map((card) => card.getBoundingClientRect().height));
+  expect(Math.max(...cardHeights) - Math.min(...cardHeights)).toBeLessThanOrEqual(1);
+
+  await accountEntry.click();
+  await expect(page).toHaveURL(/\/app\?section=profile$/);
+  await expect(page.locator('#appMorePanel')).not.toBeAttached();
+  await context.close();
+});
+
+test('mobile sheet closes cleanly on 899 to 900 resize and stays closed on return', async ({
+  browser,
+}) => {
+  const context = await browser.newContext({
+    viewport: { width: 899, height: 900 },
+    hasTouch: true,
+  });
+  const page = await context.newPage();
+  await installPlatformApi(page, { browserSession: true, authProviders: ['telegram'] });
+  await page.goto('/app?section=today');
+
+  const mobileTrigger = page.getByRole('button', {
+    name: 'Открыть профиль и настройки',
+    exact: true,
+  });
+  await mobileTrigger.click();
+  await expect(page.getByRole('dialog', { name: 'Профиль и настройки' })).toBeVisible();
+  await expect(page.locator('body')).toHaveCSS('position', 'fixed');
+
+  await page.setViewportSize({ width: 900, height: 900 });
+  await expect(page.locator('#appMorePanel')).not.toBeAttached();
+  await expect(page.locator('body')).not.toHaveCSS('position', 'fixed');
+  await expect(page.getByRole('link', { name: 'Профиль и настройки', exact: true })).toBeFocused();
+
+  await page.setViewportSize({ width: 899, height: 900 });
+  await expect(mobileTrigger).toBeVisible();
+  await expect(mobileTrigger).toHaveAttribute('aria-expanded', 'false');
+  await expect(page.locator('#appMorePanel')).not.toBeAttached();
+  await context.close();
+});
+
+test('profile stays compact while disclosures, icons and shared provider actions remain usable', async ({
+  browser,
+}) => {
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    hasTouch: true,
+  });
+  const page = await context.newPage();
+  await installPlatformApi(page, {
+    browserSession: true,
+    authProviders: ['telegram'],
+  });
+  await page.route('**/api/v1/public/config', (route) =>
+    route.fulfill({
+      json: {
+        app_env: 'test',
+        enable_dev_auth: true,
+        enable_web_auth: true,
+        enable_email_auth: false,
+        telegram_bot_username: 'fit_test_bot',
+        oauth_providers: ['google', 'yandex'],
+      },
+    }),
+  );
+  await page.goto('/app?section=profile');
+
+  await expect(page.locator('.profile-identity')).not.toBeAttached();
+  await expect(page.locator('.app-desktop-account-entry')).not.toBeVisible();
+  await expect(
+    page.getByRole('button', { name: 'Открыть профиль и настройки', exact: true }),
+  ).toBeVisible();
+  const iconContract = [
+    ['Личные данные', 'nav-profile'],
+    ['Цели и параметры', 'nav-plan'],
+    ['Тренер и приглашения', 'nav-coach'],
+    ['Уведомления', 'nav-today'],
+    ['Доступ и безопасность', 'permission-denied'],
+  ] as const;
+  const profileNavigation = page.getByRole('navigation', { name: 'Разделы профиля' });
+  for (const [name, icon] of iconContract) {
+    await expect(profileNavigation.getByRole('link', { name, exact: true })).toBeVisible();
+    await expect(
+      profileNavigation.getByRole('link', { name, exact: true }).locator(`[data-icon="${icon}"]`),
+    ).toBeVisible();
+  }
+
+  const majorCards = page.locator('.profile-settings > details.card-disclosure');
+  expect(await majorCards.count()).toBeGreaterThanOrEqual(5);
+  for (const card of await majorCards.all()) await expect(card).not.toHaveAttribute('open');
+
+  await openProfileSection(page, 'Цели и параметры');
+  const profileCard = page.locator('#profile-personal');
+  await expect(profileCard).toHaveAttribute('open');
+  const saveProfile = page.getByRole('button', { name: 'Сохранить изменения' });
+  await expect(saveProfile).toBeDisabled();
+  await page.getByLabel('Имя').fill('Анна Петрова-Северная');
+  await expect(saveProfile).toBeEnabled();
+
+  const trainingPreferences = page.locator('#profile-training-preferences');
+  await trainingPreferences.locator(':scope > summary').press('Enter');
+  await expect(trainingPreferences).toHaveAttribute('open');
+  const schedule = trainingPreferences.getByText('Расписание', { exact: true }).locator('..');
+  const scheduleDetails = schedule.locator('xpath=ancestor::details[1]');
+  await expect(scheduleDetails).not.toHaveAttribute('open');
+  const scheduleSummary = scheduleDetails.locator(':scope > summary');
+  await scheduleSummary.focus();
+  await expect(scheduleSummary).toBeFocused();
+  await scheduleSummary.press('Enter');
+  await expect(scheduleDetails).toHaveAttribute('open');
+
+  await openProfileSection(page, 'Уведомления');
+  const notificationCenter = page
+    .getByText('Центр уведомлений', { exact: true })
+    .locator('xpath=ancestor::details[1]');
+  await expect(notificationCenter).not.toHaveAttribute('open');
+  await notificationCenter.locator(':scope > summary').focus();
+  await page.keyboard.press('Space');
+  await expect(notificationCenter).toHaveAttribute('open');
+
+  await openProfileSection(page, 'Доступ и безопасность');
+  await page.getByText('Способы входа', { exact: true }).click();
+  const googleAction = page.getByRole('button', { name: 'Привязать Google' });
+  await expect(googleAction).toHaveClass(/oauth-button--google/);
+  await expect(googleAction.locator('.oauth-button__icon img')).toBeVisible();
+  await context.close();
+});
+
+test('captures matching compact Profile state in light and dark themes', async ({ browser }) => {
+  for (const surface of [
+    { name: 'mobile-390x844', width: 390, height: 844, hasTouch: true, fullPage: false },
+    { name: 'desktop-1280x900', width: 1280, height: 900, hasTouch: false, fullPage: true },
+  ] as const) {
+    for (const theme of ['light', 'dark'] as const) {
+      const context = await browser.newContext({
+        viewport: { width: surface.width, height: surface.height },
+        hasTouch: surface.hasTouch,
+        colorScheme: theme,
+      });
+      await context.addInitScript((selectedTheme) => {
+        localStorage.setItem('app-theme', selectedTheme);
+      }, theme);
+      const page = await context.newPage();
+      await installPlatformApi(page, {
+        browserSession: true,
+        authProviders: ['telegram', 'google'],
+      });
+      await page.goto('/app?section=profile');
+      await expect(page.locator('html')).toHaveAttribute('data-color-scheme', theme);
+      await expect(page.getByRole('heading', { name: 'Профиль и настройки' })).toBeVisible();
+      await expect(page.locator('.profile-settings > details.card-disclosure')).toHaveCount(5);
+      if (surface.hasTouch) {
+        await expect(page.locator('.profile-identity')).not.toBeAttached();
+        await expect(page.locator('.app-desktop-account-entry')).not.toBeVisible();
+      } else {
+        await expect(page.locator('.app-desktop-account-entry')).toBeVisible();
+      }
+      await expect(page.locator('.profile-settings > details[open]')).toHaveCount(0);
+      await page.screenshot({
+        path: `../.artifacts/screenshots/task-122/profile-compact-${surface.name}-${theme}.png`,
+        fullPage: surface.fullPage,
+      });
+      await context.close();
+    }
+  }
+});

--- a/frontend/tests/e2e/tma-smoke.spec.ts
+++ b/frontend/tests/e2e/tma-smoke.spec.ts
@@ -374,6 +374,9 @@ test('notification center keeps Mobile Web/TMA parity, unread geometry and an ex
 
   for (const page of [tmaPage, mobilePage]) {
     await expect(page.getByRole('heading', { name: 'Каналы' })).toBeVisible();
+    const notificationCenter = page.locator('details.notification-center');
+    await expect(notificationCenter.locator(':scope > summary')).toContainText('Непрочитанные · 2');
+    await notificationCenter.locator(':scope > summary').click();
     await expect(page.getByRole('heading', { name: 'Непрочитанные · 2' })).toBeVisible();
     await expect(page.getByText('Комментарий тренера к тренировке')).toBeVisible();
     await expectNoHorizontalOverflow(page);
@@ -414,7 +417,9 @@ test('notification center keeps Mobile Web/TMA parity, unread geometry and an ex
   await expect.poll(async () => (await tma.state()).backButton.visible).toBe(true);
   await tma.clickBack();
   await expect(tmaPage).toHaveURL('/app?section=profile#profile-notifications');
-  await expect(tmaPage.getByRole('heading', { name: 'Всё прочитано' })).toBeVisible();
+  await expect(tmaPage.locator('details.notification-center > summary')).toContainText(
+    'Всё прочитано',
+  );
 });
 
 test('program history keeps current block, readable revisions and workout return in Mobile Web/TMA parity', async ({

--- a/frontend/tests/unit/app/AppShell.test.tsx
+++ b/frontend/tests/unit/app/AppShell.test.tsx
@@ -3,6 +3,24 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppShell } from '../../../src/app/AppShell';
 
 const logout = vi.fn();
+function stubViewport(initialWidth: number, reducedMotion = false) {
+  let width = initialWidth;
+  Object.defineProperty(window, 'innerWidth', { configurable: true, get: () => width });
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    get matches() {
+      if (query === '(max-width: 899px)') return width < 900;
+      if (query === '(prefers-reduced-motion: reduce)') return reducedMotion;
+      return false;
+    },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  }));
+  return (nextWidth: number) => {
+    width = nextWidth;
+    window.dispatchEvent(new Event('resize'));
+  };
+}
+
 function finishAnimation(element: Element, animationName: string) {
   const event = new Event('animationend', { bubbles: true });
   Object.defineProperty(event, 'animationName', { value: animationName });
@@ -44,6 +62,7 @@ describe('AppShell', () => {
     navigation.search = '';
     logout.mockClear();
     vi.unstubAllGlobals();
+    stubViewport(1280);
     delete window.Telegram;
   });
 
@@ -67,6 +86,7 @@ describe('AppShell', () => {
     expect(screen.queryByRole('button', { name: 'Ещё' })).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Тренер' })).toHaveAttribute('aria-current', 'page');
     expect(screen.queryByRole('link', { name: 'Админ-панель' })).not.toBeInTheDocument();
+    expect(screen.getByText('Ресурсы')).toBeInTheDocument();
     expect(screen.getByText('Михаил')).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Выйти из аккаунта' }));
@@ -88,6 +108,7 @@ describe('AppShell', () => {
   });
 
   it('открывает доступное mobile-меню с secondary navigation и завершает exit после возврата фокуса', async () => {
+    stubViewport(390);
     navigation.path = '/app';
     render(<AppShell section="profile">Содержимое</AppShell>);
 
@@ -127,11 +148,7 @@ describe('AppShell', () => {
   });
 
   it('открывает и закрывает mobile-меню сразу при reduced motion', () => {
-    vi.stubGlobal('matchMedia', () => ({
-      addEventListener: vi.fn(),
-      matches: true,
-      removeEventListener: vi.fn(),
-    }));
+    stubViewport(390, true);
     navigation.path = '/app';
     render(<AppShell section="today">Содержимое</AppShell>);
 
@@ -181,6 +198,7 @@ describe('AppShell', () => {
   });
 
   it('не показывает библиотеку знаний в Web или Telegram Mini App navigation', () => {
+    stubViewport(390);
     navigation.path = '/app';
     const web = render(<AppShell section="today">Содержимое</AppShell>);
 
@@ -198,7 +216,7 @@ describe('AppShell', () => {
 
   it('показывает тематическую заглушку, если аватар отсутствует или не загрузился', () => {
     const { container, rerender } = render(<AppShell>Содержимое</AppShell>);
-    const avatar = container.querySelector('.app-bottom-nav__avatar');
+    const avatar = container.querySelector('.app-desktop-account-entry__avatar');
 
     expect(avatar).toHaveTextContent(/🏋️|💪|🏃|🚴|🥗|⚡|🎯|🔥/);
 
@@ -210,5 +228,63 @@ describe('AppShell', () => {
     fireEvent.error(image!);
     expect(avatar?.querySelector('img')).not.toBeInTheDocument();
     expect(avatar).toHaveTextContent(/🏋️|💪|🏃|🚴|🥗|⚡|🎯|🔥/);
+  });
+
+  it('использует account row под брендом как единственный desktop-вход в профиль без dialog', () => {
+    navigation.path = '/app';
+    render(<AppShell section="profile">Содержимое</AppShell>);
+
+    const profileLink = screen.getByRole('link', { name: 'Профиль и настройки' });
+    expect(profileLink).toHaveAttribute('href', '/app?section=profile');
+    expect(profileLink).toHaveAttribute('aria-current', 'page');
+    expect(profileLink.closest('.app-bottom-nav__profile-slot')).toBeInTheDocument();
+    expect(profileLink.closest('nav')).toHaveAccessibleName('Основная навигация');
+    expect(screen.queryByRole('link', { name: /^Профиль$/ })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Открыть профиль и настройки' }),
+    ).not.toBeInTheDocument();
+    expect(document.getElementById('appMorePanel')).not.toBeInTheDocument();
+  });
+
+  it('закрывает mobile sheet и переносит focus в desktop account row на breakpoint 900px', async () => {
+    const resize = stubViewport(899, true);
+    navigation.path = '/app';
+    render(<AppShell section="today">Содержимое</AppShell>);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Открыть профиль и настройки' }));
+    expect(screen.getByRole('dialog', { name: 'Профиль и настройки' })).toBeInTheDocument();
+    expect(document.body.style.position).toBe('fixed');
+
+    resize(900);
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(document.body.style.position).toBe('');
+    await waitFor(() =>
+      expect(screen.getByRole('link', { name: 'Профиль и настройки' })).toHaveFocus(),
+    );
+
+    resize(899);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Открыть профиль и настройки' })).toHaveAttribute(
+        'aria-expanded',
+        'false',
+      ),
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('не перехватывает focus при обычном desktop resize без открытого sheet', async () => {
+    const resize = stubViewport(900);
+    render(
+      <AppShell section="today">
+        <button type="button">Контроль focus</button>
+      </AppShell>,
+    );
+
+    const control = screen.getByRole('button', { name: 'Контроль focus' });
+    control.focus();
+    resize(1100);
+
+    await waitFor(() => expect(control).toHaveFocus());
   });
 });

--- a/frontend/tests/unit/features/account/NotificationsPanel.test.tsx
+++ b/frontend/tests/unit/features/account/NotificationsPanel.test.tsx
@@ -104,7 +104,11 @@ describe('NotificationsPanel', () => {
   it('разделяет каналы и открывает canonical destination через server resolver', async () => {
     const onNavigate = renderPanel();
 
-    expect(await screen.findByText('Непрочитанные · 2')).toBeInTheDocument();
+    expect((await screen.findAllByText('Непрочитанные · 2')).length).toBeGreaterThan(0);
+    const notificationCenter = screen.getByText('Центр уведомлений').closest('details');
+    expect(notificationCenter).not.toHaveAttribute('open');
+    fireEvent.click(screen.getByText('Центр уведомлений'));
+    expect(notificationCenter).toHaveAttribute('open');
     expect(screen.getByText('В приложении')).toBeInTheDocument();
     expect(screen.getByText('Предстоящая тренировка')).toBeInTheDocument();
     expect(screen.queryByText('Комментарий тренера')).not.toBeInTheDocument();

--- a/frontend/tests/unit/features/profile/TrainingPreferencesForm.test.tsx
+++ b/frontend/tests/unit/features/profile/TrainingPreferencesForm.test.tsx
@@ -118,6 +118,7 @@ describe('TrainingPreferencesForm', () => {
       'href',
       '/app?section=programs',
     );
+    expect(screen.getByText('Расписание').closest('details')).not.toHaveAttribute('open');
 
     const preferred = screen
       .getByText('Предпочитаемые упражнения')


### PR DESCRIPTION
## Summary
- simplify Profile sections with icons and compact disclosures
- reuse shared provider buttons and shared account identity
- keep mobile account sheet while moving desktop profile identity below the sidebar logo
- balance theme/logout actions and preserve responsive focus behavior

## Verification
- frontend build and lint passed
- 41 targeted unit tests passed
- Task 122, AppShell, account lifecycle and mocked TMA E2E passed
- owner visual checkpoint approved