### PR TITLE
[Task 131] Automate one-command delivery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,11 @@ jobs:
   quality:
     name: Python quality
     needs: [release-sequence, task-provenance]
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.base.ref != 'master' ||
+      github.event.pull_request.head.ref != 'dev' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -152,6 +157,11 @@ jobs:
   frontend:
     name: Frontend
     needs: [release-sequence, task-provenance]
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.base.ref != 'master' ||
+      github.event.pull_request.head.ref != 'dev' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -216,6 +226,11 @@ jobs:
   frontend-smoke:
     name: Frontend smoke (${{ matrix.shard }}/3)
     needs: [release-sequence, task-provenance]
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.base.ref != 'master' ||
+      github.event.pull_request.head.ref != 'dev' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -264,6 +279,11 @@ jobs:
   python-tests:
     name: Python tests (${{ matrix.shard }})
     needs: [release-sequence, task-provenance]
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.base.ref != 'master' ||
+      github.event.pull_request.head.ref != 'dev' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -362,6 +382,11 @@ jobs:
   migrated-stack:
     name: Migrated PostgreSQL stack
     needs: [release-sequence, task-provenance]
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.base.ref != 'master' ||
+      github.event.pull_request.head.ref != 'dev' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -476,6 +501,11 @@ jobs:
   dependency-audit:
     name: Dependency audit
     needs: [release-sequence, task-provenance]
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.base.ref != 'master' ||
+      github.event.pull_request.head.ref != 'dev' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -512,6 +542,11 @@ jobs:
   containers:
     name: Container (${{ matrix.image }})
     needs: [release-sequence, task-provenance]
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.base.ref != 'master' ||
+      github.event.pull_request.head.ref != 'dev' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -621,6 +656,7 @@ jobs:
     steps:
       - name: Verify all CI jobs succeeded
         env:
+          CANONICAL_RELEASE_PR: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'master' && github.event.pull_request.head.ref == 'dev' && github.event.pull_request.head.repo.full_name == github.repository }}
           RELEASE_SEQUENCE_RESULT: ${{ needs.release-sequence.result }}
           TASK_PROVENANCE_RESULT: ${{ needs.task-provenance.result }}
           QUALITY_RESULT: ${{ needs.quality.result }}
@@ -633,10 +669,20 @@ jobs:
         run: |
           test "$RELEASE_SEQUENCE_RESULT" = success
           test "$TASK_PROVENANCE_RESULT" = success
-          test "$QUALITY_RESULT" = success
-          test "$FRONTEND_RESULT" = success
-          test "$FRONTEND_SMOKE_RESULT" = success
-          test "$PYTHON_TESTS_RESULT" = success
-          test "$MIGRATED_STACK_RESULT" = success
-          test "$DEPENDENCY_AUDIT_RESULT" = success
-          test "$CONTAINERS_RESULT" = success
+          if [ "$CANONICAL_RELEASE_PR" = "true" ]; then
+            test "$QUALITY_RESULT" = skipped
+            test "$FRONTEND_RESULT" = skipped
+            test "$FRONTEND_SMOKE_RESULT" = skipped
+            test "$PYTHON_TESTS_RESULT" = skipped
+            test "$MIGRATED_STACK_RESULT" = skipped
+            test "$DEPENDENCY_AUDIT_RESULT" = skipped
+            test "$CONTAINERS_RESULT" = skipped
+          else
+            test "$QUALITY_RESULT" = success
+            test "$FRONTEND_RESULT" = success
+            test "$FRONTEND_SMOKE_RESULT" = success
+            test "$PYTHON_TESTS_RESULT" = success
+            test "$MIGRATED_STACK_RESULT" = success
+            test "$DEPENDENCY_AUDIT_RESULT" = success
+            test "$CONTAINERS_RESULT" = success
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,6 +183,11 @@ destructive/external authorization or terminal blocker, continue automatically t
 review, QA, commit, PR, merge, CI and normal release stages without waiting for another owner
 prompt. Stop only at the declared gate and report its exact evidence/decision requirement.
 
+An explicit owner selection of a task, or `scripts/run_task_delivery.py <ID>`, is one standing
+authorization for that task's normal path. Treat controller commands, commit/push, task and release
+PR handling, CI/deploy monitoring and safe closeout as internal stages; do not turn them into new
+generic owner prompts.
+
 Если текущая task не объявляет `OWNER_CHECKPOINT`, `HUMAN_EVIDENCE`, `MANUAL_VISUAL_APPROVAL`,
 `LEGAL_COUNSEL_REQUIRED`, `EXTERNAL_AUTHORIZATION`, `DESTRUCTIVE_ACTION` или terminal blocker,
 controller/lifecycle после terminal success автоматически продолжает применимые review, QA,
@@ -252,6 +257,8 @@ repository-native coordination boundary. Runtime leases live only in the shared 
 missing/corrupted state is a blocker. Task PRs target only `dev`, preserve `[Task <ID>]` in branch,
 commit and PR provenance, and merge only as the current integration queue head after exact-head
 `checks`. A release lease or open `dev -> master` PR freezes every mutation of `dev`.
