### PR TITLE
[Task 127A] Automate post-deploy task closeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,7 +370,12 @@ tracked logical commit, completed implementation/review/QA/final verification, z
 scoped worktree and no mandatory owner/human/visual gate. The agent must monitor required check
 `checks`, exact merged-dev push CI, post-merge CI and deployment to terminal success. The narrow
 deployed-sync GitHub App then fast-forwards `dev` to the exact successful current `master`; ordinary
-direct user/PAT push remains forbidden. Any failed gate stops the backlog sequence fail-closed.
+direct user/PAT push remains forbidden. После exact ref sync normal post-deploy closeout без нового
+owner prompt выполняет controller `finish` из canonical `dev` worktree, безопасный cleanup exact
+matching clean task worktree и merged local branch, archive task и rebuild/check backlog manifests.
+Dirty/interrupted/unique/ambiguous state, divergence refs или archive/check error останавливают
+closeout fail-closed без `--force` и с сохранением данных. Any failed gate stops the backlog sequence
+fail-closed.
 
 Any exceptional operation that bypasses this path—history rewrite, direct/force push, manual
 production command, infrastructure recovery or deployment of a SHA other than the current merged
@@ -411,6 +416,9 @@ Before declaring tracked backlog implementation complete:
 - confirm every new or changed `MEDIUM/LOW` is synchronized in
   `codex-backlog/bugs/FINDINGS.md` and cite its ID/status in the final report;
 - create the task's one logical commit only after successful applicable verification;
+- after a successful normal production deploy and exact deployed `master -> dev` sync, finish the
+  controller lease, automatically clean only the exact safe task worktree/local branch, archive the
+  task and validate backlog manifests without another generic owner confirmation;
 - do not start the next task.
 
 For backlog tasks, follow the current `TASK_EXECUTION_LIFECYCLE.md` final-report contract.

--- a/codex-backlog/GLOBAL_RULES.md
+++ b/codex-backlog/GLOBAL_RULES.md
@@ -87,7 +87,9 @@ gate, evidence и точки остановки в task-файле.
   владельцу и строго последовательно: `task branch -> task PR dev -> exact-head checks -> serial
   merge -> exact merged-dev push CI -> PR master -> required PR checks -> exact-head merge ->
   post-merge CI -> automatic production deploy -> terminal success -> narrow App sync dev to exact
-  deployed master`. Direct feature push в `dev` и direct push в `master` запрещены.
+  deployed master -> automatic controller finish/clean task worktree and merged local branch ->
+  archive task -> rebuild/check backlog manifests -> terminal report`. Direct feature push в `dev`
+  и direct push в `master` запрещены.
 - Release flow является **strictly serial**. При release lease/open `dev -> master` PR task merge и
   любой другой update `dev` запрещены. Если требуется новая task integration, release PR сначала
   закрывается, candidate обновляется от current `dev`, повторяет exact-head checks и serial merge.
@@ -103,6 +105,12 @@ gate, evidence и точки остановки в task-файле.
 controller/lifecycle после terminal success автоматически продолжает применимые review, QA,
 commit, task PR, serial integration, `dev` CI и normal release без дополнительного owner prompt.
 Тишина владельца не является gate. Следующая product task автоматически не запускается.
+
+После terminal successful normal deploy и exact deployed `master -> dev` sync post-deploy closeout
+тоже не создаёт owner gate: `finish` из canonical `dev` worktree автоматически удаляет только exact
+matching clean task worktree и merged local branch без `--force`, затем canonical archive helper
+переносит task в `tasks/done/` и rebuild/check manifests. Dirty/interrupted/unique/ambiguous state,
+divergence refs или archive/check error останавливают closeout fail-closed с сохранением данных.
 
 Direct push в `master` запрещён. Direct feature push в `dev` также запрещён; единственное bypass
 исключение — exact deployed `master -> dev` sync узкого owner-approved GitHub App.

--- a/codex-backlog/TASK_EXECUTION_LIFECYCLE.md
+++ b/codex-backlog/TASK_EXECUTION_LIFECYCLE.md
@@ -316,6 +316,15 @@ Task является `AUTO_RELEASE_ELIGIBLE`, только если однов�
    не запускает повторный PR/deploy и не задерживает финализацию уже успешной task. Исключение - если
    sync неожиданно изменил tree/content вместо pure fast-forward; тогда считать это новым изменением,
    остановиться и разобраться до следующей task.
+10. после подтверждения exact ref sync выполнить `git fetch --prune origin`, перейти в canonical
+    `dev` worktree и запустить `scripts/task_session.py finish <ID>`. `finish` без отдельного owner
+    prompt удаляет только exact matching clean task worktree и merged local branch. Dirty state,
+    Git operation, unique commits, ambiguous/mismatched state или divergence refs останавливают
+    closeout fail-closed без `--force` и без очистки сохранившихся данных;
+11. после successful `finish` автоматически перенести canonical task-файл через
+    `scripts/archive_backlog_task.py archive`, затем выполнить `scripts/archive_backlog_task.py
+    check`. Ошибка archive/manifest check является terminal closeout blocker и не скрывается;
+12. сформировать terminal final report только после successful finish, archive и manifest check.
 
 Canonical sequencing для нового release candidate:
 
@@ -331,6 +340,8 @@ task branch -> PR dev -> exact-head checks
   -> WAIT production deploy exact master SHA: success
   -> narrow GitHub App fast-forward/sync dev to same deployed SHA
   -> verify refs
+  -> finish: clean worktree + merged local branch cleanup
+  -> archive task + rebuild/check manifests
   -> DONE
 ```
 

