### PR TITLE
[Task 110] Release private custom avatars

### DIFF
--- a/backend/alembic/versions/0067_user_avatars.py
+++ b/backend/alembic/versions/0067_user_avatars.py
@@ -1,0 +1,43 @@
+"""Add private normalized user avatars.
+
+Revision ID: 0067_user_avatars
+Revises: 0066_workout_metric_backfill
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0067_user_avatars"
+down_revision: str | None = "0066_workout_metric_backfill"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+online_rollout_phase = "expand"
+online_rollout_notes = (
+    "Eight nullable columns only; no default, constraint, index, existing-row rewrite or backfill."
+)
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("custom_avatar_content_type", sa.String(32), nullable=True))
+    op.add_column("users", sa.Column("custom_avatar_image_bytes", sa.LargeBinary(), nullable=True))
+    op.add_column("users", sa.Column("custom_avatar_byte_size", sa.Integer(), nullable=True))
+    op.add_column("users", sa.Column("custom_avatar_width", sa.Integer(), nullable=True))
+    op.add_column("users", sa.Column("custom_avatar_height", sa.Integer(), nullable=True))
+    op.add_column("users", sa.Column("custom_avatar_sha256", sa.String(64), nullable=True))
+    op.add_column("users", sa.Column("custom_avatar_created_at", sa.DateTime(), nullable=True))
+    op.add_column("users", sa.Column("custom_avatar_updated_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "custom_avatar_updated_at")
+    op.drop_column("users", "custom_avatar_created_at")
+    op.drop_column("users", "custom_avatar_sha256")
+    op.drop_column("users", "custom_avatar_height")
+    op.drop_column("users", "custom_avatar_width")
+    op.drop_column("users", "custom_avatar_byte_size")
+    op.drop_column("users", "custom_avatar_image_bytes")
+    op.drop_column("users", "custom_avatar_content_type")

--- a/backend/fitminiapp_api/api/v1/me.py
+++ b/backend/fitminiapp_api/api/v1/me.py
@@ -1,10 +1,11 @@
 from typing import Literal, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, File, HTTPException, Request, Response, UploadFile, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import set_committed_value
+from starlette.concurrency import run_in_threadpool
 
 from fitminiapp_api.core.config import settings
 from fitminiapp_api.core.rate_limit import limiter
@@ -21,6 +22,7 @@ from fitminiapp_api.schemas.user import (
     AccountDeleteRequest,
     AccountExportDownloadLinkResponse,
     AccountExportStatusResponse,
+    AvatarMetadataResponse,
     BodyPriorityOptionsResponse,
     BodyPriorityPreference,
     HeartRatePreviewRequest,
@@ -62,6 +64,13 @@ from fitminiapp_api.services.account_linking import (
 )
 from fitminiapp_api.services.accounts import build_account_export, delete_user_cascade
 from fitminiapp_api.services.audit import record_audit_event
+from fitminiapp_api.services.avatars import (
+    AVATAR_UPLOAD_MAX_BYTES,
+    AvatarValidationError,
+    delete_user_avatar,
+    process_avatar_image,
+    save_user_avatar,
+)
 from fitminiapp_api.services.coach_clients import (
     confirm_coach_invite_link,
     get_current_trainer,
@@ -180,6 +189,17 @@ def _build_user_response(db: Session, user) -> UserResponse:
         first_name=user.first_name,
         last_name=user.last_name,
         photo_url=user.photo_url,
+        custom_avatar=(
+            AvatarMetadataResponse(
+                content_type="image/webp",
+                byte_size=user.custom_avatar_byte_size,
+                width=512,
+                height=512,
+                updated_at=user.custom_avatar_updated_at,
+            )
+            if user.custom_avatar_updated_at is not None
+            else None
+        ),
         is_coach=user.is_coach,
         is_admin=user.is_admin,
         is_root=has_verified_root_identity(db, user),
@@ -237,6 +257,89 @@ def _build_user_response(db: Session, user) -> UserResponse:
 
 @router.get("", response_model=UserResponse)
 def read_me(user=Depends(get_current_user), db: Session = Depends(get_db)):
+    return _build_user_response(db, user)
+
+
+@router.get("/avatar")
+def read_avatar(user=Depends(get_current_user), db: Session = Depends(get_db)) -> Response:
+    avatar = (
+        db.query(
+            User.custom_avatar_image_bytes,
+            User.custom_avatar_content_type,
+            User.custom_avatar_byte_size,
+            User.custom_avatar_sha256,
+        )
+        .filter(User.id == user.id, User.custom_avatar_updated_at.is_not(None))
+        .first()
+    )
+    if avatar is None or any(value is None for value in avatar):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Свой аватар не установлен"
+        )
+    image_bytes, content_type, byte_size, sha256 = avatar
+    return Response(
+        content=bytes(image_bytes),
+        media_type=content_type,
+        headers={
+            "Cache-Control": "private, no-store",
+            "Content-Length": str(byte_size),
+            "ETag": f'"{sha256}"',
+            "X-Content-Type-Options": "nosniff",
+        },
+    )
+
+
+@router.put("/avatar", response_model=UserResponse)
+@limiter.limit("10/hour")
+async def replace_avatar(
+    request: Request,
+    file: UploadFile = File(...),
+    user=Depends(get_current_user),
+    db: Session = Depends(get_db),
+) -> UserResponse:
+    del request
+    try:
+        source = await file.read(AVATAR_UPLOAD_MAX_BYTES + 1)
+    finally:
+        await file.close()
+    try:
+        processed = await run_in_threadpool(process_avatar_image, source)
+    except AvatarValidationError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=str(exc)) from exc
+
+    replacing = user.custom_avatar_updated_at is not None
+    current = save_user_avatar(db, user.id, processed)
+    record_audit_event(
+        db,
+        action="account.avatar_replaced" if replacing else "account.avatar_created",
+        resource_type="user_avatar",
+        actor_user_id=user.id,
+        target_user_id=user.id,
+        resource_id=str(user.id),
+        details={
+            "content_type": current.custom_avatar_content_type,
+            "byte_size": current.custom_avatar_byte_size,
+            "width": current.custom_avatar_width,
+            "height": current.custom_avatar_height,
+        },
+    )
+    db.commit()
+    return _build_user_response(db, user)
+
+
+@router.delete("/avatar", response_model=UserResponse)
+def remove_avatar(user=Depends(get_current_user), db: Session = Depends(get_db)) -> UserResponse:
+    deleted = delete_user_avatar(db, user.id)
+    if deleted:
+        record_audit_event(
+            db,
+            action="account.avatar_deleted",
+            resource_type="user_avatar",
+            actor_user_id=user.id,
+            target_user_id=user.id,
+            resource_id=str(user.id),
+        )
+    db.commit()
     return _build_user_response(db, user)
 
 

--- a/backend/fitminiapp_api/middleware/request_body_limit.py
+++ b/backend/fitminiapp_api/middleware/request_body_limit.py
@@ -10,7 +10,9 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 DEFAULT_BODY_LIMIT_BYTES: Final = 1024 * 1024
 AUTH_BODY_LIMIT_BYTES: Final = 64 * 1024
+AVATAR_BODY_LIMIT_BYTES: Final = 6 * 1024 * 1024
 AUTH_PATH_PREFIX: Final = "/api/v1/auth/"
+AVATAR_PATH: Final = "/api/v1/me/avatar"
 REQUEST_ID_PATTERN = re.compile(r"[A-Za-z0-9._:-]{1,128}\Z")
 
 logger = logging.getLogger("app.http")
@@ -19,6 +21,8 @@ logger = logging.getLogger("app.http")
 def _body_limit(path: str) -> int:
     if path == AUTH_PATH_PREFIX.rstrip("/") or path.startswith(AUTH_PATH_PREFIX):
         return AUTH_BODY_LIMIT_BYTES
+    if path == AVATAR_PATH:
+        return AVATAR_BODY_LIMIT_BYTES
     return DEFAULT_BODY_LIMIT_BYTES
 
 

--- a/backend/fitminiapp_api/models/user.py
+++ b/backend/fitminiapp_api/models/user.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    LargeBinary,
     String,
     Text,
     Time,
@@ -37,6 +38,16 @@ class User(Base):
     first_name: Mapped[str | None] = mapped_column(String(64), nullable=True)
     last_name: Mapped[str | None] = mapped_column(String(64), nullable=True)
     photo_url: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    custom_avatar_content_type: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    custom_avatar_image_bytes: Mapped[bytes | None] = mapped_column(
+        LargeBinary, nullable=True, deferred=True
+    )
+    custom_avatar_byte_size: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    custom_avatar_width: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    custom_avatar_height: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    custom_avatar_sha256: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    custom_avatar_created_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    custom_avatar_updated_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     is_coach: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default="false"
     )

--- a/backend/fitminiapp_api/schemas/user.py
+++ b/backend/fitminiapp_api/schemas/user.py
@@ -174,6 +174,14 @@ class AccountExportDownloadLinkResponse(BaseModel):
     expires_at: datetime
 
 
+class AvatarMetadataResponse(BaseModel):
+    content_type: Literal["image/webp"]
+    byte_size: int = Field(gt=0, le=1024 * 1024)
+    width: Literal[512]
+    height: Literal[512]
+    updated_at: datetime
+
+
 class TelegramLinkCreateResponse(BaseModel):
     telegram_url: str
     expires_in_seconds: int
@@ -266,6 +274,7 @@ class UserResponse(BaseModel):
     first_name: str | None = None
     last_name: str | None = None
     photo_url: str | None = None
+    custom_avatar: AvatarMetadataResponse | None = None
     is_coach: bool = False
     is_admin: bool = False
     is_root: bool = False

--- a/backend/fitminiapp_api/services/account_export.py
+++ b/backend/fitminiapp_api/services/account_export.py
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
     from fitminiapp_api.models.recipe import RecipeIngredient
 
 
-ACCOUNT_EXPORT_SCHEMA_VERSION = 4
+ACCOUNT_EXPORT_SCHEMA_VERSION = 5
 
 # Every ORM table whose rows can be reached from users through ownership or actor FKs must be
 # classified here. Tests compare this inventory with SQLAlchemy metadata so a new persistent user
@@ -650,7 +650,6 @@ def build_account_export(db: Session, user: User) -> dict[str, object]:
         .order_by(WorkoutComment.created_at.asc(), WorkoutComment.id.asc())
         .all()
     )
-
     profile = user.profile
     return {
         "schema_version": ACCOUNT_EXPORT_SCHEMA_VERSION,
@@ -667,6 +666,20 @@ def build_account_export(db: Session, user: User) -> dict[str, object]:
             "is_admin": user.is_admin,
             "is_active": user.is_active,
         },
+        "custom_avatar": (
+            {
+                "content_type": user.custom_avatar_content_type,
+                "byte_size": user.custom_avatar_byte_size,
+                "width": user.custom_avatar_width,
+                "height": user.custom_avatar_height,
+                "sha256": user.custom_avatar_sha256,
+                "created_at": user.custom_avatar_created_at,
+                "updated_at": user.custom_avatar_updated_at,
+                "file": "avatar/avatar.webp",
+            }
+            if user.custom_avatar_updated_at is not None
+            else None
+        ),
         "auth_identities": [
             _fields(
                 identity,

--- a/backend/fitminiapp_api/services/account_exports.py
+++ b/backend/fitminiapp_api/services/account_exports.py
@@ -115,10 +115,63 @@ def _workout_rows(payload: dict[str, object]) -> list[dict[str, object]]:
     return rows
 
 
+def _custom_avatar_export_snapshot(
+    db: Session, user_id: int
+) -> tuple[dict[str, object] | None, bytes | None]:
+    avatar = (
+        db.query(
+            User.custom_avatar_image_bytes,
+            User.custom_avatar_content_type,
+            User.custom_avatar_byte_size,
+            User.custom_avatar_width,
+            User.custom_avatar_height,
+            User.custom_avatar_sha256,
+            User.custom_avatar_created_at,
+            User.custom_avatar_updated_at,
+        )
+        .filter(User.id == user_id)
+        .one()
+    )
+    if avatar.custom_avatar_updated_at is None:
+        return None, None
+    required_values = (
+        avatar.custom_avatar_image_bytes,
+        avatar.custom_avatar_content_type,
+        avatar.custom_avatar_byte_size,
+        avatar.custom_avatar_width,
+        avatar.custom_avatar_height,
+        avatar.custom_avatar_sha256,
+        avatar.custom_avatar_created_at,
+    )
+    if any(value is None for value in required_values):
+        raise AccountExportError("Custom avatar storage is incomplete")
+    image_bytes = bytes(avatar.custom_avatar_image_bytes)
+    if (
+        avatar.custom_avatar_byte_size != len(image_bytes)
+        or avatar.custom_avatar_sha256 != hashlib.sha256(image_bytes).hexdigest()
+    ):
+        raise AccountExportError("Custom avatar metadata does not match stored bytes")
+    return (
+        {
+            "content_type": avatar.custom_avatar_content_type,
+            "byte_size": avatar.custom_avatar_byte_size,
+            "width": avatar.custom_avatar_width,
+            "height": avatar.custom_avatar_height,
+            "sha256": avatar.custom_avatar_sha256,
+            "created_at": avatar.custom_avatar_created_at,
+            "updated_at": avatar.custom_avatar_updated_at,
+            "file": "avatar/avatar.webp",
+        },
+        image_bytes,
+    )
+
+
 def build_account_export_archive(db: Session, user: User) -> tuple[bytes, str]:
     """Build a bounded ZIP without durable filesystem artifacts."""
 
+    avatar_metadata, avatar_bytes = _custom_avatar_export_snapshot(db, user.id)
     payload = build_account_export(db, user)
+    payload["custom_avatar"] = avatar_metadata
     files: dict[str, bytes] = {
         "account.json": _json_bytes(payload, indent=2),
         "measurements.csv": _csv_bytes(
@@ -209,6 +262,8 @@ def build_account_export_archive(db: Session, user: User) -> tuple[bytes, str]:
             ),
         ),
     }
+    if avatar_bytes is not None:
+        files["avatar/avatar.webp"] = avatar_bytes
     source_size = sum(len(content) for content in files.values())
     if source_size > ACCOUNT_EXPORT_MAX_SOURCE_BYTES:
         raise AccountExportTooLargeError("Account export source exceeds the bounded limit")
@@ -223,6 +278,7 @@ def build_account_export_archive(db: Session, user: User) -> tuple[bytes, str]:
             "account.json is the complete portability document.",
             "CSV files are tabular views of selected account-owned domains.",
             "Temporary report artifacts and authentication credentials are not included.",
+            "A custom avatar, when present, is normalized WebP without source EXIF metadata.",
         ],
     }
     files["manifest.json"] = _json_bytes(manifest, indent=2)

--- a/backend/fitminiapp_api/services/avatars.py
+++ b/backend/fitminiapp_api/services/avatars.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import time
+import warnings
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from PIL import Image, ImageOps, UnidentifiedImageError
+from sqlalchemy.orm import Session
+
+from fitminiapp_api.core.timezone import now_msk_naive
+from fitminiapp_api.models.user import User
+
+AVATAR_UPLOAD_MAX_BYTES = 5 * 1024 * 1024
+AVATAR_MAX_SOURCE_DIMENSION = 8192
+AVATAR_MAX_DECODED_PIXELS = 25_000_000
+AVATAR_OUTPUT_DIMENSION = 512
+AVATAR_OUTPUT_MAX_BYTES = 1024 * 1024
+AVATAR_PROCESSING_TIMEOUT_SECONDS = 3.0
+AVATAR_SUPPORTED_FORMATS = frozenset({"JPEG", "PNG", "WEBP"})
+
+
+class AvatarValidationError(ValueError):
+    def __init__(self, message: str, *, status_code: int = 422) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+@dataclass(frozen=True)
+class ProcessedAvatar:
+    image_bytes: bytes
+    content_type: str
+    width: int
+    height: int
+    sha256: str
+
+
+def _ensure_within_deadline(started_at: float, clock: Callable[[], float]) -> None:
+    if clock() - started_at > AVATAR_PROCESSING_TIMEOUT_SECONDS:
+        raise AvatarValidationError(
+            "Обработка изображения заняла слишком много времени. Выберите файл меньшего размера."
+        )
+
+
+def process_avatar_image(
+    source: bytes,
+    *,
+    clock: Callable[[], float] = time.monotonic,
+) -> ProcessedAvatar:
+    if not source:
+        raise AvatarValidationError("Файл изображения пуст")
+    if len(source) > AVATAR_UPLOAD_MAX_BYTES:
+        raise AvatarValidationError(
+            "Файл больше 5 МБ. Выберите изображение меньшего размера.",
+            status_code=413,
+        )
+
+    started_at = clock()
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", Image.DecompressionBombWarning)
+            with Image.open(io.BytesIO(source)) as opened:
+                source_format = (opened.format or "").upper()
+                if source_format not in AVATAR_SUPPORTED_FORMATS:
+                    raise AvatarValidationError(
+                        "Поддерживаются только JPEG, PNG и WebP.", status_code=415
+                    )
+                if getattr(opened, "is_animated", False) or getattr(opened, "n_frames", 1) != 1:
+                    raise AvatarValidationError(
+                        "Анимированные изображения не поддерживаются.", status_code=415
+                    )
+                width, height = opened.size
+                if (
+                    width <= 0
+                    or height <= 0
+                    or width > AVATAR_MAX_SOURCE_DIMENSION
+                    or height > AVATAR_MAX_SOURCE_DIMENSION
+                    or width * height > AVATAR_MAX_DECODED_PIXELS
+                ):
+                    raise AvatarValidationError(
+                        "Слишком большое разрешение изображения.", status_code=413
+                    )
+                opened.load()
+                _ensure_within_deadline(started_at, clock)
+                oriented = ImageOps.exif_transpose(opened)
+                normalized = ImageOps.fit(
+                    oriented.convert("RGBA"),
+                    (AVATAR_OUTPUT_DIMENSION, AVATAR_OUTPUT_DIMENSION),
+                    method=Image.Resampling.LANCZOS,
+                    centering=(0.5, 0.5),
+                )
+                _ensure_within_deadline(started_at, clock)
+    except AvatarValidationError:
+        raise
+    except Image.DecompressionBombError, Image.DecompressionBombWarning:
+        raise AvatarValidationError("Слишком большое разрешение изображения.", status_code=413)
+    except UnidentifiedImageError, OSError, ValueError:
+        raise AvatarValidationError("Файл повреждён или не является поддерживаемым изображением.")
+
+    output = io.BytesIO()
+    try:
+        normalized.save(output, format="WEBP", quality=84, method=4, exact=True)
+    except OSError:
+        raise AvatarValidationError("Не удалось безопасно подготовить изображение.")
+    _ensure_within_deadline(started_at, clock)
+    image_bytes = output.getvalue()
+    if not image_bytes or len(image_bytes) > AVATAR_OUTPUT_MAX_BYTES:
+        raise AvatarValidationError("Подготовленный аватар получился слишком большим.")
+
+    return ProcessedAvatar(
+        image_bytes=image_bytes,
+        content_type="image/webp",
+        width=AVATAR_OUTPUT_DIMENSION,
+        height=AVATAR_OUTPUT_DIMENSION,
+        sha256=hashlib.sha256(image_bytes).hexdigest(),
+    )
+
+
+def save_user_avatar(db: Session, user_id: int, processed: ProcessedAvatar) -> User:
+    user = db.query(User).filter(User.id == user_id).with_for_update().one()
+    now = now_msk_naive()
+    if user.custom_avatar_created_at is None:
+        user.custom_avatar_created_at = now
+    user.custom_avatar_content_type = processed.content_type
+    user.custom_avatar_image_bytes = processed.image_bytes
+    user.custom_avatar_byte_size = len(processed.image_bytes)
+    user.custom_avatar_width = processed.width
+    user.custom_avatar_height = processed.height
+    user.custom_avatar_sha256 = processed.sha256
+    user.custom_avatar_updated_at = now
+    db.flush()
+    return user
+
+
+def delete_user_avatar(db: Session, user_id: int) -> bool:
+    user = db.query(User).filter(User.id == user_id).with_for_update().one()
+    if user.custom_avatar_updated_at is None:
+        return False
+    user.custom_avatar_content_type = None
+    user.custom_avatar_image_bytes = None
+    user.custom_avatar_byte_size = None
+    user.custom_avatar_width = None
+    user.custom_avatar_height = None
+    user.custom_avatar_sha256 = None
+    user.custom_avatar_created_at = None
+    user.custom_avatar_updated_at = None
+    db.flush()
+    return True

--- a/backend/tests/test_alembic_config.py
+++ b/backend/tests/test_alembic_config.py
@@ -49,7 +49,7 @@ def test_legacy_support_revision_remains_in_the_linear_upgrade_path() -> None:
     assert auth_families is not None
     assert relocated_marker is not None
     assert auth_families.down_revision == legacy_support.revision
-    assert revisions.get_heads() == ["0066_workout_metric_backfill"]
+    assert revisions.get_heads() == ["0067_user_avatars"]
     assert relocated_marker.revision in {
         revision.revision
         for revision in revisions.iterate_revisions("head", legacy_support.revision)

--- a/backend/tests/test_request_body_limits.py
+++ b/backend/tests/test_request_body_limits.py
@@ -9,6 +9,7 @@ import pytest
 from fitminiapp_api.main import app as production_app
 from fitminiapp_api.middleware.request_body_limit import (
     AUTH_BODY_LIMIT_BYTES,
+    AVATAR_BODY_LIMIT_BYTES,
     DEFAULT_BODY_LIMIT_BYTES,
     RequestBodyLimitMiddleware,
 )
@@ -94,6 +95,7 @@ def _response_json(messages: list[dict]) -> dict:
     ("path", "limit"),
     [
         ("/api/v1/auth/dev-login", AUTH_BODY_LIMIT_BYTES),
+        ("/api/v1/me/avatar", AVATAR_BODY_LIMIT_BYTES),
         ("/api/v1/workouts", DEFAULT_BODY_LIMIT_BYTES),
     ],
 )
@@ -214,7 +216,11 @@ def test_edge_and_asgi_limits_share_the_reviewed_contract() -> None:
     compose = (root / "docker-compose.yml").read_text(encoding="utf-8")
 
     configured_sizes = [int(value) for value in re.findall(r"max_size (\d+)", caddyfile)]
-    assert configured_sizes == [AUTH_BODY_LIMIT_BYTES, DEFAULT_BODY_LIMIT_BYTES]
+    assert configured_sizes == [
+        AVATAR_BODY_LIMIT_BYTES,
+        AUTH_BODY_LIMIT_BYTES,
+        DEFAULT_BODY_LIMIT_BYTES,
+    ]
     assert "reverse_proxy {$YFC_ACTIVE_UPSTREAM}" in caddyfile
     assert "reverse_proxy {$YFC_ASSET_FALLBACK_UPSTREAM}" in caddyfile
     assert 'Cache-Control "no-store, private"' in caddyfile

--- a/backend/tests/test_user_avatar.py
+++ b/backend/tests/test_user_avatar.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import io
+import json
+import random
+import zipfile
+
+import pytest
+from PIL import Image
+
+from fitminiapp_api.db.session import get_session_context
+from fitminiapp_api.models.user import User
+from fitminiapp_api.services import account_exports
+from fitminiapp_api.services.avatars import (
+    AVATAR_UPLOAD_MAX_BYTES,
+    AvatarValidationError,
+    process_avatar_image,
+)
+
+
+def _login(client, telegram_user_id: int) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/auth/dev-login",
+        json={"telegram_user_id": telegram_user_id, "is_coach": False},
+    )
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _image_bytes(
+    image_format: str,
+    *,
+    color: tuple[int, int, int, int] = (105, 210, 20, 255),
+    size: tuple[int, int] = (720, 480),
+    exif: Image.Exif | None = None,
+) -> bytes:
+    image = Image.new("RGBA", size, color)
+    if image_format == "JPEG":
+        image = image.convert("RGB")
+    output = io.BytesIO()
+    save_options = {"exif": exif} if exif is not None else {}
+    image.save(output, format=image_format, **save_options)
+    return output.getvalue()
+
+
+def _animated_webp() -> bytes:
+    first = Image.new("RGB", (64, 64), "red")
+    second = Image.new("RGB", (64, 64), "blue")
+    output = io.BytesIO()
+    first.save(output, format="WEBP", save_all=True, append_images=[second], duration=100, loop=0)
+    return output.getvalue()
+
+
+def _large_png() -> bytes:
+    random_bytes = random.Random(110).randbytes(800 * 800 * 3)
+    image = Image.frombytes("RGB", (800, 800), random_bytes)
+    output = io.BytesIO()
+    image.save(output, format="PNG")
+    return output.getvalue()
+
+
+def _upload(client, headers: dict[str, str], content: bytes, filename: str, media_type: str):
+    return client.put(
+        "/api/v1/me/avatar",
+        headers=headers,
+        files={"file": (filename, content, media_type)},
+    )
+
+
+def test_avatar_is_authenticated_private_and_uses_decoded_format(client) -> None:
+    jpeg = _image_bytes("JPEG")
+    assert _upload(client, {}, jpeg, "avatar.jpg", "image/jpeg").status_code == 401
+    assert client.get("/api/v1/me/avatar").status_code == 401
+
+    owner_headers = _login(client, 9_810_001)
+    other_headers = _login(client, 9_810_002)
+    uploaded = _upload(client, owner_headers, jpeg, "looks-like.svg", "image/svg+xml")
+    assert uploaded.status_code == 200
+    assert uploaded.json()["custom_avatar"]["content_type"] == "image/webp"
+    assert uploaded.json()["custom_avatar"]["width"] == 512
+    assert uploaded.json()["custom_avatar"]["height"] == 512
+
+    downloaded = client.get("/api/v1/me/avatar", headers=owner_headers)
+    assert downloaded.status_code == 200
+    assert downloaded.headers["content-type"] == "image/webp"
+    assert downloaded.headers["cache-control"] == "no-store, private"
+    assert downloaded.headers["x-content-type-options"] == "nosniff"
+    assert downloaded.headers["etag"].startswith('"')
+    with Image.open(io.BytesIO(downloaded.content)) as image:
+        assert image.format == "WEBP"
+        assert image.size == (512, 512)
+
+    assert client.get("/api/v1/me/avatar", headers=other_headers).status_code == 404
+
+
+def test_avatar_rejects_unsupported_malformed_animated_and_bounded_inputs(client) -> None:
+    headers = _login(client, 9_810_003)
+
+    svg = b'<svg xmlns="http://www.w3.org/2000/svg"><rect width="1" height="1"/></svg>'
+    unsupported = _upload(client, headers, svg, "avatar.png", "image/png")
+    assert unsupported.status_code == 422
+    assert "повреждён" in unsupported.json()["detail"]
+
+    malformed = _upload(client, headers, b"not-an-image", "avatar.webp", "image/webp")
+    assert malformed.status_code == 422
+
+    animated = _upload(client, headers, _animated_webp(), "avatar.webp", "image/webp")
+    assert animated.status_code == 415
+    assert "Анимированные" in animated.json()["detail"]
+
+    too_many_bytes = _upload(
+        client,
+        headers,
+        b"x" * (AVATAR_UPLOAD_MAX_BYTES + 1),
+        "avatar.png",
+        "image/png",
+    )
+    assert too_many_bytes.status_code == 413
+
+    too_wide = _upload(
+        client,
+        headers,
+        _image_bytes("PNG", size=(8193, 1)),
+        "avatar.png",
+        "image/png",
+    )
+    assert too_wide.status_code == 413
+    assert client.get("/api/v1/me", headers=headers).json()["custom_avatar"] is None
+
+
+def test_avatar_accepts_valid_upload_larger_than_default_request_limit(client) -> None:
+    headers = _login(client, 9_810_007)
+    source = _large_png()
+    assert 1024 * 1024 < len(source) <= AVATAR_UPLOAD_MAX_BYTES
+
+    uploaded = _upload(client, headers, source, "large-avatar.png", "image/png")
+
+    assert uploaded.status_code == 200
+    assert uploaded.json()["custom_avatar"]["content_type"] == "image/webp"
+
+
+def test_avatar_processing_deadline_fails_closed() -> None:
+    ticks = iter((0.0, 4.0))
+    with pytest.raises(AvatarValidationError, match="слишком много времени"):
+        process_avatar_image(_image_bytes("PNG"), clock=lambda: next(ticks))
+
+
+def test_avatar_strips_metadata_and_failed_replace_keeps_previous_blob(client) -> None:
+    headers = _login(client, 9_810_004)
+    exif = Image.Exif()
+    exif[270] = "sensitive-description"
+    exif[274] = 6
+    first = _image_bytes("JPEG", color=(255, 0, 0, 255), size=(320, 640), exif=exif)
+    assert _upload(client, headers, first, "portrait.jpg", "image/jpeg").status_code == 200
+    original = client.get("/api/v1/me/avatar", headers=headers).content
+
+    failed = _upload(client, headers, b"broken", "replacement.jpg", "image/jpeg")
+    assert failed.status_code == 422
+    assert client.get("/api/v1/me/avatar", headers=headers).content == original
+
+    with Image.open(io.BytesIO(original)) as normalized:
+        assert normalized.size == (512, 512)
+        assert not normalized.getexif()
+        assert "exif" not in normalized.info
+
+    second = _image_bytes("PNG", color=(0, 0, 255, 255))
+    replaced = _upload(client, headers, second, "replacement.png", "image/png")
+    assert replaced.status_code == 200
+    assert client.get("/api/v1/me/avatar", headers=headers).content != original
+    with get_session_context() as db:
+        user_id = client.get("/api/v1/me", headers=headers).json()["id"]
+        stored = db.query(User).filter(User.id == user_id).one()
+        assert stored.custom_avatar_updated_at is not None
+        assert stored.custom_avatar_byte_size == len(stored.custom_avatar_image_bytes or b"")
+
+
+def test_avatar_delete_restores_provider_fallback_without_changing_provider_photo(client) -> None:
+    headers = _login(client, 9_810_005)
+    user_id = client.get("/api/v1/me", headers=headers).json()["id"]
+    with get_session_context() as db:
+        user = db.query(User).filter(User.id == user_id).one()
+        user.photo_url = "https://provider.example.test/avatar.jpg"
+
+    assert (
+        _upload(client, headers, _image_bytes("WEBP"), "avatar.webp", "image/webp").status_code
+        == 200
+    )
+    deleted = client.delete("/api/v1/me/avatar", headers=headers)
+    assert deleted.status_code == 200
+    current = deleted.json()
+    assert current["custom_avatar"] is None
+    assert current["photo_url"] == "https://provider.example.test/avatar.jpg"
+    assert client.get("/api/v1/me/avatar", headers=headers).status_code == 404
+    assert client.delete("/api/v1/me/avatar", headers=headers).status_code == 200
+
+
+def test_avatar_is_in_account_export_and_removed_with_account(client) -> None:
+    headers = _login(client, 9_810_006)
+    user_id = client.get("/api/v1/me", headers=headers).json()["id"]
+    assert (
+        _upload(client, headers, _image_bytes("PNG"), "avatar.png", "image/png").status_code == 200
+    )
+
+    export = client.post("/api/v1/me/exports", headers=headers)
+    assert export.status_code == 201
+    downloaded = client.get(
+        f"/api/v1/me/exports/{export.json()['export_id']}/download",
+        headers=headers,
+    )
+    with zipfile.ZipFile(io.BytesIO(downloaded.content)) as archive:
+        assert "avatar/avatar.webp" in archive.namelist()
+        payload = json.loads(archive.read("account.json"))
+        exported_avatar = archive.read("avatar/avatar.webp")
+    assert payload["custom_avatar"]["file"] == "avatar/avatar.webp"
+    assert payload["custom_avatar"]["byte_size"] == len(exported_avatar)
+    assert payload["custom_avatar"]["sha256"]
+
+    deleted = client.request(
+        "DELETE",
+        "/api/v1/me/account",
+        headers=headers,
+        json={"confirmation": "DELETE"},
+    )
+    assert deleted.status_code == 204
+    with get_session_context() as db:
+        assert db.query(User).filter(User.id == user_id).first() is None
+
+
+def test_account_export_uses_one_avatar_metadata_and_bytes_snapshot(
+    client, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    headers = _login(client, 9_810_008)
+    user_id = client.get("/api/v1/me", headers=headers).json()["id"]
+    assert (
+        _upload(client, headers, _image_bytes("PNG"), "avatar.png", "image/png").status_code == 200
+    )
+
+    with get_session_context() as db:
+        user = db.query(User).filter(User.id == user_id).one()
+        original_bytes = bytes(user.custom_avatar_image_bytes or b"")
+        original_sha256 = user.custom_avatar_sha256
+        build_payload = account_exports.build_account_export
+
+        def replace_avatar_after_snapshot(session, snapshot_user):
+            payload = build_payload(session, snapshot_user)
+            replacement = process_avatar_image(_image_bytes("PNG", color=(0, 0, 255, 255)))
+            snapshot_user.custom_avatar_image_bytes = replacement.image_bytes
+            snapshot_user.custom_avatar_byte_size = len(replacement.image_bytes)
+            snapshot_user.custom_avatar_sha256 = replacement.sha256
+            session.flush()
+            return payload
+
+        monkeypatch.setattr(account_exports, "build_account_export", replace_avatar_after_snapshot)
+        archive_bytes, _ = account_exports.build_account_export_archive(db, user)
+
+    with zipfile.ZipFile(io.BytesIO(archive_bytes)) as archive:
+        payload = json.loads(archive.read("account.json"))
+        exported_avatar = archive.read("avatar/avatar.webp")
+    assert exported_avatar == original_bytes
+    assert payload["custom_avatar"]["sha256"] == original_sha256
+    assert payload["custom_avatar"]["byte_size"] == len(original_bytes)

--- a/deploy/Caddyfile.edge
+++ b/deploy/Caddyfile.edge
@@ -3,12 +3,17 @@
 }
 
 :8080 {
+	@avatar path /api/v1/me/avatar
+	request_body @avatar {
+		max_size 6291456
+	}
+
 	@auth path /api/v1/auth /api/v1/auth/*
 	request_body @auth {
 		max_size 65536
 	}
 
-	@default not path /api/v1/auth /api/v1/auth/*
+	@default not path /api/v1/auth /api/v1/auth/* /api/v1/me/avatar
 	request_body @default {
 		max_size 1048576
 	}

--- a/docs/custom-avatar.md
+++ b/docs/custom-avatar.md
@@ -1,0 +1,53 @@
+# Пользовательский аватар
+
+## Назначение и границы
+
+Собственный аватар используется только для узнаваемости авторизованного аккаунта внутри Your
+Fitness Coach. Он не является публичным профилем, фотографией прогресса, источником анализа
+внешности или материалом для AI/analytics. Изображение не передаётся во внешние CDN, Telegram API
+или сторонние сервисы.
+
+Цепочка отображения едина для Web, Mobile Web и общей TMA UI:
+
+```text
+custom avatar -> provider photo_url -> deterministic emoji fallback
+```
+
+`users.photo_url` продолжает принадлежать auth-provider lifecycle. Собственный аватар хранится в
+отдельных server-owned полях `users.custom_avatar_*`, поэтому новый вход через provider не
+перезаписывает выбор пользователя. Binary-колонка помечена как deferred и не загружается обычным
+чтением пользователя.
+
+## Upload и нормализация
+
+- authenticated `PUT /api/v1/me/avatar` принимает один multipart-файл;
+- максимальный исходный размер — `5 MiB`;
+- поддерживаются только однокадровые JPEG, PNG и WebP, определённые по декодированному содержимому,
+  а не расширению или client MIME;
+- максимальная сторона — `8192 px`, максимум декодированных пикселей — `25 000 000`;
+- cooperative processing deadline — `3 s`; между decode, crop и encode запрос прекращается при
+  превышении лимита;
+- orientation нормализуется, затем выполняется center-crop до квадрата `512x512`;
+- результат заново кодируется как WebP размером не более `1 MiB`; исходные EXIF/GPS, filename и
+  прочие metadata не сохраняются.
+
+Ошибочный upload не меняет уже сохранённую запись. Replace выполняется в транзакции после полной
+проверки нового изображения и сериализуется блокировкой строки пользователя.
+
+## Доступ и lifecycle
+
+Bytes доступны только владельцу через authenticated `GET /api/v1/me/avatar`. Endpoint не содержит
+user ID или bearer token в URL и возвращает `Cache-Control: private, no-store` и
+`X-Content-Type-Options: nosniff`. Другим пользователям, тренерам и администраторам новый доступ не
+добавляется.
+
+`DELETE /api/v1/me/avatar` обнуляет только поля custom avatar и немедленно возвращает provider/emoji
+fallback. При account deletion media удаляется атомарно вместе со строкой пользователя. Account
+export включает `avatar/avatar.webp` и metadata/hash в `account.json`.
+
+Удаление убирает canonical blob из рабочей PostgreSQL-базы. Уже созданные резервные копии базы
+живут по действующей политике backup retention и не обещают мгновенного физического исчезновения;
+они не являются активной продуктовой копией и исчезают только по штатному lifecycle резервов.
+
+Логи и audit events содержат только безопасные технические metadata (`content_type`, размеры и
+число bytes). Image bytes, base64, filename, EXIF, URL и request body не логируются.

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -227,6 +227,7 @@ export function AppShell({
           >
             <AccountAvatar
               className="app-bottom-nav__avatar"
+              customAvatarVersion={user?.custom_avatar?.updated_at}
               name={displayName}
               photoUrl={user?.photo_url}
             />
@@ -263,6 +264,7 @@ export function AppShell({
                   <AccountIdentity
                     avatarClassName="app-desktop-account-entry__avatar"
                     className="app-desktop-account-entry__identity"
+                    customAvatarVersion={user?.custom_avatar?.updated_at}
                     name={displayName}
                     photoUrl={user?.photo_url}
                     role={accountRole}
@@ -415,6 +417,7 @@ export function AppShell({
                     <AccountIdentity
                       avatarClassName="app-bottom-nav__avatar"
                       className="app-more-panel__identity"
+                      customAvatarVersion={user?.custom_avatar?.updated_at}
                       name={demo?.menuTitle ?? displayName}
                       photoUrl={user?.photo_url}
                       role={demo ? 'Отдельная сессия' : accountRole}

--- a/frontend/src/app/AuthProvider.tsx
+++ b/frontend/src/app/AuthProvider.tsx
@@ -64,6 +64,7 @@ interface AuthContextValue {
   config: PublicConfig | null;
   loading: boolean;
   error: string | null;
+  updateUser(user: User): void;
   reloadUser(): Promise<User | null>;
   devLogin(input: DevLoginInput): Promise<void>;
   telegramLogin(telegram?: TelegramWebApp | null): Promise<void>;
@@ -356,6 +357,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       config,
       loading,
       error,
+      updateUser: acceptAuthenticatedUser,
       reloadUser,
       devLogin,
       telegramLogin,
@@ -371,6 +373,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       config,
       loading,
       error,
+      acceptAuthenticatedUser,
       reloadUser,
       devLogin,
       telegramLogin,

--- a/frontend/src/features/profile/AvatarSettings.tsx
+++ b/frontend/src/features/profile/AvatarSettings.tsx
@@ -1,0 +1,267 @@
+import { useEffect, useRef, useState } from 'react';
+import { useAuth } from '../../app/AuthProvider';
+import { AccountAvatar } from '../../shared/account/AccountIdentity';
+import { api, ApiError } from '../../shared/api/client';
+import type { User } from '../../shared/api/types';
+
+const MAX_AVATAR_BYTES = 5 * 1024 * 1024;
+const SUPPORTED_AVATAR_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
+
+function userDisplayName(user: User): string {
+  return user.profile?.full_name || user.first_name || user.username || 'Пользователь';
+}
+
+function selectedFileError(file: File): string | null {
+  if (file.size > MAX_AVATAR_BYTES) return 'Файл больше 5 МБ. Выберите изображение поменьше.';
+  if (file.type && !SUPPORTED_AVATAR_TYPES.has(file.type)) {
+    return 'Поддерживаются только JPEG, PNG и WebP. HEIC, SVG и анимация не поддерживаются.';
+  }
+  return null;
+}
+
+export function AvatarSettings() {
+  const { updateUser, user } = useAuth();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const chooseButtonRef = useRef<HTMLButtonElement>(null);
+  const deleteButtonRef = useRef<HTMLButtonElement>(null);
+  const confirmDeleteButtonRef = useRef<HTMLButtonElement>(null);
+  const previewRef = useRef<string | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  useEffect(
+    () => () => {
+      if (previewRef.current) URL.revokeObjectURL(previewRef.current);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (confirmDelete) confirmDeleteButtonRef.current?.focus();
+  }, [confirmDelete]);
+
+  if (!user) return null;
+
+  const clearSelection = () => {
+    if (previewRef.current) URL.revokeObjectURL(previewRef.current);
+    previewRef.current = null;
+    setPreviewUrl(null);
+    setSelectedFile(null);
+    if (inputRef.current) inputRef.current.value = '';
+  };
+
+  const chooseFile = (file: File | null) => {
+    setStatus(null);
+    setError(null);
+    if (!file) return;
+    const validationError = selectedFileError(file);
+    if (validationError) {
+      clearSelection();
+      setError(validationError);
+      return;
+    }
+    clearSelection();
+    const objectUrl = URL.createObjectURL(file);
+    previewRef.current = objectUrl;
+    setPreviewUrl(objectUrl);
+    setSelectedFile(file);
+  };
+
+  const saveAvatar = async () => {
+    if (!selectedFile || saving) return;
+    setSaving(true);
+    setError(null);
+    setStatus(null);
+    const formData = new FormData();
+    formData.append('file', selectedFile, selectedFile.name);
+    try {
+      const current = await api<User>('/api/v1/me/avatar', {
+        method: 'PUT',
+        body: formData,
+        timeoutMs: 20_000,
+      });
+      updateUser(current);
+      clearSelection();
+      setStatus('Аватар сохранён и уже используется в профиле.');
+    } catch (reason) {
+      setError(
+        reason instanceof ApiError || reason instanceof Error
+          ? reason.message
+          : 'Не удалось сохранить аватар. Попробуйте снова.',
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const deleteAvatar = async () => {
+    if (deleting) return;
+    setDeleting(true);
+    setError(null);
+    setStatus(null);
+    try {
+      const current = await api<User>('/api/v1/me/avatar', { method: 'DELETE' });
+      updateUser(current);
+      clearSelection();
+      setConfirmDelete(false);
+      requestAnimationFrame(() => chooseButtonRef.current?.focus());
+      setStatus(
+        current.photo_url
+          ? 'Свой аватар удалён. Снова показывается фото из способа входа.'
+          : 'Свой аватар удалён. Снова показывается нейтральный emoji.',
+      );
+    } catch (reason) {
+      setError(
+        reason instanceof ApiError || reason instanceof Error
+          ? reason.message
+          : 'Не удалось удалить аватар. Попробуйте снова.',
+      );
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const hasCustomAvatar = Boolean(user.custom_avatar);
+  const sourceLabel = selectedFile
+    ? 'Предпросмотр нового изображения'
+    : hasCustomAvatar
+      ? 'Используется свой аватар'
+      : user.photo_url
+        ? 'Используется фото из способа входа'
+        : 'Используется нейтральный emoji';
+
+  return (
+    <section className="profile-avatar-card" id="profile-avatar" aria-labelledby="avatar-title">
+      <div className="profile-avatar-card__visual">
+        <AccountAvatar
+          className="profile-avatar-card__avatar"
+          customAvatarVersion={user.custom_avatar?.updated_at}
+          name={userDisplayName(user)}
+          photoUrl={user.photo_url}
+          previewUrl={previewUrl}
+        />
+        <span>{sourceLabel}</span>
+      </div>
+
+      <div className="profile-avatar-card__body">
+        <div className="profile-avatar-card__copy">
+          <span className="eyebrow">Персонализация аккаунта</span>
+          <h2 id="avatar-title">Аватар</h2>
+          <p>
+            Выберите JPEG, PNG или WebP до 5 МБ. Перед сохранением изображение будет обрезано по
+            центру до квадрата, а исходные metadata будут удалены.
+          </p>
+        </div>
+
+        <input
+          ref={inputRef}
+          className="sr-only"
+          type="file"
+          accept="image/jpeg,image/png,image/webp"
+          aria-label="Выбрать изображение для аватара"
+          onChange={(event) => chooseFile(event.target.files?.[0] ?? null)}
+        />
+
+        <div className="profile-avatar-card__actions">
+          <button
+            ref={chooseButtonRef}
+            type="button"
+            className="secondary"
+            disabled={saving || deleting}
+            onClick={() => inputRef.current?.click()}
+          >
+            {selectedFile ? 'Выбрать другое' : hasCustomAvatar ? 'Заменить' : 'Выбрать изображение'}
+          </button>
+          {selectedFile && (
+            <>
+              <button type="button" disabled={saving} onClick={() => void saveAvatar()}>
+                {saving ? 'Сохраняем…' : error ? 'Повторить сохранение' : 'Сохранить аватар'}
+              </button>
+              <button
+                type="button"
+                className="text-button"
+                disabled={saving}
+                onClick={() => {
+                  clearSelection();
+                  setError(null);
+                }}
+              >
+                Отмена
+              </button>
+            </>
+          )}
+          {hasCustomAvatar && !selectedFile && (
+            <button
+              ref={deleteButtonRef}
+              type="button"
+              className="secondary profile-avatar-card__delete"
+              disabled={deleting}
+              onClick={() => setConfirmDelete(true)}
+            >
+              Удалить свой аватар
+            </button>
+          )}
+        </div>
+
+        {confirmDelete && hasCustomAvatar && (
+          <div
+            className="profile-avatar-delete-confirmation"
+            role="alertdialog"
+            aria-labelledby="avatar-delete-title"
+            aria-describedby="avatar-delete-description"
+            onKeyDown={(event) => {
+              if (event.key !== 'Escape') return;
+              setConfirmDelete(false);
+              requestAnimationFrame(() => deleteButtonRef.current?.focus());
+            }}
+          >
+            <div>
+              <strong id="avatar-delete-title">Удалить свой аватар?</strong>
+              <p id="avatar-delete-description">
+                Свой файл будет удалён. Фото из способа входа или emoji останется доступным.
+              </p>
+            </div>
+            <div className="profile-avatar-delete-confirmation__actions">
+              <button
+                ref={confirmDeleteButtonRef}
+                type="button"
+                className="btn-danger"
+                disabled={deleting}
+                onClick={() => void deleteAvatar()}
+              >
+                {deleting ? 'Удаляем…' : 'Удалить'}
+              </button>
+              <button
+                type="button"
+                className="secondary"
+                disabled={deleting}
+                onClick={() => {
+                  setConfirmDelete(false);
+                  requestAnimationFrame(() => deleteButtonRef.current?.focus());
+                }}
+              >
+                Отмена
+              </button>
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <p className="profile-avatar-card__message is-error" role="alert">
+            {error}
+          </p>
+        )}
+        {status && (
+          <p className="profile-avatar-card__message is-success" role="status">
+            {status}
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/miniapp/MiniAppPage.tsx
+++ b/frontend/src/pages/miniapp/MiniAppPage.tsx
@@ -51,6 +51,11 @@ const ProfileForm = lazy(() =>
     default: module.ProfileForm,
   })),
 );
+const AvatarSettings = lazy(() =>
+  import('../../features/profile/AvatarSettings').then((module) => ({
+    default: module.AvatarSettings,
+  })),
+);
 const ProgramBuilder = lazy(() =>
   import('../../features/programs/ProgramBuilder').then((module) => ({
     default: module.ProgramBuilder,
@@ -427,6 +432,7 @@ export default function MiniAppPage() {
                   </a>
                 </nav>
 
+                <AvatarSettings />
                 <ProfileForm key={profileFormKey} />
                 <Card
                   className="profile-settings-group"

--- a/frontend/src/shared/account/AccountIdentity.tsx
+++ b/frontend/src/shared/account/AccountIdentity.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { apiFile } from '../api/client';
 
 const AVATAR_EMOJIS = ['🏋️', '💪', '🏃', '🚴', '🥗', '⚡', '🎯', '🔥'] as const;
 
@@ -18,24 +19,66 @@ export function accountRoleLabel(isRoot: boolean, isCoach: boolean): string {
 
 export function AccountAvatar({
   className = 'account-identity__avatar',
+  customAvatarVersion,
   name,
   photoUrl,
+  previewUrl,
 }: {
   className?: string;
+  customAvatarVersion?: string | null;
   name: string;
   photoUrl?: string | null;
+  previewUrl?: string | null;
 }) {
-  const [failedPhotoUrl, setFailedPhotoUrl] = useState<string | null>(null);
-  const photoFailed = Boolean(photoUrl && failedPhotoUrl === photoUrl);
+  const [failedPhotoUrls, setFailedPhotoUrls] = useState<ReadonlySet<string>>(() => new Set());
+  const [privateAvatar, setPrivateAvatar] = useState<{
+    version: string;
+    url: string | null;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!customAvatarVersion) return;
+    let active = true;
+    let objectUrl: string | null = null;
+    void apiFile('/api/v1/me/avatar')
+      .then(({ blob }) => {
+        if (!active) return;
+        objectUrl = URL.createObjectURL(blob);
+        setPrivateAvatar({ version: customAvatarVersion, url: objectUrl });
+      })
+      .catch(() => {
+        if (active) setPrivateAvatar({ version: customAvatarVersion, url: null });
+      });
+    return () => {
+      active = false;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [customAvatarVersion]);
+
+  const customUrl =
+    privateAvatar && privateAvatar.version === customAvatarVersion ? privateAvatar.url : null;
+  const privateUrl = previewUrl || customUrl || null;
+  const selectedUrl =
+    privateUrl && !failedPhotoUrls.has(privateUrl)
+      ? privateUrl
+      : photoUrl && !failedPhotoUrls.has(photoUrl)
+        ? photoUrl
+        : null;
 
   return (
     <span className={className} aria-hidden="true">
-      {photoUrl && !photoFailed ? (
+      {selectedUrl ? (
         <img
-          src={photoUrl}
+          src={selectedUrl}
           alt=""
           referrerPolicy="no-referrer"
-          onError={() => setFailedPhotoUrl(photoUrl)}
+          onError={() =>
+            setFailedPhotoUrls((current) => {
+              const next = new Set(current);
+              next.add(selectedUrl);
+              return next;
+            })
+          }
         />
       ) : (
         avatarFallback(name)
@@ -47,19 +90,26 @@ export function AccountAvatar({
 export function AccountIdentity({
   avatarClassName,
   className = 'account-identity',
+  customAvatarVersion,
   name,
   photoUrl,
   role,
 }: {
   avatarClassName?: string;
   className?: string;
+  customAvatarVersion?: string | null;
   name: string;
   photoUrl?: string | null;
   role: string;
 }) {
   return (
     <span className={className}>
-      <AccountAvatar className={avatarClassName} name={name} photoUrl={photoUrl} />
+      <AccountAvatar
+        className={avatarClassName}
+        customAvatarVersion={customAvatarVersion}
+        name={name}
+        photoUrl={photoUrl}
+      />
       <span className="account-identity__copy">
         <strong className="account-identity__name">{name}</strong>
         <small className="account-identity__role">{role}</small>

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -238,18 +238,21 @@ export async function api<T>(path: string, options: ApiOptions = {}): Promise<T>
   if (signal?.aborted) abortFromCaller();
   else signal?.addEventListener('abort', abortFromCaller, { once: true });
   const token = getAccessToken();
+  const formData = typeof FormData !== 'undefined' && body instanceof FormData;
   try {
     const response = await fetch(path, {
       ...init,
       credentials: 'same-origin',
       signal: controller.signal,
       headers: {
-        ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+        ...(body !== undefined && !formData ? { 'Content-Type': 'application/json' } : {}),
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
         ...headers,
       },
       ...(body !== undefined
-        ? { body: typeof body === 'string' ? body : JSON.stringify(body) }
+        ? {
+            body: formData ? body : typeof body === 'string' ? body : JSON.stringify(body),
+          }
         : {}),
     });
     if (response.status === 401 && retryAuth && (await refreshAccessToken())) {

--- a/frontend/src/shared/api/schema.d.ts
+++ b/frontend/src/shared/api/schema.d.ts
@@ -362,6 +362,25 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/me/avatar": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Read Avatar */
+        get: operations["read_avatar_api_v1_me_avatar_get"];
+        /** Replace Avatar */
+        put: operations["replace_avatar_api_v1_me_avatar_put"];
+        post?: never;
+        /** Remove Avatar */
+        delete: operations["remove_avatar_api_v1_me_avatar_delete"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/me/trainer-capability": {
         parameters: {
             query?: never;
@@ -3289,6 +3308,31 @@ export interface components {
             /** Token */
             token: string;
         };
+        /** AvatarMetadataResponse */
+        AvatarMetadataResponse: {
+            /**
+             * Content Type
+             * @constant
+             */
+            content_type: "image/webp";
+            /** Byte Size */
+            byte_size: number;
+            /**
+             * Width
+             * @constant
+             */
+            width: 512;
+            /**
+             * Height
+             * @constant
+             */
+            height: 512;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+        };
         /** AvoidedExercisePreference */
         AvoidedExercisePreference: {
             /** Exercise Id */
@@ -3432,6 +3476,11 @@ export interface components {
             mode: "balanced" | "muscle_groups";
             /** Muscle Group Ids */
             muscle_group_ids?: string[];
+        };
+        /** Body_replace_avatar_api_v1_me_avatar_put */
+        Body_replace_avatar_api_v1_me_avatar_put: {
+            /** File */
+            file: string;
         };
         /** BotDigestDraftRequest */
         BotDigestDraftRequest: {
@@ -7180,6 +7229,7 @@ export interface components {
             last_name?: string | null;
             /** Photo Url */
             photo_url?: string | null;
+            custom_avatar?: components["schemas"]["AvatarMetadataResponse"] | null;
             /**
              * Is Coach
              * @default false
@@ -8740,6 +8790,79 @@ export interface operations {
         };
     };
     read_me_api_v1_me_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserResponse"];
+                };
+            };
+        };
+    };
+    read_avatar_api_v1_me_avatar_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    replace_avatar_api_v1_me_avatar_put: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": components["schemas"]["Body_replace_avatar_api_v1_me_avatar_put"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    remove_avatar_api_v1_me_avatar_delete: {
         parameters: {
             query?: never;
             header?: never;

--- a/frontend/src/styles/design-v2.css
+++ b/frontend/src/styles/design-v2.css
@@ -3486,6 +3486,139 @@ body:has(.standalone-page--design-v2) {
   gap: var(--v2-space-6);
 }
 
+.profile-avatar-card {
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: minmax(190px, 0.34fr) minmax(0, 1fr);
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-region-radius);
+  background: var(--v2-surface);
+}
+
+.profile-avatar-card__visual {
+  display: grid;
+  min-height: 250px;
+  place-content: center;
+  justify-items: center;
+  gap: var(--v2-space-3);
+  padding: var(--v2-space-5);
+  border-right: 1px solid var(--v2-border);
+  background: var(--v2-lime-soft);
+  color: var(--v2-text-primary);
+  text-align: center;
+}
+
+.profile-avatar-card__visual > span:last-child {
+  max-width: 18ch;
+  color: var(--v2-text-secondary);
+  font-size: 0.78rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.profile-avatar-card__avatar {
+  overflow: hidden;
+  display: grid;
+  width: 124px;
+  height: 124px;
+  place-items: center;
+  border: 3px solid var(--v2-lime);
+  border-radius: 50%;
+  background: var(--v2-surface);
+  color: var(--v2-accent-text);
+  font-size: 3rem;
+  box-shadow: 0 0 0 8px color-mix(in srgb, var(--v2-lime) 12%, transparent);
+}
+
+.profile-avatar-card__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-avatar-card__body,
+.profile-avatar-card__copy {
+  display: grid;
+}
+
+.profile-avatar-card__body {
+  align-content: center;
+  gap: var(--v2-space-4);
+  min-width: 0;
+  padding: var(--v2-space-5);
+}
+
+.profile-avatar-card__copy {
+  gap: var(--v2-space-2);
+  max-width: 64ch;
+}
+
+.profile-avatar-card__copy h2,
+.profile-avatar-card__copy p,
+.profile-avatar-delete-confirmation p,
+.profile-avatar-card__message {
+  margin: 0;
+}
+
+.profile-avatar-card__copy h2 {
+  font-size: clamp(1.55rem, 3vw, 2.2rem);
+  letter-spacing: -0.03em;
+}
+
+.profile-avatar-card__copy p,
+.profile-avatar-delete-confirmation p {
+  color: var(--v2-text-secondary);
+  line-height: 1.5;
+}
+
+.profile-avatar-card__actions,
+.profile-avatar-delete-confirmation__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--v2-space-2);
+}
+
+.profile-avatar-card__actions > button,
+.profile-avatar-delete-confirmation__actions > button {
+  min-height: 44px;
+}
+
+.profile-avatar-card__delete {
+  margin-left: auto;
+}
+
+.profile-avatar-delete-confirmation {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--v2-space-4);
+  padding: var(--v2-space-4);
+  border: 1px solid var(--v2-border-strong);
+  border-radius: var(--v2-control-radius);
+  background: var(--v2-surface-secondary);
+}
+
+.profile-avatar-delete-confirmation > div:first-child {
+  display: grid;
+  gap: var(--v2-space-1);
+}
+
+.profile-avatar-card__message {
+  padding: var(--v2-space-3);
+  border: 1px solid currentColor;
+  border-radius: var(--v2-control-radius);
+  line-height: 1.4;
+}
+
+.profile-avatar-card__message.is-error {
+  color: var(--v2-danger);
+}
+
+.profile-avatar-card__message.is-success {
+  color: var(--v2-success);
+}
+
 .profile-status-shell {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -6622,6 +6755,48 @@ body.public-shell-mode:has(.public-shell.public-shell--design-v2) {
 
   .profile-settings {
     gap: var(--v2-space-5);
+  }
+
+  .profile-avatar-card {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-avatar-card__visual {
+    grid-template-columns: auto minmax(0, 1fr);
+    min-height: 0;
+    place-content: initial;
+    justify-items: start;
+    align-items: center;
+    padding: var(--v2-space-4);
+    border-right: 0;
+    border-bottom: 1px solid var(--v2-border);
+    text-align: left;
+  }
+
+  .profile-avatar-card__avatar {
+    width: 88px;
+    height: 88px;
+    font-size: 2.25rem;
+  }
+
+  .profile-avatar-card__body {
+    padding: var(--v2-space-4);
+  }
+
+  .profile-avatar-card__actions,
+  .profile-avatar-delete-confirmation,
+  .profile-avatar-delete-confirmation__actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .profile-avatar-card__actions > button,
+  .profile-avatar-delete-confirmation__actions > button {
+    width: 100%;
+  }
+
+  .profile-avatar-card__delete {
+    margin-left: 0;
   }
 
   .profile-status-shell {

--- a/frontend/tests/e2e/avatar-settings.spec.ts
+++ b/frontend/tests/e2e/avatar-settings.spec.ts
@@ -1,0 +1,220 @@
+/// <reference types="node" />
+
+import { expect, test, type Browser, type Page } from '@playwright/test';
+import { installTelegramHarness } from './fixtures/mobile-tma';
+import { installPlatformApi, type PlatformApiController } from './fixtures/platform-api';
+
+const avatarFile = {
+  name: 'new-avatar.png',
+  mimeType: 'image/png',
+  buffer: Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAFElEQVR42mNkYPj/n4GBgYGJAQoAHgQCAftFq20AAAAASUVORK5CYII=',
+    'base64',
+  ),
+};
+
+async function openAvatarSettings(page: Page) {
+  await page.goto('/app?section=profile');
+  await expect(page.getByRole('heading', { name: 'Аватар', exact: true })).toBeVisible();
+}
+
+async function chooseAvatar(page: Page) {
+  await page.getByLabel('Выбрать изображение для аватара').setInputFiles(avatarFile);
+  await expect(page.getByText('Предпросмотр нового изображения')).toBeVisible();
+}
+
+async function createBrowserProfile(
+  browser: Browser,
+  options: Parameters<typeof installPlatformApi>[1],
+) {
+  const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  const page = await context.newPage();
+  const api = await installPlatformApi(page, { ...options, browserSession: true });
+  return { context, page, api };
+}
+
+test('failed upload keeps the local preview and retry updates every account avatar', async ({
+  browser,
+}) => {
+  const { context, page, api } = await createBrowserProfile(browser, {
+    avatarState: 'provider',
+  });
+  await openAvatarSettings(page);
+
+  await chooseAvatar(page);
+  const previewSource = await page.locator('.profile-avatar-card__avatar img').getAttribute('src');
+  expect(previewSource).toMatch(/^blob:/);
+
+  api.failNextAvatarUpload();
+  await page.getByRole('button', { name: 'Сохранить аватар' }).click();
+  await expect(page.getByRole('alert')).toContainText('Не удалось обработать изображение');
+  await expect(page.getByRole('button', { name: 'Повторить сохранение' })).toBeVisible();
+  await expect(page.locator('.profile-avatar-card__avatar img')).toHaveAttribute(
+    'src',
+    previewSource!,
+  );
+
+  await page.getByRole('button', { name: 'Повторить сохранение' }).click();
+  await expect(page.getByRole('status')).toContainText('Аватар сохранён');
+  expect(api.avatarUploads()).toBe(2);
+  await expect(page.getByText('Используется свой аватар')).toBeVisible();
+  await expect(page.locator('.app-desktop-account-entry img')).toHaveAttribute('src', /^blob:/);
+
+  await page.reload();
+  await expect(page.getByText('Используется свой аватар')).toBeVisible();
+  await expect(page.locator('.profile-avatar-card__avatar img')).toHaveAttribute('src', /^blob:/);
+  await context.close();
+});
+
+test('deletion requires confirmation and restores the provider avatar', async ({ browser }) => {
+  const { context, page, api } = await createBrowserProfile(browser, {
+    avatarState: 'custom',
+  });
+  await openAvatarSettings(page);
+
+  await page.getByRole('button', { name: 'Удалить свой аватар' }).click();
+  const confirmation = page.getByRole('alertdialog', { name: 'Удалить свой аватар?' });
+  await expect(confirmation).toBeVisible();
+  await expect(confirmation.getByRole('button', { name: 'Удалить', exact: true })).toBeFocused();
+  await confirmation.getByRole('button', { name: 'Удалить', exact: true }).click();
+
+  await expect(page.getByRole('status')).toContainText('фото из способа входа');
+  await expect(page.getByText('Используется фото из способа входа')).toBeVisible();
+  await expect(page.locator('.profile-avatar-card__avatar img')).toHaveAttribute(
+    'src',
+    /^data:image\/svg\+xml/,
+  );
+  expect(api.avatarDeletes()).toBe(1);
+  await context.close();
+});
+
+for (const viewport of [
+  { width: 360, height: 800 },
+  { width: 390, height: 844 },
+  { width: 430, height: 932 },
+]) {
+  test(`mobile ${viewport.width}px keeps avatar actions inside the viewport`, async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      viewport,
+      hasTouch: true,
+      reducedMotion: viewport.width === 360 ? 'reduce' : 'no-preference',
+    });
+    const page = await context.newPage();
+    await installPlatformApi(page, { browserSession: true, avatarState: 'custom' });
+    await openAvatarSettings(page);
+
+    await expect(page.locator('.profile-avatar-card')).toBeVisible();
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    );
+    expect(overflow).toBeLessThanOrEqual(1);
+    for (const button of await page.locator('.profile-avatar-card__actions button').all()) {
+      const box = await button.boundingBox();
+      expect(box?.height).toBeGreaterThanOrEqual(44);
+    }
+    await context.close();
+  });
+}
+
+test('mocked Telegram Mini App uses the same custom avatar flow', async ({ browser }) => {
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    hasTouch: true,
+  });
+  const page = await context.newPage();
+  await installTelegramHarness(page, {
+    colorScheme: 'dark',
+    safeAreaInset: { top: 16, right: 0, bottom: 20, left: 0 },
+    contentSafeAreaInset: { top: 8, right: 0, bottom: 24, left: 0 },
+  });
+  const api: PlatformApiController = await installPlatformApi(page, { avatarState: 'default' });
+  await openAvatarSettings(page);
+
+  await chooseAvatar(page);
+  await page.getByRole('button', { name: 'Сохранить аватар' }).click();
+  await expect(page.getByRole('status')).toContainText('Аватар сохранён');
+  await expect(page.locator('html')).toHaveAttribute('data-color-scheme', 'dark');
+  await page.getByRole('button', { name: 'Открыть профиль и настройки' }).click();
+  await expect(page.getByRole('dialog', { name: 'Профиль и настройки' })).toBeVisible();
+  await expect(page.locator('.app-more-panel__identity img')).toHaveAttribute('src', /^blob:/);
+  expect(api.authInitCalls()).toBe(1);
+  expect(api.avatarUploads()).toBe(1);
+  await context.close();
+});
+
+test('captures the owner approval matrix in matching light and dark states', async ({
+  browser,
+}) => {
+  const surfaces = [
+    { name: 'desktop-1280x900', viewport: { width: 1280, height: 900 }, hasTouch: false },
+    { name: 'mobile-390x844', viewport: { width: 390, height: 844 }, hasTouch: true },
+  ] as const;
+  const states = ['default', 'provider', 'custom', 'error', 'delete-confirmation'] as const;
+
+  for (const surface of surfaces) {
+    for (const theme of ['light', 'dark'] as const) {
+      for (const state of states) {
+        const context = await browser.newContext({
+          viewport: surface.viewport,
+          hasTouch: surface.hasTouch,
+          colorScheme: theme,
+        });
+        await context.addInitScript((selectedTheme) => {
+          localStorage.setItem('app-theme', selectedTheme);
+        }, theme);
+        const page = await context.newPage();
+        const api = await installPlatformApi(page, {
+          browserSession: true,
+          avatarState:
+            state === 'provider' || state === 'error'
+              ? 'provider'
+              : state === 'custom' || state === 'delete-confirmation'
+                ? 'custom'
+                : 'default',
+        });
+        await openAvatarSettings(page);
+        await expect(page.locator('html')).toHaveAttribute('data-color-scheme', theme);
+
+        if (state === 'error') {
+          await chooseAvatar(page);
+          api.failNextAvatarUpload();
+          await page.getByRole('button', { name: 'Сохранить аватар' }).click();
+          await expect(page.getByRole('alert')).toBeVisible();
+        } else if (state === 'delete-confirmation') {
+          await page.getByRole('button', { name: 'Удалить свой аватар' }).click();
+          await expect(page.getByRole('alertdialog')).toBeVisible();
+        } else {
+          const label = {
+            default: 'Используется нейтральный emoji',
+            provider: 'Используется фото из способа входа',
+            custom: 'Используется свой аватар',
+          }[state];
+          await expect(page.getByText(label)).toBeVisible();
+        }
+
+        if (surface.hasTouch) {
+          const overflow = await page.evaluate(
+            () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+          );
+          expect(overflow).toBeLessThanOrEqual(1);
+        }
+        await page.screenshot({
+          path: `../.artifacts/screenshots/task-110/approval/${surface.name}-${theme}-${state}.png`,
+          fullPage: false,
+        });
+        const bottomNavigation = page.locator('.app-bottom-nav');
+        if (surface.hasTouch) {
+          await bottomNavigation.evaluate((element) => {
+            element.style.visibility = 'hidden';
+          });
+        }
+        await page.locator('.profile-avatar-card').screenshot({
+          path: `../.artifacts/screenshots/task-110/approval/card-${surface.name}-${theme}-${state}.png`,
+        });
+        await context.close();
+      }
+    }
+  }
+});

--- a/frontend/tests/e2e/fixtures/platform-api.ts
+++ b/frontend/tests/e2e/fixtures/platform-api.ts
@@ -1,3 +1,5 @@
+/// <reference types="node" />
+
 import type { Page, Route } from '@playwright/test';
 
 type WorkoutStatus = 'planned' | 'in_progress' | 'completed' | 'none';
@@ -19,6 +21,7 @@ export interface PlatformApiOptions {
   trainerActive?: boolean;
   measurementHistory?: 'none' | 'many';
   cardioState?: 'empty' | 'planned' | 'completed';
+  avatarState?: 'default' | 'provider' | 'custom';
 }
 
 export interface PlatformApiController {
@@ -44,6 +47,9 @@ export interface PlatformApiController {
   accountExportCreates(): number;
   accountUnlinks(): string[];
   accountDeletes(): number;
+  failNextAvatarUpload(): void;
+  avatarUploads(): number;
+  avatarDeletes(): number;
 }
 
 const zeroNutrition = {
@@ -100,6 +106,10 @@ export async function installPlatformApi(
   let weeklyReviewSubmits = 0;
   let accountExportCreates = 0;
   let accountDeletes = 0;
+  let avatarState = options.avatarState ?? 'default';
+  let failNextAvatarUpload = false;
+  let avatarUploads = 0;
+  let avatarDeletes = 0;
   let accountExportState = options.accountExportState ?? 'none';
   let authProviders = [...(options.authProviders ?? ['telegram'])];
   const accountUnlinks: string[] = [];
@@ -175,6 +185,47 @@ export async function installPlatformApi(
   let adaptationApplyCalls = 0;
   let adaptationApplyMode: 'success' | 'conflict' | 'error' = 'success';
   const progressionOutcome = options.progressionOutcome ?? 'review';
+  const providerAvatar =
+    'data:image/svg+xml;charset=utf-8,' +
+    encodeURIComponent(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128"><rect width="128" height="128" fill="#d8f799"/><circle cx="64" cy="48" r="24" fill="#43631f"/><path d="M22 122c4-31 20-46 42-46s38 15 42 46" fill="#43631f"/></svg>',
+    );
+  const customAvatarUpdatedAt = '2030-01-02T12:00:00Z';
+  const currentUser = () => ({
+    id: 7,
+    telegram_user_id: authProviders.includes('telegram') ? 7007 : null,
+    username: 'mobile_user',
+    first_name: 'Анна',
+    photo_url: avatarState === 'provider' || avatarState === 'custom' ? providerAvatar : null,
+    custom_avatar:
+      avatarState === 'custom'
+        ? {
+            content_type: 'image/webp',
+            byte_size: 1084,
+            width: 512,
+            height: 512,
+            updated_at: customAvatarUpdatedAt,
+          }
+        : null,
+    is_coach: trainerActive,
+    is_admin: false,
+    has_active_program: activeProgram,
+    has_workout_history: false,
+    auth_providers: authProviders,
+    onboarding: { status: 'complete', required_fields: [], missing_fields: [] },
+    profile: {
+      full_name: 'Анна Петрова',
+      timezone: 'Europe/Moscow',
+      goal: 'maintenance',
+      level: 'beginner',
+      height_cm: 168,
+      weight_kg: 67,
+      workouts_per_week: 3,
+      cardio_trainings_per_week: 1,
+      kbju: currentTarget,
+    },
+    trainer: null,
+  });
   const previousTargetDate = new Date(todayDate);
   previousTargetDate.setUTCDate(previousTargetDate.getUTCDate() - 30);
   const targetSource = options.nutritionTargetSource ?? 'manual';
@@ -1166,34 +1217,42 @@ export async function installPlatformApi(
       accountDeletes += 1;
       return route.fulfill({ status: 204 });
     }
+    if (path.endsWith('/me/avatar') && request.method() === 'GET') {
+      if (avatarState !== 'custom') {
+        return route.fulfill({ status: 404, json: { detail: 'Custom avatar not found' } });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'image/webp',
+        body: Buffer.from(
+          'UklGRjQEAABXRUJQVlA4ICgEAADQGwCdASqAAIAAPjEYiUKiIaEWzjQAIAMEs4BqRSMgP/oMLs4xtiueO01Cnb/BX9P/gHbV/a8UIAO+un1nhB2pv8Tkpvxb/afwD+deQD4AeIB6Hn+T88/4B+gHkDTAP45/nvYk/Qf9R/VfyA9hfxL/0vcC/i38r/2H9m/w/uZ+oD9ZvYF/V4b0YSGupd7aYQHC7RGxfixSB86Po6wMWpXPiOwqPEQocFVovGF/jumXFt9kCeY72DgVVkgXqRDsoN7OaLbA6b55lMfm0A2Afnxg+WuQVwnAK5qWYcwVNYQ4RQMxg8fc1uAA/v0lEv/WV/+ZX/5lf75HgMgnRnESCAAfpIPOfGqGc4+DGdJlvJGfpF34XWYV3pL/g07R66uV0G7CXAkxCWPEAD9ibHI0VaXt02JPDARoH99l0/7AACo/7Vk3/js91Rzx8C1zMad8/rQGhB6w5IPcgJfT5iFWK+xF5/ilkNl0+OIwntYK7CyMBcV+omuj+ZR4ubvMv8ux7+sHidS2DA9sFH08nh5R82zn6skw+YB4ZVU3OAnG7j8WACgXAmnQ7GPAxjqNu0Zk9iY4OfDdod559qh7Onvw2MTuHSh/7gu+bSEy5/GxhIYvFWMZJ2unPvX3odo6GHl6Uk4wsKPL4iLxKVqLdN3+6NKwo3KrMfOONxVoWlOVty4WN8blGBoRBCdlDdbTwxbKw1jb9qW1I45aG87wMUiQooJ4jaD6BsckeBzmCNVcjDQniN5WNbg+bHfG/hEQV/2t3aG0OWiVe8TSFupD3yVBnAc2JcWYNxHpz4eJEfsUe21O+JljaqtHUjXuRnyXFnEwXAVa1LtFpSWT++zCv20SSTu4+M5IvVmd/xhjH6k1P7as3Be/os2YeaYXoi/Bopt8Mui346kCQ5fbVmDfJII6oBDpBNVFes5OqlcPfjKvSFsKFQhWC38vmslkAmV50P+e9jkV7Lp/C8br73Ynx4WvImahkZCndKigYjzazD6n4g0Pca37wG1/jZqHedohaSz+O+c91DVUy+lAr4BY1uqcs9zxxJ6DKzJuihFgSkWbxKlay5yxfVVjxjY2dJD2ZYGw+JwGe/szxNCuzjOqSf/miJ1rH35y53yIdBQLxBfR6GWEjuf4xnM9nP8Lg7o67VVGYweSEpWcu8RBYApOjSG5O3pzOuIKUVOO7weBwE9Hbkzi74Q1pALtUMAJdzCKSGs7TzbPIK9FYf+jw2sAIIDFYuuCUC519wquOTol44qxTGCypj0DhyUV+2SnwF2vM2cmnYl4p5PdurFRqqM3yOzI+bjl5h7wu8REg46LJ4UKUqvOP/KzjR/IyugC8aNqyuT6GXMB+Er9Tv1+prbI7wd3+aQvZuK134S6OtQcnpV6KcnBK5tW2R32Rc6Vq86Gby/RWv5+WVVeQYAAAA==',
+          'base64',
+        ),
+      });
+    }
+    if (path.endsWith('/me/avatar') && request.method() === 'PUT') {
+      avatarUploads += 1;
+      if (failNextAvatarUpload) {
+        failNextAvatarUpload = false;
+        return route.fulfill({
+          status: 422,
+          json: { detail: 'Не удалось обработать изображение' },
+        });
+      }
+      avatarState = 'custom';
+      return route.fulfill({ json: currentUser() });
+    }
+    if (path.endsWith('/me/avatar') && request.method() === 'DELETE') {
+      avatarDeletes += 1;
+      avatarState =
+        options.avatarState === 'provider' || options.avatarState === 'custom'
+          ? 'provider'
+          : 'default';
+      return route.fulfill({ json: currentUser() });
+    }
     if (path.endsWith('/me')) {
       meCalls += 1;
-      return route.fulfill({
-        json: {
-          id: 7,
-          telegram_user_id: authProviders.includes('telegram') ? 7007 : null,
-          username: 'mobile_user',
-          first_name: 'Анна',
-          is_coach: trainerActive,
-          is_admin: false,
-          has_active_program: activeProgram,
-          has_workout_history: false,
-          auth_providers: authProviders,
-          onboarding: { status: 'complete', required_fields: [], missing_fields: [] },
-          profile: {
-            full_name: 'Анна Петрова',
-            timezone: 'Europe/Moscow',
-            goal: 'maintenance',
-            level: 'beginner',
-            height_cm: 168,
-            weight_kg: 67,
-            workouts_per_week: 3,
-            cardio_trainings_per_week: 1,
-            kbju: currentTarget,
-          },
-          trainer: null,
-        },
-      });
+      return route.fulfill({ json: currentUser() });
     }
     if (path.endsWith('/coach/clients')) {
       return route.fulfill({
@@ -1997,6 +2056,15 @@ export async function installPlatformApi(
     },
     accountDeletes() {
       return accountDeletes;
+    },
+    failNextAvatarUpload() {
+      failNextAvatarUpload = true;
+    },
+    avatarUploads() {
+      return avatarUploads;
+    },
+    avatarDeletes() {
+      return avatarDeletes;
     },
   };
 }

--- a/frontend/tests/unit/app/AppShell.test.tsx
+++ b/frontend/tests/unit/app/AppShell.test.tsx
@@ -26,8 +26,9 @@ function finishAnimation(element: Element, animationName: string) {
   Object.defineProperty(event, 'animationName', { value: animationName });
   fireEvent(element, event);
 }
-const { authState, navigation, user } = vi.hoisted(() => ({
+const { authState, avatarFile, navigation, user } = vi.hoisted(() => ({
   authState: { missing: false },
+  avatarFile: vi.fn(),
   navigation: { path: '/coach', search: '' },
   user: {
     id: 1,
@@ -36,8 +37,17 @@ const { authState, navigation, user } = vi.hoisted(() => ({
     is_coach: true,
     is_root: false,
     photo_url: null as string | null,
+    custom_avatar: null as null | {
+      content_type: 'image/webp';
+      byte_size: number;
+      width: 512;
+      height: 512;
+      updated_at: string;
+    },
   },
 }));
+
+vi.mock('../../../src/shared/api/client', () => ({ apiFile: avatarFile }));
 
 vi.mock('../../../src/app/AuthProvider', () => ({
   useOptionalAuth: () => (authState.missing ? null : { user, logout }),
@@ -57,10 +67,12 @@ describe('AppShell', () => {
     cleanup();
     authState.missing = false;
     user.photo_url = null;
+    user.custom_avatar = null;
     user.is_root = false;
     navigation.path = '/coach';
     navigation.search = '';
     logout.mockClear();
+    avatarFile.mockReset();
     vi.unstubAllGlobals();
     stubViewport(1280);
     delete window.Telegram;
@@ -228,6 +240,36 @@ describe('AppShell', () => {
     fireEvent.error(image!);
     expect(avatar?.querySelector('img')).not.toBeInTheDocument();
     expect(avatar).toHaveTextContent(/🏋️|💪|🏃|🚴|🥗|⚡|🎯|🔥/);
+  });
+
+  it('показывает private avatar раньше provider photo и возвращается к provider при ошибке', async () => {
+    avatarFile.mockResolvedValue({
+      blob: new Blob(['private-avatar'], { type: 'image/webp' }),
+      filename: null,
+    });
+    user.custom_avatar = {
+      content_type: 'image/webp',
+      byte_size: 4096,
+      width: 512,
+      height: 512,
+      updated_at: '2030-01-02T12:00:00',
+    };
+    user.photo_url = 'https://provider.example.test/avatar.jpg';
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:private-avatar'),
+      revokeObjectURL: vi.fn(),
+    });
+
+    const { container } = render(<AppShell>Содержимое</AppShell>);
+    const avatar = container.querySelector('.app-desktop-account-entry__avatar');
+    await waitFor(() =>
+      expect(avatar?.querySelector('img')).toHaveAttribute('src', 'blob:private-avatar'),
+    );
+    const privateImage = avatar?.querySelector('img');
+    expect(privateImage).not.toBeNull();
+    fireEvent.error(privateImage!);
+    expect(avatar?.querySelector('img')).toHaveAttribute('src', user.photo_url);
   });
 
   it('использует account row под брендом как единственный desktop-вход в профиль без dialog', () => {

--- a/frontend/tests/unit/features/profile/AvatarSettings.test.tsx
+++ b/frontend/tests/unit/features/profile/AvatarSettings.test.tsx
@@ -1,0 +1,115 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AvatarSettings } from '../../../../src/features/profile/AvatarSettings';
+
+const { api, authState, updateUser } = vi.hoisted(() => ({
+  api: vi.fn(),
+  authState: {
+    user: {
+      id: 7,
+      first_name: 'Анна',
+      username: 'anna',
+      photo_url: null as string | null,
+      custom_avatar: null as null | {
+        content_type: 'image/webp';
+        byte_size: number;
+        width: 512;
+        height: 512;
+        updated_at: string;
+      },
+      profile: { full_name: 'Анна Петрова' },
+    },
+  },
+  updateUser: vi.fn(),
+}));
+
+vi.mock('../../../../src/app/AuthProvider', () => ({
+  useAuth: () => ({ user: authState.user, updateUser }),
+}));
+
+vi.mock('../../../../src/shared/api/client', () => ({
+  api,
+  ApiError: class ApiError extends Error {},
+}));
+
+vi.mock('../../../../src/shared/account/AccountIdentity', () => ({
+  AccountAvatar: ({ previewUrl }: { previewUrl?: string | null }) => (
+    <span data-testid="avatar-preview" data-preview-url={previewUrl ?? ''} />
+  ),
+}));
+
+describe('AvatarSettings', () => {
+  beforeEach(() => {
+    api.mockReset();
+    updateUser.mockReset();
+    authState.user.photo_url = null;
+    authState.user.custom_avatar = null;
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:selected-avatar'),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps a selected file for preview and updates the shared user after save', async () => {
+    api.mockResolvedValue({ ...authState.user, custom_avatar: { updated_at: '2030-01-02' } });
+    render(<AvatarSettings />);
+
+    expect(screen.getByText('Используется нейтральный emoji')).toBeInTheDocument();
+    const file = new File(['png'], 'portrait.png', { type: 'image/png' });
+    fireEvent.change(screen.getByLabelText('Выбрать изображение для аватара'), {
+      target: { files: [file] },
+    });
+    expect(screen.getByTestId('avatar-preview')).toHaveAttribute(
+      'data-preview-url',
+      'blob:selected-avatar',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Сохранить аватар' }));
+    await waitFor(() => expect(api).toHaveBeenCalledOnce());
+    const options = api.mock.calls[0]?.[1];
+    expect(options.body).toBeInstanceOf(FormData);
+    const uploadedFile = (options.body as FormData).get('file') as File;
+    expect(uploadedFile).toMatchObject({ name: file.name, size: file.size, type: file.type });
+    await waitFor(() => expect(updateUser).toHaveBeenCalledOnce());
+    expect(screen.getByRole('status')).toHaveTextContent('Аватар сохранён');
+  });
+
+  it('shows a client validation error for unsupported files without a request', () => {
+    render(<AvatarSettings />);
+    fireEvent.change(screen.getByLabelText('Выбрать изображение для аватара'), {
+      target: { files: [new File(['heic'], 'portrait.heic', { type: 'image/heic' })] },
+    });
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Поддерживаются только JPEG, PNG и WebP');
+    expect(api).not.toHaveBeenCalled();
+  });
+
+  it('requires explicit confirmation and applies provider fallback after delete', async () => {
+    authState.user.photo_url = 'https://provider.example.test/avatar.jpg';
+    authState.user.custom_avatar = {
+      content_type: 'image/webp',
+      byte_size: 10_000,
+      width: 512,
+      height: 512,
+      updated_at: '2030-01-02T12:00:00',
+    };
+    api.mockResolvedValue({ ...authState.user, custom_avatar: null });
+    render(<AvatarSettings />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Удалить свой аватар' }));
+    const confirmation = screen.getByRole('alertdialog', { name: 'Удалить свой аватар?' });
+    expect(confirmation).toHaveTextContent('Фото из способа входа или emoji');
+    fireEvent.click(screen.getByRole('button', { name: /^Удалить$/ }));
+
+    await waitFor(() =>
+      expect(api).toHaveBeenCalledWith('/api/v1/me/avatar', { method: 'DELETE' }),
+    );
+    expect(updateUser).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/tests/unit/shared/account/AccountIdentity.test.tsx
+++ b/frontend/tests/unit/shared/account/AccountIdentity.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AccountAvatar } from '../../../../src/shared/account/AccountIdentity';
+
+const { apiFile } = vi.hoisted(() => ({ apiFile: vi.fn() }));
+
+vi.mock('../../../../src/shared/api/client', () => ({ apiFile }));
+
+describe('AccountAvatar', () => {
+  beforeEach(() => {
+    apiFile.mockReset();
+    vi.stubGlobal('URL', {
+      ...URL,
+      createObjectURL: vi.fn(() => 'blob:private-avatar'),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('uses deterministic emoji when no image source exists', () => {
+    const view = render(<AccountAvatar name="Анна Петрова" />);
+    const first = view.container.textContent;
+    view.rerender(<AccountAvatar name="Анна Петрова" />);
+    expect(view.container.textContent).toBe(first);
+    expect(first).toMatch(/🏋️|💪|🏃|🚴|🥗|⚡|🎯|🔥/);
+  });
+
+  it('prefers private bytes and falls back through provider photo to emoji', async () => {
+    apiFile.mockResolvedValue({
+      blob: new Blob(['private'], { type: 'image/webp' }),
+      filename: null,
+    });
+    const view = render(
+      <AccountAvatar
+        customAvatarVersion="2030-01-02T12:00:00"
+        name="Анна Петрова"
+        photoUrl="https://provider.example.test/avatar.jpg"
+      />,
+    );
+
+    await waitFor(() =>
+      expect(view.container.querySelector('img')).toHaveAttribute('src', 'blob:private-avatar'),
+    );
+    fireEvent.error(view.container.querySelector('img')!);
+    expect(view.container.querySelector('img')).toHaveAttribute(
+      'src',
+      'https://provider.example.test/avatar.jpg',
+    );
+    fireEvent.error(view.container.querySelector('img')!);
+    expect(view.container.querySelector('img')).not.toBeInTheDocument();
+    expect(view.container).toHaveTextContent(/🏋️|💪|🏃|🚴|🥗|⚡|🎯|🔥/);
+  });
+});

--- a/frontend/tests/unit/shared/api/client.test.ts
+++ b/frontend/tests/unit/shared/api/client.test.ts
@@ -165,6 +165,24 @@ describe('api client', () => {
     });
   });
 
+  it('sends FormData with auth without overriding the browser multipart boundary', async () => {
+    setAccessToken('avatar-token');
+    const form = new FormData();
+    form.append('file', new Blob(['avatar'], { type: 'image/png' }), 'avatar.png');
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+
+    await expect(
+      api<{ ok: boolean }>('/api/v1/me/avatar', { method: 'PUT', body: form }),
+    ).resolves.toEqual({ ok: true });
+
+    const init = fetchMock.mock.calls[0]?.[1];
+    expect(init?.body).toBe(form);
+    expect(init?.headers).toMatchObject({ Authorization: 'Bearer avatar-token' });
+    expect(init?.headers).not.toHaveProperty('Content-Type');
+  });
+
   it('forwards caller cancellation without presenting it as a timeout', async () => {
     const controller = new AbortController();
     vi.spyOn(globalThis, 'fetch').mockImplementationOnce((_input, init) => {

--- a/scripts/task_session.py
+++ b/scripts/task_session.py
@@ -1354,23 +1354,35 @@ class TaskController:
             raise TaskSessionError("withdraw-integration requires a non-empty reason")
         integration_path = self.store.mode_lease_path("integration")
         integration = self.store.read_json(integration_path)
-        if integration is None or integration.get("task_id") != expected:
-            raise TaskSessionError(f"Task {expected} does not own integration lease")
-        pull_request = self._github().pull_request(int(integration["pr_number"]))
+        queue = self.store.read_json(self.store.queue_path, {"version": 1, "candidates": []})
+        if not queue["candidates"] or queue["candidates"][0].get("task_id") != expected:
+            raise TaskSessionError(f"Task {expected} is not the integration queue head")
+        candidate = queue["candidates"][0]
+        if integration is None:
+            if candidate.get("state") != "queued":
+                raise TaskSessionError(
+                    f"Task {expected} has no integration lease and is not queued"
+                )
+        elif (
+            integration.get("task_id") != expected
+            or candidate.get("state") != "eligible"
+            or candidate.get("head_sha") != integration.get("head_sha")
+            or candidate.get("pr_number") != integration.get("pr_number")
+        ):
+            raise TaskSessionError(f"Task {expected} does not own matching integration state")
+        pull_request = self._github().pull_request(int(candidate["pr_number"]))
         if pull_request.get("merged_at"):
             raise TaskSessionError("Merged integration cannot be withdrawn; verify exact dev CI")
         with self.store.lock():
             current = self.store.read_json(integration_path)
             if current != integration:
                 raise TaskSessionError("Integration lease changed while withdrawal was validated")
-            queue = self.store.read_json(self.store.queue_path)
-            if (
-                not queue["candidates"]
-                or queue["candidates"][0].get("task_id") != expected
-                or queue["candidates"][0].get("head_sha") != integration.get("head_sha")
-            ):
+            current_queue = self.store.read_json(
+                self.store.queue_path, {"version": 1, "candidates": []}
+            )
+            if not current_queue["candidates"] or current_queue["candidates"][0] != candidate:
                 raise TaskSessionError("Integration queue head changed before withdrawal")
-            withdrawn = queue["candidates"].pop(0)
+            withdrawn = current_queue["candidates"].pop(0)
             withdrawn.update(
                 {
                     "state": "withdrawn-for-fix",
@@ -1387,9 +1399,10 @@ class TaskController:
             task_lease["last_integration_withdrawal"] = withdrawn
             for field in ("ready_head_sha", "review_verdict", "qa_verdict"):
                 task_lease.pop(field, None)
-            StateStore.replace_json(self.store.queue_path, queue)
+            StateStore.replace_json(self.store.queue_path, current_queue)
             StateStore.replace_json(task_lease_path, task_lease)
-            integration_path.unlink()
+            if integration is not None:
+                integration_path.unlink()
         return {"withdrawn": withdrawn, "task_lease": task_lease}
 
     def complete_integration(self, task_id: str, *, merge_sha: str) -> dict[str, Any]:

--- a/tests/test_task_session.py
+++ b/tests/test_task_session.py
@@ -686,6 +686,28 @@ def test_unmerged_integration_can_be_withdrawn_for_blocking_fix(
     assert not controller.store.mode_lease_path("integration").exists()
 
 
+def test_queued_integration_can_be_withdrawn_before_checks_pass(
+    repository: tuple[Path, Any],
+) -> None:
+    root, git_repository = repository
+    base_sha = git_repository.ref("origin/dev")
+    head_sha = "5" * 40
+    github = FakeGitHub(base_sha)
+    controller = task_session.TaskController(git_repository, github=github)
+    _task_lease(controller, "309", root, base_sha, ready_head_sha=head_sha)
+    github.pulls[9] = _task_pr(9, "309", base_sha, head_sha)
+    github.commits[9] = [_task_commit("309")]
+    controller.enqueue_integration("309", pr_number=9)
+
+    result = controller.withdraw_integration("309", reason="failed required checks")
+
+    assert result["withdrawn"]["state"] == "withdrawn-for-fix"
+    assert result["task_lease"]["lifecycle_state"] == "implementation"
+    assert "ready_head_sha" not in result["task_lease"]
+    assert controller.store.read_json(controller.store.queue_path)["candidates"] == []
+    assert not controller.store.mode_lease_path("integration").exists()
+
+
 def test_research_readonly_lease_cannot_enter_integration_queue(
     repository: tuple[Path, Any],
 ) -> None:


### PR DESCRIPTION
## Summary
- add private normalized custom avatar upload, replacement, removal and precedence
- include avatar privacy lifecycle, export snapshot integrity and 5 MiB upload contract
- retain Task 122 desktop/mobile profile navigation behavior

## Evidence
- task PR #112 exact head ae4b35aa4af97622de99e84507cdbec3aea548bb: required checks passed
- merged dev SHA 07e3351ff2838a8b30aacd8d1e3868d17e010ee7: push CI run 33477419220 passed
- owner-approved light/dark desktop and mobile visual matrices