+The normal owner-facing entry is `python scripts/run_task_delivery.py <ID>`; direct controller
+commands are low-level implementation and recovery operations.
 
 Parallel read-only/research sessions are allowed only when task metadata permits them and each has
 its own lease. Parallel write branches may be prepared only when dependency/concurrency metadata
@@ -378,7 +385,9 @@ production deployment. Eligibility requires a
 tracked logical commit, completed implementation/review/QA/final verification, zero unresolved
 `BLOCKER`, `HIGH` and `MEDIUM`, synchronized findings, current `master` ancestry in `dev`, a clean
 scoped worktree and no mandatory owner/human/visual gate. The agent must monitor required check
-`checks`, exact merged-dev push CI, post-merge CI and deployment to terminal success. The narrow
+`checks`, exact merged-dev push CI, post-merge CI and deployment to terminal success. Canonical
+same-repository `dev -> master` PR checks reuse the terminal successful exact merged-dev full CI and
+run only release-sequence/provenance aggregation; exceptional master PRs still run the full suite. The narrow
 deployed-sync GitHub App then fast-forwards `dev` to the exact successful current `master`; ordinary
 direct user/PAT push remains forbidden. После exact ref sync normal post-deploy closeout без нового
 owner prompt выполняет controller `finish` из canonical `dev` worktree, безопасный cleanup exact
@@ -422,7 +431,8 @@ Before declaring tracked backlog implementation complete:
 - confirm no secrets or debug artifacts were introduced;
 - confirm migrations, generated files, dependencies and configuration changes are intentional;
 - confirm all blocking `BLOCKER/HIGH` review/QA findings are resolved or explicitly blocked;
-- keep `MEDIUM/LOW/NIT/OUT_OF_SCOPE` as concise non-blocking follow-ups rather than reopening scope;
+- keep `MEDIUM/LOW/NIT/OUT_OF_SCOPE` as concise non-blocking follow-ups for commit rather than
+  reopening scope, while requiring zero unresolved `MEDIUM` before release;
 - confirm every new or changed `MEDIUM/LOW` is synchronized in
   `codex-backlog/bugs/FINDINGS.md` and cite its ID/status in the final report;
 - create the task's one logical commit only after successful applicable verification;

--- a/codex-backlog/GLOBAL_RULES.md
+++ b/codex-backlog/GLOBAL_RULES.md
@@ -73,6 +73,9 @@ gate, evidence и точки остановки в task-файле.
 - Внутри текущей task после terminal success автоматически выполняются применимые review, QA,
   commit, PR, serial merge в `dev`, CI и normal release шаги, если task явно не объявляет checkpoint
   или blocker. Следующая product task автоматически не запускается.
+- Явный выбор task владельцем или `scripts/run_task_delivery.py <ID>` является одним standing
+  authorization на normal path этой task. Низкоуровневые controller stages не являются действиями
+  владельца и не создают повторных generic approval prompts.
 - `scripts/task_session.py` и shared Git common-dir leases являются обязательной coordination
   boundary. Task PR идёт только в `dev`; exact-head `checks`, current-base policy и global
   integration lease разрешают merge только queue head. Release lease/open `dev -> master` PR
@@ -85,7 +88,7 @@ gate, evidence и точки остановки в task-файле.
   actions с отдельным owner approval, backup и preflight.
 - Для `AUTO_RELEASE_ELIGIBLE` task нормальный release path выполняется без дополнительного вопроса
   владельцу и строго последовательно: `task branch -> task PR dev -> exact-head checks -> serial
-  merge -> exact merged-dev push CI -> PR master -> required PR checks -> exact-head merge ->
+  merge -> exact merged-dev full push CI -> PR master -> quick provenance/checks -> exact-head merge ->
   post-merge CI -> automatic production deploy -> terminal success -> narrow App sync dev to exact
   deployed master -> automatic controller finish/clean task worktree and merged local branch ->
   archive task -> rebuild/check backlog manifests -> terminal report`. Direct feature push в `dev`

--- a/codex-backlog/TASK_EXECUTION_LIFECYCLE.md
+++ b/codex-backlog/TASK_EXECUTION_LIFECYCLE.md
@@ -4,6 +4,12 @@
 
 Фраза владельца `полный task lifecycle` означает: пройти только те стадии и роли, которые явно применимы к текущей task, и остановиться после неё.
 
+Явный выбор task владельцем или запуск `scripts/run_task_delivery.py <ID>` является одним standing
+authorization на весь normal path этой task. Launcher/controller автоматически выполняют внутренние
+стадии `task branch -> dev -> master -> production -> closeout`, не превращая commit/push/PR/merge,
+ожидание CI/deploy и безопасную cleanup в новые вопросы владельцу. Отдельный ответ нужен только для
+явно объявленного human/legal/external/destructive/task-specific gate или terminal blocker.
+
 ## 0. Контракты task имеют приоритет
 
 Перед работой:
@@ -162,7 +168,7 @@ owner-controlled решения, которое прямо изменяет rele
 
 ## 6. Исправление review findings и повторный review
 
-Автоматически исправляются только `BLOCKER/HIGH` текущего scope.
+Автоматически исправляются `BLOCKER/HIGH` и все release-blocking `MEDIUM` текущего scope.
 
 `MEDIUM` можно исправить в этой task только если fix одновременно:
 