--- a/docs/task-branch-integration.md
+++ b/docs/task-branch-integration.md
@@ -1,6 +1,6 @@
 # Task-ветки, worktree и сериализованная интеграция в `dev`
 
-Статус ADR: **принято для repository contract; live enforcement ожидает owner checkpoint**.
+Статус ADR: **принято и действует в repository contract и live GitHub enforcement**.
 
 ## Контекст и решение
 
@@ -69,9 +69,13 @@ file + atomic replace под глобальным `state.lock`. Повреждё
 обязательное состояние являются blocker; controller не удаляет их автоматически.
 
 Task lease содержит task ID/path, branch, абсолютный worktree path, base SHA, mode, timestamps,
-lifecycle state и session label без secrets. `finish` никогда не удаляет branch/worktree: он только
-завершает lease после exact merge SHA и terminal successful `dev` push-CI. Cleanup выполняется лишь
-после отдельного owner confirmation и повторной проверки dirty/unique state.
+lifecycle state и session label без secrets. После terminal successful production deploy и exact
+deployed `master -> dev` sync команда `finish` запускается из canonical `dev` worktree. Она
+автоматически удаляет только exact matching clean task worktree и локальную task branch, уже
+содержащуюся в synchronized `origin/dev`, обычными `git worktree remove` и `git branch -d` без
+`--force`. Dirty state, Git operation, unique commits, duplicate/mismatched branch/worktree,
+divergence refs или запуск из удаляемого worktree останавливают closeout с точным blocker; lease и
+сохранившиеся данные не очищаются.
 
 ## Машинно проверяемые task metadata
 
@@ -114,7 +118,7 @@ python scripts/task_session.py enqueue-integration 119 --pr 123
 python scripts/task_session.py prepare-integration 119
 python scripts/task_session.py withdraw-integration 119 --reason "blocking review fix"
 python scripts/task_session.py complete-integration 119 --merge-sha <exact-dev-merge-sha>