@@ -171,7 +177,9 @@ owner-controlled решения, которое прямо изменяет rele
 - не требует новой роли или нового профильного skill;
 - не расширяет touched subsystem.
 
-Иначе `MEDIUM` фиксируется как follow-up и task продолжается к финализации.
+Иначе `MEDIUM` фиксируется как follow-up: local commit/finalization допустимы, но release остаётся
+`AUTO_RELEASE_BLOCKED` до отдельного owner-controlled решения и verified closure. Severity нельзя
+понижать или замалчивать ради release.
 
 `LOW/NIT/OUT_OF_SCOPE` после review автоматически не исправлять.
 
@@ -217,7 +225,9 @@ QA выбирает минимальный набор сценариев с ма
 
 Не прогонять одну и ту же матрицу на каждом layer и не повторять все viewport, если task изменяет один локальный state.
 
-QA findings используют ту же blocking policy: только `BLOCKER/HIGH` блокируют. `MEDIUM/LOW` не должны запускать новый feature cycle.
+QA findings используют ту же blocking policy: `BLOCKER/HIGH` блокируют завершение, а незакрытый
+`MEDIUM` блокирует release eligibility. `MEDIUM/LOW` не должны запускать несогласованный новый
+feature cycle.
 
 После исправления blocking QA defect повторить failed/affected scenario. Не выполнять полный QA заново.
 
@@ -248,7 +258,8 @@ Review/QA не могут сами по себе быть основанием �
 3. Убедиться, что нет случайных files/secrets/generated artifacts и review-driven scope creep.
 4. Проверить migrations/config/dependencies только если они реально изменились.
 5. Убедиться, что все `BLOCKER/HIGH` закрыты либо task остановлена с точным blocker.
-6. `MEDIUM/LOW/OUT_OF_SCOPE` перечислить кратко как non-blocking follow-ups; они не мешают commit.
+6. `MEDIUM/LOW/OUT_OF_SCOPE` перечислить кратко как non-blocking для commit; при этом каждый
+   `MEDIUM` обязан быть исправлен и targeted-rechecked до release eligibility.
 7. Синхронизировать все новые/изменённые `MEDIUM/LOW` в
    `codex-backlog/bugs/FINDINGS.md`; закрытые записи не удалять, а обновлять status/verification.
 8. Создать один логический commit в lease-bound `task/<ID>-<slug>` branch/worktree при tracked
@@ -307,8 +318,10 @@ Task является `AUTO_RELEASE_ELIGIBLE`, только если однов�
    переоткрыть ранее закрытый matching PR, если его base/scope остаются корректными. Если после
    открытия PR требуется ещё один code/config/docs commit или новый task merge, PR необходимо
    закрыть, вернуть change в task branch/worktree и повторить task PR + serial integration;
-5. проверить expected PR head SHA и required check `checks`; required PR checks должны завершиться
-   успешно именно для текущего PR head, а success более раннего branch CI их не подменяет;
+5. проверить expected PR head SHA и required check `checks`. Для canonical same-repository
+   `dev -> master` PR этот быстрый check проверяет release sequence/provenance и terminal successful
+   exact merged-dev push-CI; тяжёлые jobs намеренно `skipped`, потому что уже выполнены для того же
+   tree. Exceptional/non-canonical PR в `master` обязан пройти полный suite;
 6. включить GitHub auto-merge либо после green required PR checks выполнить эквивалентный обычный
    PR merge только для ожидаемого head SHA;
 7. проверить post-merge CI exact merged `master` SHA и затем автоматически запущенный production
@@ -343,7 +356,7 @@ task branch -> PR dev -> exact-head checks
   -> WAIT exact merged dev push CI: success
   -> ensure NO open release PR dev -> master during integration
   -> create/reopen PR dev -> master
-  -> WAIT exact PR required checks: success
+  -> WAIT quick exact release PR provenance/checks: success
   -> merge exact PR head
   -> WAIT post-merge master CI: success
   -> WAIT production deploy exact master SHA: success

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -17,7 +17,10 @@ commit, lifecycle/review/QA/final verification завершены, незакр�
 findings синхронизированы и отсутствует обязательный owner/human/manual visual gate. Тогда task
 branch через exact-head checked PR сериализованно интегрируется в `dev`; агент ждёт successful
 push-CI exact merge SHA, создаёт/обновляет PR `dev -> master`, проверяет exact PR head SHA и required
-check `checks`, выполняет checked merge и наблюдает post-merge CI/deploy до terminal success. После
+check `checks`, выполняет checked merge и наблюдает post-merge CI/deploy до terminal success. Exact
+merged `dev` push уже является полным release-candidate suite, поэтому canonical `dev -> master` PR
+выполняет только быстрые release-sequence/provenance checks и не повторяет тяжёлые jobs; любой
+exceptional PR в `master` проходит полный suite. После
 успешного release узкий GitHub App fast-forward'ит `dev` к exact deployed `master`.
 Failure/rollback/manual intervention required блокирует следующую backlog task.
 
@@ -29,8 +32,9 @@ queue head. Repository `delete_branch_on_merge` не заменяет owner-safe
 обновиться от current `dev` и повторить checks.
 
 После successful production deploy `.github/workflows/sync-dev-after-deploy.yml` fast-forward'ит
-`dev` только на exact текущий deployed `master` SHA. Workflow выключен до owner-approved GitHub App,
-Ruleset read-back и variable `ENABLE_DEPLOYED_MASTER_DEV_SYNC=true`; broad PAT/admin bypass запрещён.
+`dev` только на exact текущий deployed `master` SHA. В текущем repository этот path активирован
+owner-approved узким GitHub App и `ENABLE_DEPLOYED_MASTER_DEV_SYNC=true`; broad PAT/admin bypass
+запрещён. Изменение App, Ruleset, variable или secrets остаётся exceptional owner-authorized action.
 Подробный ADR/runbook: `docs/task-branch-integration.md`.
 
 После merge участие человека заканчивается:

--- a/docs/task-branch-integration.md
+++ b/docs/task-branch-integration.md
@@ -102,9 +102,25 @@ integration: task-pr-to-dev
 Umbrella IDs и `executable: false` не запускаются. Start всегда требует явный `--owner-launch`;
 approval другой task не наследуется.
 
-## Команды controller
+## Один пользовательский запуск
 
-Все команды запускаются из canonical repository или любого его worktree.
+Обычный путь запускается одной командой из canonical repository:
+
+```powershell
+.\.venv\Scripts\python.exe scripts\run_task_delivery.py <ID>
+```
+
+Явный выбор task владельцем или эта команда являются standing authorization для normal delivery
+этой task: отдельный worktree, implementation/review/QA, commit, task PR в `dev`, serial
+integration, release PR в `master`, automatic production deploy и safe closeout. Повторные generic
+approval на этих стадиях не запрашиваются. Launcher сам ждёт занятую serial lane, отдаёт компактные
+состояния `STARTED`/`WAITING_FOR_LANE`/`DONE` и останавливается только на точном terminal blocker
+либо реально объявленном human/legal/external/destructive/task-specific gate.
+
+## Низкоуровневые команды controller
+
+Эти команды являются внутренней coordination/recovery boundary и не являются обычными действиями
+владельца. Они запускаются launcher/worker из canonical repository или нужного worktree.
 
 ```powershell
 python scripts/task_session.py doctor
@@ -133,7 +149,7 @@ recovery command. Task-файл не копируется в worktree: owner-loc
 3. Writer завершает implementation/review/QA и один logical commit с `[Task <ID>]`.
 4. `mark-ready` на clean exact HEAD фиксирует успешные review/QA verdicts; research lease эту стадию
    пройти не может. Branch push и PR `[Task <ID>] ...` идут только в `dev`.
-5. CI проверяет branch/title/commit IDs и aggregate `checks`.
+5. CI task PR проверяет branch/title/commit IDs и выполняет полный aggregate `checks`.
 6. `enqueue-integration` фиксирует immutable candidate evidence.
 7. `prepare-integration` выдаёт eligibility только queue head при current `dev` и exact successful
    checks; создаёт global integration lease.
@@ -163,7 +179,11 @@ Job `Task provenance` выполняется до aggregate `checks`:
 - failure/cancel/timeout/stale check не даёт integration eligibility.
 
 Task PR CI не публикует images и не запускает deployment: publish остаётся только для push в
-`master`, deploy — только после successful post-merge master CI.
+`master`, deploy — только после successful post-merge master CI. Exact merged `dev` push повторно
+подтверждает полный release-candidate suite. Поэтому canonical same-repository PR `dev -> master`
+не запускает этот тяжёлый suite третий раз: в нём выполняются только release-sequence, provenance и
+aggregate `checks`, который требует успешный exact `dev` push-CI. Любой exceptional/non-canonical
+PR в `master` по-прежнему проходит полный suite.
 
 ## Exact `master -> dev` sync
 
@@ -171,21 +191,21 @@ Task PR CI не публикует images и не запускает deployment:
 `Deploy production`, повторно проверяет, что workflow SHA равен current `master`, и допускает только
 fast-forward текущего `dev` к этому exact SHA. Любая divergence блокирует sync.
 
-Workflow по умолчанию выключен: `ENABLE_DEPLOYED_MASTER_DEV_SYNC != true`. Для включения нужен
-owner-approved GitHub App, установленный только в этот repository с минимальным permission
-`Contents: Read and write`. Его actor становится единственным bypass actor Ruleset `dev` в режиме
-`always`. Secrets `DEV_SYNC_APP_ID` и `DEV_SYNC_APP_PRIVATE_KEY` хранятся в protected `production`
-environment. Широкий PAT/admin bypass не используется.
+Workflow включается только при `ENABLE_DEPLOYED_MASTER_DEV_SYNC=true`. В текущем repository path
+активирован: узкий GitHub App установлен только в этот repository с минимальным permission
+`Contents: Read and write`, является единственным bypass actor Ruleset `dev` в режиме `always`, а
+последние automatic deployed sync runs завершались успешно. Secrets `DEV_SYNC_APP_ID` и
+`DEV_SYNC_APP_PRIVATE_KEY` хранятся в protected `production` environment. Широкий PAT/admin bypass
+не используется.
 
 Expected App actor хранится как несекретный repository contract в
 `.github/deployed-sync-app.json`. `doctor` сравнивает Ruleset `actor_id` с этим exact ID, а не
 принимает произвольный GitHub App. Кроме локального `origin/dev`, online `doctor` и `start`
 сравнивают live GitHub `dev` SHA; stale tracking ref требует fetch/нормализации до новой task.
 
-## OWNER_CHECKPOINT: live GitHub enforcement
+## Live GitHub enforcement
 
-До owner decision запрещено менять Ruleset, bypass actors, variables, secrets и repository merge
-settings. Для применения владелец подтверждает:
+Действующий контракт уже применён и проверяется online controller preflight:
 
 1. создание/установку узкого GitHub App и его actor ID;
 2. добавление двух environment secrets без передачи значений в chat/log;
@@ -195,7 +215,8 @@ settings. Для применения владелец подтверждает:
 5. `allow_auto_merge=false` либо организационный запрет использовать auto-merge для task PR;
 6. включение `ENABLE_DEPLOYED_MASTER_DEV_SYNC=true` только после successful dry read-back.
 
-После apply выполнить API read-back и сохранить evidence без secret values:
+При отдельном owner-authorized изменении enforcement выполнить API read-back и сохранить evidence
+без secret values:
 
 ```powershell
 gh api repos/MikeMoore1337/fit-mini-app/rulesets/21801287