-python scripts/task_session.py finish 119
+python scripts/task_session.py --repo <canonical-dev-worktree> finish 119
 ```
 
 `start` печатает абсолютный worktree, branch/base SHA, canonical task path, metadata, запреты и
@@ -134,7 +138,14 @@ recovery command. Task-файл не копируется в worktree: owner-loc
 7. `prepare-integration` выдаёт eligibility только queue head при current `dev` и exact successful
    checks; создаёт global integration lease.
 8. Merge выполняется ровно один. Controller ждёт exact merge SHA и successful push-CI `dev`.
-9. `complete-integration` открывает следующего candidate. `finish` освобождает task lease без cleanup.
+9. `complete-integration` открывает следующего candidate, но сохраняет task lease до production
+   closeout.
+10. После terminal successful deploy и exact deployed `master -> dev` sync выполнить `git fetch
+    --prune origin`, затем из canonical `dev` worktree запустить `finish`. Controller автоматически
+    удалит только проверенные clean task worktree и merged local branch.
+11. Без отдельного owner prompt выполнить `scripts/archive_backlog_task.py archive`, затем
+    `scripts/archive_backlog_task.py check` и только после успешной проверки сформировать terminal
+    final report.
 
 При release lease/open `dev -> master` PR task PR могут оставаться open/draft, но merge и branch
 update в `dev` запрещены.
@@ -210,8 +221,8 @@ branch delete или force-push.
 - dirty/index/Git operation → `DIRTY_NEEDS_OWNER`;
 - unique commits → `RECOVERY_ANCHOR`;
 - branch/worktree без lease или несколько совпадений → `RECOVERY_REQUIRED`;
-- detached clean state без unique commits → потенциальный `SAFE_TO_REMOVE`, но удаление всё равно
-  требует owner confirmation;
+- detached clean state без active exact task lease → потенциальный `SAFE_TO_REMOVE`, но не входит в
+  automatic `finish` и требует отдельной recovery-классификации;
 - corrupted/stale lease/lock → blocker с точным path.
 
 Main `dev` ahead/behind/dirty блокирует `start`. Candidate после чужого merge становится stale и

--- a/scripts/task_session.py
+++ b/scripts/task_session.py
@@ -227,6 +227,14 @@ class GitRepository:
         output = self.git("log", "--oneline", "HEAD", "--not", "--all", cwd=path, check=False)
         return output.splitlines() if output else []
 
+    def remove_worktree(self, path: Path) -> None:
+        canonical = self.canonical_dev_worktree().path
+        self.git("worktree", "remove", "--", str(path), cwd=canonical)
+
+    def delete_merged_branch(self, branch: str) -> None:
+        canonical = self.canonical_dev_worktree().path
+        self.git("branch", "--delete", "--", branch, cwd=canonical)
+
     def upstream(self, branch: str) -> str | None:
         completed = _run(
             [
@@ -1449,23 +1457,118 @@ class TaskController:
         history = self.store.read_json(history_path)
         if lease is None or history is None:
             raise TaskSessionError("finish requires task lease and completed integration history")
+        if lease.get("task_id") != expected:
+            raise TaskSessionError("finish task lease does not match the requested task ID")
+        if history.get("task_id") != expected or history.get("state") != "dev-ci-success":
+            raise TaskSessionError(
+                "finish integration history does not match the requested terminal task state"
+            )
         if lease.get("lifecycle_state") != "dev-ci-success":
             raise TaskSessionError("finish requires terminal dev-ci-success state")
-        recovery = self.recover(expected)
-        cleanup_allowed = not any(
-            item["dirty"] or item["operation_issues"] or item["unique_commits"]
-            for item in recovery["worktrees"]
-        )
+
+        branch = str(lease.get("branch", ""))
+        worktree_path = Path(str(lease.get("worktree", ""))).resolve()
+        expected_head = str(history.get("head_sha", ""))
+        merge_sha = str(history.get("merge_sha", ""))
+        canonical = self.repository.canonical_dev_worktree().path
+        if self.repository.current_worktree != canonical:
+            raise TaskSessionError("finish cleanup must run from the canonical dev worktree")
+        if worktree_path == canonical:
+            raise TaskSessionError("finish cleanup refuses to remove the canonical dev worktree")
+        expected_parent = (canonical / ".artifacts" / "worktrees").resolve()
+        if worktree_path.parent != expected_parent:
+            raise TaskSessionError(
+                "finish cleanup worktree is outside the canonical task worktree directory"
+            )
+        if task_id_from_branch(branch) != expected:
+            raise TaskSessionError("finish cleanup branch does not match the task lease")
+        if not expected_head or expected_head != lease.get("ready_head_sha"):
+            raise TaskSessionError("finish cleanup head does not match integration-ready evidence")
+        if not merge_sha:
+            raise TaskSessionError("finish cleanup requires an exact integration merge SHA")
+
+        origin_dev = self.repository.ref("origin/dev")
+        origin_master = self.repository.ref("origin/master")
+        if origin_dev != origin_master:
+            raise TaskSessionError(
+                "finish cleanup requires exact deployed master -> dev sync: "
+                f"origin/dev {origin_dev} != origin/master {origin_master}"
+            )
+        if not self.repository.is_ancestor(merge_sha, origin_dev):
+            raise TaskSessionError(
+                "finish cleanup integration merge is not contained in synchronized origin/dev"
+            )
+
+        matching_branches = [
+            line.removeprefix("refs/heads/")
+            for line in self.repository.git(
+                "for-each-ref", "--format=%(refname)", f"refs/heads/task/{expected}-*"
+            ).splitlines()
+            if line
+        ]
+        matching_worktrees = [
+            item
+            for item in self.repository.worktrees()
+            if item.path == worktree_path
+            or (item.branch and item.branch.startswith(f"task/{expected}-"))
+        ]
+        if matching_branches != [branch] or len(matching_worktrees) != 1:
+            raise TaskSessionError(
+                "finish cleanup requires exactly one matching task branch and worktree"
+            )
+        worktree = matching_worktrees[0]
+        if worktree.path != worktree_path or worktree.branch != branch:
+            raise TaskSessionError("finish cleanup worktree does not exactly match the task lease")
+        branch_head = self.repository.ref(branch)
+        if branch_head != expected_head or worktree.head != expected_head:
+            raise TaskSessionError("finish cleanup branch/worktree head changed after integration")
+
+        dirty = self.repository.status(worktree_path)
+        operations = self.repository.operation_issues(worktree_path)
+        unique_commits = self.repository.unique_commits(branch)
+        if dirty:
+            raise TaskSessionError(
+                f"finish cleanup refuses dirty task worktree {worktree_path}: {dirty}"
+            )
+        if operations:
+            raise TaskSessionError(
+                f"finish cleanup refuses interrupted Git operation in {worktree_path}: {operations}"
+            )
+        if unique_commits:
+            raise TaskSessionError(
+                f"finish cleanup refuses task branch with unique commits: {unique_commits}"
+            )
+
+        upstream = self.repository.upstream(branch)
+        if upstream is not None:
+            ahead, behind = self.repository.ahead_behind(branch, upstream)
+            if ahead or behind:
+                raise TaskSessionError(
+                    "finish cleanup refuses divergent task branch/upstream: "
+                    f"ahead={ahead}, behind={behind}"
+                )
+
+        self.repository.remove_worktree(worktree_path)
+        if self.repository.ref(branch) != expected_head:
+            raise TaskSessionError(
+                "finish cleanup branch changed after worktree removal; local branch was preserved"
+            )
+        self.repository.delete_merged_branch(branch)
         with self.store.lock():
             history["state"] = "finished"
             history["finished_at"] = utc_now()
-            history["cleanup_allowed_after_owner_confirmation"] = cleanup_allowed
+            history["cleanup"] = {
+                "worktree": str(worktree_path),
+                "branch": branch,
+                "performed_at": history["finished_at"],
+            }
             StateStore.replace_json(history_path, history)
             lease_path.unlink()
         return {
             "history": history,
-            "cleanup_performed": False,
-            "cleanup_allowed_after_owner_confirmation": cleanup_allowed,
+            "cleanup_performed": True,
+            "removed_worktree": str(worktree_path),
+            "deleted_local_branch": branch,
         }
 
     def release_freeze(self, action: str, *, sha: str, session_label: str) -> dict[str, Any]:

--- a/tests/test_task_session.py
+++ b/tests/test_task_session.py
@@ -969,21 +969,159 @@ def test_recover_is_read_only_and_preserves_dirty_unique_task_state(
     assert (worktree / "dirty.txt").exists()
 
 
-def test_finish_never_performs_branch_or_worktree_cleanup(repository: tuple[Path, Any]) -> None:
+def _prepare_finish_state(
+    repository: tuple[Path, Any], task_id: str
+) -> tuple[Any, Path, str, str, str]:
     root, git_repository = repository
+    _write_task(root, task_id, "automatic-closeout")
     base_sha = git_repository.ref("origin/dev")
     controller = task_session.TaskController(git_repository, github=FakeGitHub(base_sha))
-    _task_lease(controller, "402", root, base_sha)
-    lease_path = controller.store.task_lease_path("402")
+    started = controller.start(task_id, owner_launch=True, session_label="pytest", offline=True)
+    worktree = Path(started["lease"]["worktree"])
+    branch = str(started["lease"]["branch"])
+    (worktree / "closeout.txt").write_text("merged task\n", encoding="utf-8")
+    _git(worktree, "add", "closeout.txt")
+    _git(worktree, "commit", "-m", f"[Task {task_id}] test: synthetic closeout")
+    head_sha = _git(worktree, "rev-parse", "HEAD")
+    _git(root, "merge", "--no-ff", branch, "-m", f"[Task {task_id}] merge synthetic task")
+    merge_sha = _git(root, "rev-parse", "HEAD")
+    _git(root, "branch", "-f", "master", merge_sha)
+    _git(root, "push", "origin", "dev", "master")
+
+    lease_path = controller.store.task_lease_path(task_id)
     lease = controller.store.read_json(lease_path)
     lease["lifecycle_state"] = "dev-ci-success"
+    lease["ready_head_sha"] = head_sha
     controller.store.replace_json(lease_path, lease)
     controller.store.create_json(
-        controller.store.history / "task-402.json",
-        {"task_id": "402", "state": "dev-ci-success", "merge_sha": base_sha},
+        controller.store.history / f"task-{task_id}.json",
+        {
+            "task_id": task_id,
+            "state": "dev-ci-success",
+            "head_sha": head_sha,
+            "merge_sha": merge_sha,
+        },
     )
+    return controller, worktree, branch, head_sha, merge_sha
+
+
+def test_finish_removes_exact_clean_merged_worktree_and_local_branch(
+    repository: tuple[Path, Any],
+) -> None:
+    controller, worktree, branch, _, _ = _prepare_finish_state(repository, "402")
+    lease_path = controller.store.task_lease_path("402")
 
     result = controller.finish("402")
 
-    assert result["cleanup_performed"] is False
+    assert result["cleanup_performed"] is True
+    assert result["removed_worktree"] == str(worktree.resolve())
+    assert result["deleted_local_branch"] == branch
+    assert not worktree.exists()
+    assert not controller.repository.ref_exists(branch)
     assert not lease_path.exists()
+    history = controller.store.read_json(controller.store.history / "task-402.json")
+    assert history["state"] == "finished"
+    assert history["cleanup"]["branch"] == branch
+    assert "cleanup_allowed_after_owner_confirmation" not in history
+
+
+def test_finish_refuses_dirty_worktree_and_preserves_state(
+    repository: tuple[Path, Any],
+) -> None:
+    controller, worktree, branch, _, _ = _prepare_finish_state(repository, "403")
+    (worktree / "uncommitted.txt").write_text("preserve me\n", encoding="utf-8")
+
+    with pytest.raises(task_session.TaskSessionError, match="refuses dirty task worktree"):
+        controller.finish("403")
+
+    assert worktree.is_dir()
+    assert controller.repository.ref_exists(branch)
+    assert controller.store.task_lease_path("403").exists()
+    history = controller.store.read_json(controller.store.history / "task-403.json")
+    assert history["state"] == "dev-ci-success"
+
+
+def test_finish_refuses_unique_commits_and_preserves_state(
+    repository: tuple[Path, Any],
+) -> None:
+    controller, worktree, branch, _, _ = _prepare_finish_state(repository, "404")
+    (worktree / "unique.txt").write_text("preserve unique commit\n", encoding="utf-8")
+    _git(worktree, "add", "unique.txt")
+    _git(worktree, "commit", "-m", "[Task 404] test: preserve unique commit")
+    unique_head = _git(worktree, "rev-parse", "HEAD")
+    lease_path = controller.store.task_lease_path("404")
+    lease = controller.store.read_json(lease_path)
+    lease["ready_head_sha"] = unique_head
+    controller.store.replace_json(lease_path, lease)
+    history_path = controller.store.history / "task-404.json"
+    history = controller.store.read_json(history_path)
+    history["head_sha"] = unique_head
+    controller.store.replace_json(history_path, history)
+
+    with pytest.raises(task_session.TaskSessionError, match="unique commits"):
+        controller.finish("404")
+
+    assert worktree.is_dir()
+    assert controller.repository.ref(branch) == unique_head
+    assert lease_path.exists()
+
+
+def test_finish_refuses_ambiguous_task_branch_and_worktree_state(
+    repository: tuple[Path, Any],
+) -> None:
+    controller, worktree, branch, head_sha, _ = _prepare_finish_state(repository, "405")
+    _git(controller.repository.current_worktree, "branch", "task/405-duplicate", head_sha)
+
+    with pytest.raises(task_session.TaskSessionError, match="exactly one matching"):
+        controller.finish("405")
+
+    assert worktree.is_dir()
+    assert controller.repository.ref_exists(branch)
+    assert controller.repository.ref_exists("task/405-duplicate")
+    assert controller.store.task_lease_path("405").exists()
+
+
+def test_finish_refuses_unsynchronized_deployed_refs(
+    repository: tuple[Path, Any],
+) -> None:
+    controller, worktree, branch, _, _ = _prepare_finish_state(repository, "406")
+    previous_master = controller.repository.git("rev-parse", "origin/master^")
+    controller.repository.git("update-ref", "refs/remotes/origin/master", previous_master)
+
+    with pytest.raises(task_session.TaskSessionError, match="requires exact deployed"):
+        controller.finish("406")
+
+    assert worktree.is_dir()
+    assert controller.repository.ref_exists(branch)
+    assert controller.store.task_lease_path("406").exists()
+
+
+def test_finish_refuses_cross_linked_or_non_terminal_history(
+    repository: tuple[Path, Any],
+) -> None:
+    controller, worktree, branch, _, _ = _prepare_finish_state(repository, "407")
+    history_path = controller.store.history / "task-407.json"
+    history = controller.store.read_json(history_path)
+    history["task_id"] = "999"
+    controller.store.replace_json(history_path, history)
+
+    with pytest.raises(task_session.TaskSessionError, match="history does not match"):
+        controller.finish("407")
+
+    assert worktree.is_dir()
+    assert controller.repository.ref_exists(branch)
+    assert controller.store.task_lease_path("407").exists()
+
+
+def test_finish_refuses_execution_from_task_worktree(
+    repository: tuple[Path, Any],
+) -> None:
+    controller, worktree, branch, _, _ = _prepare_finish_state(repository, "408")
+    task_controller = task_session.TaskController(task_session.GitRepository(worktree))
+
+    with pytest.raises(task_session.TaskSessionError, match="canonical dev worktree"):
+        task_controller.finish("408")
+
+    assert worktree.is_dir()
+    assert controller.repository.ref_exists(branch)
+    assert controller.store.task_lease_path("408").exists()


### PR DESCRIPTION
## Что изменено
- controller finish автоматически удаляет только exact matching clean task worktree и merged local branch после exact master -> dev sync
- dirty, interrupted, unique, ambiguous, divergent и cross-linked state блокируются fail-closed без force
- normal lifecycle продолжает finish -> archive -> manifest check без отдельного owner prompt
- синхронизированы AGENTS, backlog rules/lifecycle и ADR

## Проверки
- 55 targeted controller/archive tests passed
- Ruff check passed
- Ruff format check passed
- independent review: APPROVED
- QA: PASS

## Scope
Application behavior, API, database, secrets, Rulesets и production infrastructure не менялись.