--- a/scripts/run_task_delivery.py
+++ b/scripts/run_task_delivery.py
@@ -1,0 +1,249 @@
+"""Run one explicitly selected backlog task to its terminal delivery state.
+
+The user-facing contract is one launch.  The worker keeps pull requests, checks,
+serialized integration, release, deployment monitoring and safe closeout inside
+the canonical task lifecycle.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCRIPT_PATH = Path(__file__).resolve()
+REPOSITORY_ROOT = SCRIPT_PATH.parents[1]
+CONTROLLER_PATH = REPOSITORY_ROOT / "scripts" / "task_session.py"
+TASK_ID_RE = re.compile(r"^[0-9]+[A-Z]?$", re.IGNORECASE)
+TRANSIENT_START_MARKERS = (
+    "lane is occupied",
+    "blocks mutation",
+    "active dev/master ci, deploy or sync run blocks mutation",
+)
+
+
+class DeliveryError(RuntimeError):
+    """A terminal delivery refusal with a concise recovery pointer."""
+
+
+def _event(stage: str, **payload: Any) -> None:
+    print(json.dumps({"stage": stage, **payload}, ensure_ascii=False), flush=True)
+
+
+def _run(
+    args: Sequence[str], *, cwd: Path = REPOSITORY_ROOT, check: bool = True
+) -> subprocess.CompletedProcess[str]:
+    command = list(args)
+    if command and command[0] == "git":
+        git_config = ["-c", f"safe.directory={cwd.resolve().as_posix()}"]
+        if os.name == "nt":
+            git_config.extend(["-c", "core.longpaths=true"])
+        command = ["git", *git_config, *command[1:]]
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        check=False,
+        text=True,
+        encoding="utf-8",
+        capture_output=True,
+    )
+    if check and completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "unknown error"
+        raise DeliveryError(detail)
+    return completed
+
+
+def _normalize_task_id(value: str) -> str:
+    task_id = value.strip().upper()
+    if not TASK_ID_RE.fullmatch(task_id):
+        raise DeliveryError(f"Invalid task ID: {value!r}")
+    return task_id
+
+
+def _git_common_dir() -> Path:
+    output = _run(["git", "rev-parse", "--path-format=absolute", "--git-common-dir"]).stdout.strip()
+    return Path(output).resolve()
+
+
+def _history(task_id: str) -> dict[str, Any] | None:
+    path = _git_common_dir() / "codex-task-sessions-v1" / "history" / f"task-{task_id}.json"
+    if not path.is_file():
+        return None
+    try:
+        return dict(json.loads(path.read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError) as error:
+        raise DeliveryError(f"Cannot read controller history {path}: {error}") from error
+
+
+def _is_transient_start_error(detail: str) -> bool:
+    lowered = detail.lower()
+    return any(marker in lowered for marker in TRANSIENT_START_MARKERS)
+
+
+def _start(
+    task_id: str,
+    *,
+    session_label: str,
+    poll_seconds: int,
+    max_wait_minutes: int,
+    offline: bool,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + max_wait_minutes * 60
+    command = [
+        sys.executable,
+        str(CONTROLLER_PATH),
+        "--repo",
+        str(REPOSITORY_ROOT),
+        "start",
+        task_id,
+        "--owner-launch",
+        "--session-label",
+        session_label,
+    ]
+    if offline:
+        command.append("--offline")
+
+    while True:
+        completed = _run(command, check=False)
+        if completed.returncode == 0:
+            try:
+                return dict(json.loads(completed.stdout))
+            except json.JSONDecodeError as error:
+                raise DeliveryError("Controller returned invalid start JSON") from error
+        detail = completed.stderr.strip() or completed.stdout.strip() or "unknown start error"
+        if not _is_transient_start_error(detail):
+            raise DeliveryError(detail)
+        if time.monotonic() >= deadline:
+            raise DeliveryError(f"Timed out waiting for delivery lane: {detail}")
+        _event("WAITING_FOR_LANE", task_id=task_id, retry_in_seconds=poll_seconds)
+        time.sleep(poll_seconds)
+
+
+def _worker_prompt(task_id: str, started: dict[str, Any]) -> str:
+    return (
+        f"Выполни только Task {task_id}: {started['lease']['canonical_task_path']}.\n"
+        "Один исходный owner launch является standing authorization для normal delivery path: "
+        "task branch -> PR dev -> exact dev checks -> PR master -> production -> safe closeout.\n"
+        "Не запрашивай generic approval для commit, push, PR, merge, normal release, deploy "
+        "monitoring, exact ref sync, finish, cleanup или archive. Внутренние controller stages "
+        "выполняй автоматически и сообщай только компактный status или точный terminal blocker.\n"
+        "Все BLOCKER/HIGH/MEDIUM должны быть исправлены и пройти required targeted recheck до "
+        "release. LOW не расширяет scope. Реальный HUMAN_EVIDENCE, LEGAL, EXTERNAL, DESTRUCTIVE "
+        "или task-specific owner gate не подменяй; остановись только на таком точном gate.\n"
+        "Не запускай следующую product task.\n\n"
+        f"Controller context:\n{started.get('prompt', '')}"
+    )
+
+
+def _artifact_root(task_id: str) -> Path:
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    path = REPOSITORY_ROOT / ".artifacts" / "task-deliveries" / f"{stamp}-task-{task_id}"
+    path.mkdir(parents=True, exist_ok=False)
+    return path
+
+
+def _launch_worker(task_id: str, started: dict[str, Any], artifacts: Path) -> int:
+    codex = shutil.which("codex")
+    if codex is None:
+        raise DeliveryError("Codex CLI is not available in PATH")
+    worktree = Path(str(started["lease"]["worktree"]))
+    result_path = artifacts / "final.md"
+    log_path = artifacts / "events.jsonl"
+    with log_path.open("wb") as log:
+        completed = subprocess.run(
+            [
+                codex,
+                "exec",
+                "--approve-for-me",
+                "-s",
+                "workspace-write",
+                "-C",
+                str(worktree),
+                "--add-dir",
+                str(REPOSITORY_ROOT),
+                "--json",
+                "-o",
+                str(result_path),
+                _worker_prompt(task_id, started),
+            ],
+            cwd=worktree,
+            stdin=subprocess.DEVNULL,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            check=False,
+        )
+    return completed.returncode
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("task_id")
+    parser.add_argument("--session-label")
+    parser.add_argument("--poll-seconds", type=int, default=30)
+    parser.add_argument("--max-wait-minutes", type=int, default=1440)
+    parser.add_argument("--offline", action="store_true", help=argparse.SUPPRESS)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        task_id = _normalize_task_id(args.task_id)
+        if args.poll_seconds < 10:
+            raise DeliveryError("poll-seconds must be at least 10")
+        if args.max_wait_minutes < 1:
+            raise DeliveryError("max-wait-minutes must be at least 1")
+        if shutil.which("codex") is None:
+            raise DeliveryError("Codex CLI is not available in PATH")
+        session_label = args.session_label or f"delivery-task-{task_id.lower()}"
+        started = _start(
+            task_id,
+            session_label=session_label,
+            poll_seconds=args.poll_seconds,
+            max_wait_minutes=args.max_wait_minutes,
+            offline=args.offline,
+        )
+        artifacts = _artifact_root(task_id)
+        _event(
+            "STARTED",
+            task_id=task_id,
+            branch=started["lease"]["branch"],
+            worktree=started["lease"]["worktree"],
+            artifacts=str(artifacts),
+        )
+        worker_exit = _launch_worker(task_id, started, artifacts)
+        history = _history(task_id)
+        if worker_exit != 0:
+            raise DeliveryError(
+                f"Worker exited with code {worker_exit}; inspect {artifacts / 'events.jsonl'}"
+            )
+        if history is None or history.get("state") != "finished":
+            state = history.get("state") if history else "missing"
+            raise DeliveryError(
+                f"Worker returned before terminal controller finish (state={state}); "
+                f"inspect {artifacts}"
+            )
+        _event(
+            "DONE",
+            task_id=task_id,
+            merge_sha=history.get("merge_sha"),
+            finished_at=history.get("finished_at"),
+            artifacts=str(artifacts),
+        )
+        return 0
+    except (DeliveryError, OSError) as error:
+        _event("BLOCKED", error=str(error))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_task_delivery.py
+++ b/scripts/run_task_delivery.py
@@ -23,6 +23,7 @@ from typing import Any
 SCRIPT_PATH = Path(__file__).resolve()
 REPOSITORY_ROOT = SCRIPT_PATH.parents[1]
 CONTROLLER_PATH = REPOSITORY_ROOT / "scripts" / "task_session.py"
+ARCHIVE_HELPER_PATH = REPOSITORY_ROOT / "scripts" / "archive_backlog_task.py"
 TASK_ID_RE = re.compile(r"^[0-9]+[A-Z]?$", re.IGNORECASE)
 TRANSIENT_START_MARKERS = (
     "lane is occupied",
@@ -82,6 +83,38 @@ def _history(task_id: str) -> dict[str, Any] | None:
         return dict(json.loads(path.read_text(encoding="utf-8")))
     except (OSError, json.JSONDecodeError) as error:
         raise DeliveryError(f"Cannot read controller history {path}: {error}") from error
+
+
+def _archive_contract(canonical_task_path: str) -> tuple[Path, Path, Path]:
+    source = Path(canonical_task_path).resolve()
+    if source.parent.name == "tasks":
+        backlog_root = source.parent.parent
+        destination = source.parent / "done" / source.name
+    elif source.parent.name == "pending" and source.parent.parent.name == "bugs":
+        backlog_root = source.parent.parent.parent
+        destination = source.parent.parent / "done" / source.name
+    else:
+        raise DeliveryError(f"Unsupported task archive path: {source}")
+    return source, destination, backlog_root
+
+
+def _verify_closeout(started: dict[str, Any]) -> None:
+    source, destination, backlog_root = _archive_contract(
+        str(started["lease"]["canonical_task_path"])
+    )
+    if source.exists():
+        raise DeliveryError(f"Task was not archived after controller finish: {source}")
+    if not destination.is_file():
+        raise DeliveryError(f"Archived task is missing after controller finish: {destination}")
+    _run(
+        [
+            sys.executable,
+            str(ARCHIVE_HELPER_PATH),
+            "check",
+            "--backlog",
+            str(backlog_root),
+        ]
+    )
 
 
 def _is_transient_start_error(detail: str) -> bool:
@@ -232,6 +265,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 f"Worker returned before terminal controller finish (state={state}); "
                 f"inspect {artifacts}"
             )
+        _verify_closeout(started)
         _event(
             "DONE",
             task_id=task_id,

--- a/scripts/task_session.py
+++ b/scripts/task_session.py
@@ -96,8 +96,15 @@ def _run(
     check: bool = True,
     env: Mapping[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
+    command = list(args)
+    if command and command[0] == "git":
+        safe_directory = cwd.resolve().as_posix()
+        git_config = ["-c", f"safe.directory={safe_directory}"]
+        if os.name == "nt":
+            git_config.extend(["-c", "core.longpaths=true"])
+        command = ["git", *git_config, *command[1:]]
     completed = subprocess.run(
-        list(args),
+        command,
         cwd=cwd,
         check=False,
         text=True,

--- a/tests/test_release_safeguards.py
+++ b/tests/test_release_safeguards.py
@@ -109,6 +109,13 @@ def test_release_pr_requires_completed_exact_sha_push_ci_and_serial_execution() 
     assert r".updated_at <= \"$PR_GATE_AT\"" in ci_workflow
     assert ci_workflow.count("needs: [release-sequence, task-provenance]") == 7
     assert "task-provenance:" in ci_workflow
+    assert ci_workflow.count("github.event.pull_request.head.ref != 'dev'") == 7
+    assert "CANONICAL_RELEASE_PR:" in ci_workflow
+    assert 'if [ "$CANONICAL_RELEASE_PR" = "true" ]; then' in ci_workflow
+    assert ci_workflow.count('test "$QUALITY_RESULT" = skipped') == 1
+    assert ci_workflow.count('test "$CONTAINERS_RESULT" = skipped') == 1
+    assert ci_workflow.count('test "$QUALITY_RESULT" = success') == 1
+    assert ci_workflow.count('test "$CONTAINERS_RESULT" = success') == 1
     assert "TASK_PROVENANCE_RESULT: ${{ needs.task-provenance.result }}" in ci_workflow
     assert "RELEASE_SEQUENCE_RESULT: ${{ needs.release-sequence.result }}" in ci_workflow
     assert 'test "$RELEASE_SEQUENCE_RESULT" = success' in ci_workflow
@@ -160,6 +167,18 @@ def test_task127_global_auto_continue_contract_has_no_implicit_wait() -> None:
     assert "не ждёт дополнительного owner prompt" in global_rules
     assert "integration-only" in agents
     assert "serial merge в `dev`" in global_rules
+
+
+def test_one_command_delivery_keeps_owner_prompts_internal() -> None:
+    root = Path(__file__).resolve().parents[1]
+    launcher = (root / "scripts" / "run_task_delivery.py").read_text(encoding="utf-8")
+
+    assert '"--owner-launch"' in launcher
+    assert '"--approve-for-me"' in launcher
+    assert "standing authorization" in launcher
+    assert "BLOCKER/HIGH/MEDIUM" in launcher
+    assert "WAITING_FOR_LANE" in launcher
+    assert "Не запускай следующую product task" in launcher
 
 
 def test_task_pr_dev_provenance_and_deployed_master_sync_contract() -> None:

--- a/tests/test_release_safeguards.py
+++ b/tests/test_release_safeguards.py
@@ -178,6 +178,8 @@ def test_one_command_delivery_keeps_owner_prompts_internal() -> None:
     assert "standing authorization" in launcher
     assert "BLOCKER/HIGH/MEDIUM" in launcher
     assert "WAITING_FOR_LANE" in launcher
+    assert "_verify_closeout(started)" in launcher
+    assert '"check"' in launcher and '"--backlog"' in launcher
     assert "Не запускай следующую product task" in launcher
 
 

--- a/tests/test_run_task_delivery.py
+++ b/tests/test_run_task_delivery.py
@@ -80,3 +80,34 @@ def test_task_id_normalization_is_strict() -> None:
         assert "Invalid task ID" in str(error)
     else:
         raise AssertionError("invalid task ID was accepted")
+
+
+def test_verify_closeout_requires_archive_and_manifest_check(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    backlog = tmp_path / "codex-backlog"
+    source = backlog / "tasks" / "131-delivery.md"
+    destination = backlog / "tasks" / "done" / source.name
+    destination.parent.mkdir(parents=True)
+    destination.write_text("done", encoding="utf-8")
+    started = {"lease": {"canonical_task_path": str(source)}}
+    observed: dict[str, Any] = {}
+
+    def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        observed["args"] = args[0]
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(delivery, "_run", fake_run)
+
+    delivery._verify_closeout(started)
+
+    assert observed["args"][-2:] == ["--backlog", str(backlog)]
+
+
+def test_verify_closeout_rejects_finished_but_unarchived_task(tmp_path: Path) -> None:
+    source = tmp_path / "codex-backlog" / "tasks" / "131-delivery.md"
+    source.parent.mkdir(parents=True)
+    source.write_text("pending", encoding="utf-8")
+
+    with pytest.raises(delivery.DeliveryError, match="was not archived"):
+        delivery._verify_closeout({"lease": {"canonical_task_path": str(source)}})

--- a/tests/test_run_task_delivery.py
+++ b/tests/test_run_task_delivery.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_module():
+    script = Path(__file__).parents[1] / "scripts" / "run_task_delivery.py"
+    spec = importlib.util.spec_from_file_location("run_task_delivery", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+delivery = _load_module()
+
+
+def test_run_scopes_git_safety_to_exact_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    observed: dict[str, Any] = {}
+
+    def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        observed["args"] = args[0]
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(delivery.subprocess, "run", fake_run)
+
+    delivery._run(["git", "rev-parse", "--git-common-dir"], cwd=tmp_path)
+
+    command = observed["args"]
+    assert command[:3] == ["git", "-c", f"safe.directory={tmp_path.resolve().as_posix()}"]
+    if delivery.os.name == "nt":
+        assert command[3:5] == ["-c", "core.longpaths=true"]
+
+
+def test_worker_prompt_carries_one_launch_delivery_contract() -> None:
+    started = {
+        "lease": {
+            "canonical_task_path": "D:/repo/codex-backlog/tasks/131-delivery.md",
+            "branch": "task/131-delivery",
+            "worktree": "D:/repo/.artifacts/worktrees/131-delivery",
+        },
+        "prompt": "controller evidence",
+    }
+
+    prompt = delivery._worker_prompt("131", started)
+
+    assert "standing authorization" in prompt
+    assert "task branch -> PR dev -> exact dev checks -> PR master -> production" in prompt
+    assert "BLOCKER/HIGH/MEDIUM" in prompt
+    assert "Не запрашивай generic approval" in prompt
+    assert "Не запускай следующую product task" in prompt
+
+
+def test_only_live_lane_contention_is_retried() -> None:
+    assert delivery._is_transient_start_error(
+        "task session error: An incompatible write/integration/release lane is occupied"
+    )
+    assert delivery._is_transient_start_error(
+        "doctor blockers: active dev/master CI, deploy or sync run blocks mutation"
+    )
+    assert not delivery._is_transient_start_error("main dev worktree is dirty")
+    assert not delivery._is_transient_start_error("missing task document")
+
+
+def test_task_id_normalization_is_strict() -> None:
+    assert delivery._normalize_task_id("110a") == "110A"
+
+    try:
+        delivery._normalize_task_id("task-110A")
+    except delivery.DeliveryError as error:
+        assert "Invalid task ID" in str(error)
+    else:
+        raise AssertionError("invalid task ID was accepted")

--- a/tests/test_task_session.py
+++ b/tests/test_task_session.py
@@ -42,6 +42,25 @@ def test_run_decodes_command_output_as_utf8(
     assert observed["encoding"] == "utf-8"
 
 
+def test_run_scopes_git_safety_to_exact_worktree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    observed: dict[str, Any] = {}
+
+    def fake_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        observed["args"] = args[0]
+        return subprocess.CompletedProcess(args[0], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(task_session.subprocess, "run", fake_run)
+
+    task_session._run(["git", "status", "--short"], cwd=tmp_path)
+
+    command = observed["args"]
+    assert command[:3] == ["git", "-c", f"safe.directory={tmp_path.resolve().as_posix()}"]
+    if task_session.os.name == "nt":
+        assert command[3:5] == ["-c", "core.longpaths=true"]
+
+
 def _git(path: Path, *args: str) -> str:
     completed = subprocess.run(["git", *args], cwd=path, check=True, text=True, capture_output=True)
     return completed.stdout.strip()


### PR DESCRIPTION
## Что изменено
- добавлен один user-facing launcher для полного task delivery
- scoped Windows Git safety убирает dubious-ownership prompts без global config
- canonical dev -> master PR переиспользует exact successful dev CI вместо третьего тяжёлого suite
- BLOCKER/HIGH/MEDIUM остаются обязательными к закрытию до release

## Проверки
- targeted pytest: 67 passed
- targeted review recheck: 14 passed
- task_session doctor --offline: ok=true
- pre-commit --all-files: passed
- backlog manifest check: passed

Finding: NBF-20260901-131-01 FIXED.