### PR TITLE
[Task 110A] Move avatar controls into compact dialog

### DIFF
--- a/frontend/src/features/profile/AvatarSettings.tsx
+++ b/frontend/src/features/profile/AvatarSettings.tsx
@@ -3,6 +3,9 @@ import { useAuth } from '../../app/AuthProvider';
 import { AccountAvatar } from '../../shared/account/AccountIdentity';
 import { api, ApiError } from '../../shared/api/client';
 import type { User } from '../../shared/api/types';
+import { useFeedback } from '../../shared/ui/FeedbackProvider';
+import { Icon } from '../../shared/ui/Icon';
+import { useModalA11y } from '../../shared/ui/useModalA11y';
 
 const MAX_AVATAR_BYTES = 5 * 1024 * 1024;
 const SUPPORTED_AVATAR_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
@@ -19,33 +22,21 @@ function selectedFileError(file: File): string | null {
   return null;
 }
 
-export function AvatarSettings() {
+export function AvatarSettings({ open, onClose }: { open: boolean; onClose(): void }) {
   const { updateUser, user } = useAuth();
+  const { toast } = useFeedback();
   const inputRef = useRef<HTMLInputElement>(null);
-  const chooseButtonRef = useRef<HTMLButtonElement>(null);
   const deleteButtonRef = useRef<HTMLButtonElement>(null);
-  const confirmDeleteButtonRef = useRef<HTMLButtonElement>(null);
+  const deleteCancelRef = useRef<HTMLButtonElement>(null);
+  const deleteConfirmRef = useRef<HTMLButtonElement>(null);
   const previewRef = useRef<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [status, setStatus] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
-
-  useEffect(
-    () => () => {
-      if (previewRef.current) URL.revokeObjectURL(previewRef.current);
-    },
-    [],
-  );
-
-  useEffect(() => {
-    if (confirmDelete) confirmDeleteButtonRef.current?.focus();
-  }, [confirmDelete]);
-
-  if (!user) return null;
+  const blocking = saving || deleting;
 
   const clearSelection = () => {
     if (previewRef.current) URL.revokeObjectURL(previewRef.current);
@@ -55,8 +46,29 @@ export function AvatarSettings() {
     if (inputRef.current) inputRef.current.value = '';
   };
 
+  const close = () => {
+    if (blocking || confirmDelete) return;
+    clearSelection();
+    setError(null);
+    setConfirmDelete(false);
+    onClose();
+  };
+  const panelRef = useModalA11y<HTMLDivElement>(open, close, '.avatar-editor__choose');
+
+  useEffect(
+    () => () => {
+      if (previewRef.current) URL.revokeObjectURL(previewRef.current);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (confirmDelete) deleteCancelRef.current?.focus();
+  }, [confirmDelete]);
+
+  if (!open || !user) return null;
+
   const chooseFile = (file: File | null) => {
-    setStatus(null);
     setError(null);
     if (!file) return;
     const validationError = selectedFileError(file);
@@ -76,7 +88,6 @@ export function AvatarSettings() {
     if (!selectedFile || saving) return;
     setSaving(true);
     setError(null);
-    setStatus(null);
     const formData = new FormData();
     formData.append('file', selectedFile, selectedFile.name);
     try {
@@ -87,7 +98,8 @@ export function AvatarSettings() {
       });
       updateUser(current);
       clearSelection();
-      setStatus('Аватар сохранён и уже используется в профиле.');
+      toast('Аватар сохранён');
+      onClose();
     } catch (reason) {
       setError(
         reason instanceof ApiError || reason instanceof Error
@@ -103,18 +115,17 @@ export function AvatarSettings() {
     if (deleting) return;
     setDeleting(true);
     setError(null);
-    setStatus(null);
     try {
       const current = await api<User>('/api/v1/me/avatar', { method: 'DELETE' });
       updateUser(current);
       clearSelection();
-      setConfirmDelete(false);
-      requestAnimationFrame(() => chooseButtonRef.current?.focus());
-      setStatus(
+      toast(
         current.photo_url
-          ? 'Свой аватар удалён. Снова показывается фото из способа входа.'
-          : 'Свой аватар удалён. Снова показывается нейтральный emoji.',
+          ? 'Свой аватар удалён — снова показывается фото из способа входа'
+          : 'Свой аватар удалён — снова показывается нейтральный emoji',
       );
+      setConfirmDelete(false);
+      onClose();
     } catch (reason) {
       setError(
         reason instanceof ApiError || reason instanceof Error
@@ -136,88 +147,127 @@ export function AvatarSettings() {
         : 'Используется нейтральный emoji';
 
   return (
-    <section className="profile-avatar-card" id="profile-avatar" aria-labelledby="avatar-title">
-      <div className="profile-avatar-card__visual">
-        <AccountAvatar
-          className="profile-avatar-card__avatar"
-          customAvatarVersion={user.custom_avatar?.updated_at}
-          name={userDisplayName(user)}
-          photoUrl={user.photo_url}
-          previewUrl={previewUrl}
-        />
-        <span>{sourceLabel}</span>
-      </div>
-
-      <div className="profile-avatar-card__body">
-        <div className="profile-avatar-card__copy">
-          <span className="eyebrow">Персонализация аккаунта</span>
-          <h2 id="avatar-title">Аватар</h2>
-          <p>
-            Выберите JPEG, PNG или WebP до 5 МБ. Перед сохранением изображение будет обрезано по
-            центру до квадрата, а исходные metadata будут удалены.
-          </p>
-        </div>
-
-        <input
-          ref={inputRef}
-          className="sr-only"
-          type="file"
-          accept="image/jpeg,image/png,image/webp"
-          aria-label="Выбрать изображение для аватара"
-          onChange={(event) => chooseFile(event.target.files?.[0] ?? null)}
-        />
-
-        <div className="profile-avatar-card__actions">
+    <div
+      className="avatar-editor-layer"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) close();
+      }}
+    >
+      <div
+        ref={panelRef}
+        className="avatar-editor"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="avatar-editor-title"
+        aria-describedby="avatar-editor-description"
+        aria-busy={blocking || undefined}
+        tabIndex={-1}
+      >
+        <header className="avatar-editor__header" inert={confirmDelete}>
+          <div>
+            <span className="eyebrow">Настройка аккаунта</span>
+            <h2 id="avatar-editor-title">Аватар</h2>
+          </div>
           <button
-            ref={chooseButtonRef}
             type="button"
-            className="secondary"
-            disabled={saving || deleting}
+            className="avatar-editor__close"
+            aria-label="Закрыть редактор аватара"
+            disabled={blocking}
+            onClick={close}
+          >
+            <Icon name="close" />
+          </button>
+        </header>
+
+        <div className="avatar-editor__content" inert={confirmDelete}>
+          <div className="avatar-editor__preview">
+            <AccountAvatar
+              className="avatar-editor__avatar"
+              customAvatarVersion={user.custom_avatar?.updated_at}
+              name={userDisplayName(user)}
+              photoUrl={user.photo_url}
+              previewUrl={previewUrl}
+            />
+            <div>
+              <strong>{sourceLabel}</strong>
+              <p id="avatar-editor-description">
+                JPEG, PNG или WebP до 5 МБ. Изображение будет обрезано по центру до квадрата без
+                исходных metadata.
+              </p>
+            </div>
+          </div>
+
+          <input
+            ref={inputRef}
+            className="sr-only"
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            aria-label="Выбрать изображение для аватара"
+            onChange={(event) => chooseFile(event.target.files?.[0] ?? null)}
+          />
+
+          <button
+            type="button"
+            className="secondary avatar-editor__choose"
+            disabled={blocking}
             onClick={() => inputRef.current?.click()}
           >
-            {selectedFile ? 'Выбрать другое' : hasCustomAvatar ? 'Заменить' : 'Выбрать изображение'}
+            {selectedFile
+              ? 'Выбрать другое'
+              : hasCustomAvatar
+                ? 'Заменить изображение'
+                : 'Выбрать изображение'}
           </button>
-          {selectedFile && (
-            <>
-              <button type="button" disabled={saving} onClick={() => void saveAvatar()}>
-                {saving ? 'Сохраняем…' : error ? 'Повторить сохранение' : 'Сохранить аватар'}
-              </button>
-              <button
-                type="button"
-                className="text-button"
-                disabled={saving}
-                onClick={() => {
-                  clearSelection();
-                  setError(null);
-                }}
-              >
-                Отмена
-              </button>
-            </>
+
+          {error && !confirmDelete && (
+            <div className="avatar-editor__error" role="alert">
+              <strong>Изменение не сохранено</strong>
+              <span>{error}</span>
+            </div>
           )}
+
           {hasCustomAvatar && !selectedFile && (
             <button
               ref={deleteButtonRef}
               type="button"
-              className="secondary profile-avatar-card__delete"
-              disabled={deleting}
-              onClick={() => setConfirmDelete(true)}
+              className="text-button avatar-editor__delete"
+              disabled={blocking}
+              onClick={() => {
+                setError(null);
+                setConfirmDelete(true);
+              }}
             >
               Удалить свой аватар
             </button>
           )}
         </div>
 
-        {confirmDelete && hasCustomAvatar && (
+        {confirmDelete && (
           <div
-            className="profile-avatar-delete-confirmation"
+            className="avatar-editor__delete-confirmation"
             role="alertdialog"
+            aria-modal="true"
             aria-labelledby="avatar-delete-title"
             aria-describedby="avatar-delete-description"
             onKeyDown={(event) => {
-              if (event.key !== 'Escape') return;
-              setConfirmDelete(false);
-              requestAnimationFrame(() => deleteButtonRef.current?.focus());
+              event.stopPropagation();
+              if (event.key === 'Escape' && !deleting) {
+                event.preventDefault();
+                setConfirmDelete(false);
+                window.requestAnimationFrame(() => deleteButtonRef.current?.focus());
+                return;
+              }
+              if (event.key !== 'Tab') return;
+              const first = deleteCancelRef.current;
+              const last = deleteConfirmRef.current;
+              if (!first || !last) return;
+              if (event.shiftKey && document.activeElement === first) {
+                event.preventDefault();
+                last.focus();
+              } else if (!event.shiftKey && document.activeElement === last) {
+                event.preventDefault();
+                first.focus();
+              }
             }}
           >
             <div>
@@ -225,43 +275,56 @@ export function AvatarSettings() {
               <p id="avatar-delete-description">
                 Свой файл будет удалён. Фото из способа входа или emoji останется доступным.
               </p>
+              {error && (
+                <p className="avatar-editor__delete-error" role="alert">
+                  {error}
+                </p>
+              )}
             </div>
-            <div className="profile-avatar-delete-confirmation__actions">
+            <div className="avatar-editor__delete-actions">
               <button
-                ref={confirmDeleteButtonRef}
-                type="button"
-                className="btn-danger"
-                disabled={deleting}
-                onClick={() => void deleteAvatar()}
-              >
-                {deleting ? 'Удаляем…' : 'Удалить'}
-              </button>
-              <button
+                ref={deleteCancelRef}
                 type="button"
                 className="secondary"
                 disabled={deleting}
                 onClick={() => {
                   setConfirmDelete(false);
-                  requestAnimationFrame(() => deleteButtonRef.current?.focus());
+                  setError(null);
+                  window.requestAnimationFrame(() => deleteButtonRef.current?.focus());
                 }}
               >
                 Отмена
+              </button>
+              <button
+                ref={deleteConfirmRef}
+                type="button"
+                className="btn-danger"
+                disabled={deleting}
+                onClick={() => void deleteAvatar()}
+              >
+                {deleting ? 'Удаляем…' : error ? 'Повторить удаление' : 'Удалить'}
               </button>
             </div>
           </div>
         )}
 
-        {error && (
-          <p className="profile-avatar-card__message is-error" role="alert">
-            {error}
-          </p>
-        )}
-        {status && (
-          <p className="profile-avatar-card__message is-success" role="status">
-            {status}
-          </p>
-        )}
+        <footer className="avatar-editor__actions" inert={confirmDelete}>
+          <button type="button" className="secondary" disabled={blocking} onClick={close}>
+            Отмена
+          </button>
+          <button
+            type="button"
+            disabled={!selectedFile || blocking}
+            onClick={() => void saveAvatar()}
+          >
+            {saving
+              ? 'Сохраняем…'
+              : error && selectedFile
+                ? 'Повторить сохранение'
+                : 'Сохранить аватар'}
+          </button>
+        </footer>
       </div>
-    </section>
+    </div>
   );
 }

--- a/frontend/src/features/profile/AvatarSettings.tsx
+++ b/frontend/src/features/profile/AvatarSettings.tsx
@@ -29,6 +29,7 @@ export function AvatarSettings({ open, onClose }: { open: boolean; onClose(): vo
   const deleteButtonRef = useRef<HTMLButtonElement>(null);
   const deleteCancelRef = useRef<HTMLButtonElement>(null);
   const deleteConfirmRef = useRef<HTMLButtonElement>(null);
+  const deleteConfirmationWasOpenRef = useRef(false);
   const previewRef = useRef<string | null>(null);
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
@@ -46,11 +47,20 @@ export function AvatarSettings({ open, onClose }: { open: boolean; onClose(): vo
     if (inputRef.current) inputRef.current.value = '';
   };
 
+  const closeDeleteConfirmation = () => {
+    if (deleting) return;
+    setConfirmDelete(false);
+    setError(null);
+  };
+
   const close = () => {
-    if (blocking || confirmDelete) return;
+    if (blocking) return;
+    if (confirmDelete) {
+      closeDeleteConfirmation();
+      return;
+    }
     clearSelection();
     setError(null);
-    setConfirmDelete(false);
     onClose();
   };
   const panelRef = useModalA11y<HTMLDivElement>(open, close, '.avatar-editor__choose');
@@ -63,7 +73,14 @@ export function AvatarSettings({ open, onClose }: { open: boolean; onClose(): vo
   );
 
   useEffect(() => {
-    if (confirmDelete) deleteCancelRef.current?.focus();
+    if (confirmDelete) {
+      deleteConfirmationWasOpenRef.current = true;
+      deleteCancelRef.current?.focus();
+      return;
+    }
+    if (!deleteConfirmationWasOpenRef.current) return;
+    deleteConfirmationWasOpenRef.current = false;
+    deleteButtonRef.current?.focus();
   }, [confirmDelete]);
 
   if (!open || !user) return null;
@@ -253,8 +270,7 @@ export function AvatarSettings({ open, onClose }: { open: boolean; onClose(): vo
               event.stopPropagation();
               if (event.key === 'Escape' && !deleting) {
                 event.preventDefault();
-                setConfirmDelete(false);
-                window.requestAnimationFrame(() => deleteButtonRef.current?.focus());
+                closeDeleteConfirmation();
                 return;
               }
               if (event.key !== 'Tab') return;
@@ -287,11 +303,7 @@ export function AvatarSettings({ open, onClose }: { open: boolean; onClose(): vo
                 type="button"
                 className="secondary"
                 disabled={deleting}
-                onClick={() => {
-                  setConfirmDelete(false);
-                  setError(null);
-                  window.requestAnimationFrame(() => deleteButtonRef.current?.focus());
-                }}
+                onClick={closeDeleteConfirmation}
               >
                 Отмена
               </button>

--- a/frontend/src/features/profile/ProfileForm.tsx
+++ b/frontend/src/features/profile/ProfileForm.tsx
@@ -14,6 +14,8 @@ import { profileGoals } from './goals';
 import { BodyPriorityPicker, isBodyPriorityComplete } from './BodyPriorityPicker';
 import { TrainingPreferencesForm } from './TrainingPreferencesForm';
 import { Icon } from '../../shared/ui/Icon';
+import { AccountAvatar } from '../../shared/account/AccountIdentity';
+import { AvatarSettings } from './AvatarSettings';
 
 const emptyProfile: UserProfileUpdate = {
   full_name: '',
@@ -145,6 +147,7 @@ export function ProfileForm() {
   const { user, reloadUser } = useAuth();
   const { toast } = useFeedback();
   const queryClient = useQueryClient();
+  const [avatarEditorOpen, setAvatarEditorOpen] = useState(false);
   const [validationErrors, setValidationErrors] = useState<ProfileFieldErrors>({});
   const [form, setForm, clearDraft] = usePersistentState<UserProfileUpdate>(
     profileDraftStorageKey(user?.id ?? 'anonymous'),
@@ -198,6 +201,13 @@ export function ProfileForm() {
   });
 
   const numberValue = (value: string) => (value === '' ? null : Number(value));
+  const avatarSource = user?.custom_avatar
+    ? 'Используется свой аватар'
+    : user?.photo_url
+      ? 'Используется фото из способа входа'
+      : 'Используется нейтральный emoji';
+  const displayName =
+    user?.profile?.full_name || user?.first_name || user?.username || 'Пользователь';
   const updateField = <Key extends keyof UserProfileUpdate>(
     key: Key,
     value: UserProfileUpdate[Key],
@@ -252,9 +262,33 @@ export function ProfileForm() {
                 <Icon name="nav-profile" size={20} /> Личные данные
               </h3>
               <p>
-                Имя, дата рождения и часовой пояс используются только в вашем рабочем контексте.
+                Аватар, имя, дата рождения и часовой пояс используются только в вашем рабочем
+                контексте.
               </p>
             </div>
+            {user && (
+              <div className="profile-avatar-setting">
+                <AccountAvatar
+                  className="profile-avatar-setting__avatar"
+                  customAvatarVersion={user.custom_avatar?.updated_at}
+                  name={displayName}
+                  photoUrl={user.photo_url}
+                />
+                <div className="profile-avatar-setting__copy">
+                  <strong>Фото профиля</strong>
+                  <span>{avatarSource}</span>
+                </div>
+                <button
+                  type="button"
+                  className="secondary profile-avatar-setting__action"
+                  aria-label="Изменить аватар"
+                  aria-haspopup="dialog"
+                  onClick={() => setAvatarEditorOpen(true)}
+                >
+                  Изменить
+                </button>
+              </div>
+            )}
             <div className="form-grid profile-form-grid profile-form-grid--personal">
               <label className="field">
                 <span>Имя</span>
@@ -607,6 +641,7 @@ export function ProfileForm() {
         </form>
       </Card>
       <TrainingPreferencesForm />
+      <AvatarSettings open={avatarEditorOpen} onClose={() => setAvatarEditorOpen(false)} />
     </>
   );
 }

--- a/frontend/src/pages/miniapp/MiniAppPage.tsx
+++ b/frontend/src/pages/miniapp/MiniAppPage.tsx
@@ -52,11 +52,6 @@ const ProfileForm = lazy(() =>
     default: module.ProfileForm,
   })),
 );
-const AvatarSettings = lazy(() =>
-  import('../../features/profile/AvatarSettings').then((module) => ({
-    default: module.AvatarSettings,
-  })),
-);
 const ProgramBuilder = lazy(() =>
   import('../../features/programs/ProgramBuilder').then((module) => ({
     default: module.ProgramBuilder,
@@ -433,7 +428,6 @@ export default function MiniAppPage() {
                   </a>
                 </nav>
 
-                <AvatarSettings />
                 <ProfileForm key={profileFormKey} />
                 <Card
                   className="profile-settings-group"

--- a/frontend/src/styles/design-v2.css
+++ b/frontend/src/styles/design-v2.css
@@ -3486,137 +3486,268 @@ body:has(.standalone-page--design-v2) {
   gap: var(--v2-space-6);
 }
 
-.profile-avatar-card {
-  overflow: hidden;
+.avatar-editor-layer {
+  position: fixed;
+  inset: 0;
+  z-index: 9150;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding-top: max(var(--v2-space-4), var(--yfc-layout-safe-top));
+  background: rgba(10, 16, 12, 0.58);
+}
+
+.avatar-editor {
+  overflow-y: auto;
+  overscroll-behavior: contain;
   display: grid;
-  grid-template-columns: minmax(190px, 0.34fr) minmax(0, 1fr);
-  border: 1px solid var(--v2-border);
-  border-radius: var(--v2-region-radius);
+  width: min(100%, 560px);
+  max-height: calc(
+    var(--yfc-viewport-stable-height) - max(var(--v2-space-4), var(--yfc-layout-safe-top))
+  );
+  gap: var(--v2-space-4);
+  padding: var(--v2-space-4) max(var(--v2-space-4), var(--yfc-layout-safe-right))
+    max(calc(96px + var(--v2-space-3)), calc(var(--yfc-layout-safe-bottom) + var(--v2-space-4)))
+    max(var(--v2-space-4), var(--yfc-layout-safe-left));
+  border: 1px solid var(--v2-border-strong);
+  border-bottom: 0;
+  border-radius: var(--v2-region-radius) var(--v2-region-radius) 0 0;
   background: var(--v2-surface);
-}
-
-.profile-avatar-card__visual {
-  display: grid;
-  min-height: 250px;
-  place-content: center;
-  justify-items: center;
-  gap: var(--v2-space-3);
-  padding: var(--v2-space-5);
-  border-right: 1px solid var(--v2-border);
-  background: var(--v2-lime-soft);
   color: var(--v2-text-primary);
-  text-align: center;
+  box-shadow: var(--elevation-overlay);
 }
 
-.profile-avatar-card__visual > span:last-child {
-  max-width: 18ch;
+.avatar-editor--loading {
+  min-height: 180px;
+  place-items: center;
+}
+
+.avatar-editor__header,
+.avatar-editor__preview,
+.avatar-editor__actions {
+  display: flex;
+  align-items: center;
+}
+
+.avatar-editor__header {
+  justify-content: space-between;
+  gap: var(--v2-space-4);
+}
+
+.avatar-editor__header > div,
+.avatar-editor__content,
+.avatar-editor__preview > div,
+.avatar-editor__error {
+  display: grid;
+}
+
+.avatar-editor__header > div {
+  gap: var(--v2-space-1);
+}
+
+.avatar-editor__header h2,
+.avatar-editor__preview p,
+.avatar-editor__error span,
+.avatar-editor--loading p {
+  margin: 0;
+}
+
+.avatar-editor__header h2 {
+  font-size: clamp(1.65rem, 6vw, 2.15rem);
+  letter-spacing: -0.035em;
+}
+
+.avatar-editor__close {
+  display: grid;
+  width: 44px;
+  min-height: 44px;
+  flex: 0 0 44px;
+  place-items: center;
+  padding: 0;
+  border: 1px solid var(--v2-border);
+  border-radius: 50%;
+  background: var(--v2-surface-secondary);
+  color: var(--v2-text-primary);
+}
+
+.avatar-editor__close:focus-visible,
+.avatar-editor :where(button, input):focus-visible {
+  outline: 3px solid var(--v2-lime);
+  outline-offset: 3px;
+}
+
+.avatar-editor__content {
+  gap: var(--v2-space-3);
+}
+
+.avatar-editor__preview {
+  gap: var(--v2-space-4);
+  padding: var(--v2-space-4);
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-control-radius);
+  background: var(--v2-surface-secondary);
+}
+
+.avatar-editor__preview > div {
+  min-width: 0;
+  gap: var(--v2-space-1);
+}
+
+.avatar-editor__preview strong {
+  line-height: 1.3;
+}
+
+.avatar-editor__preview p,
+.avatar-editor__error span {
   color: var(--v2-text-secondary);
-  font-size: 0.78rem;
-  font-weight: 700;
-  line-height: 1.35;
+  font-size: 0.82rem;
+  line-height: 1.45;
 }
 
-.profile-avatar-card__avatar {
+.avatar-editor__avatar {
   overflow: hidden;
   display: grid;
-  width: 124px;
-  height: 124px;
+  width: 88px;
+  height: 88px;
+  flex: 0 0 88px;
   place-items: center;
   border: 3px solid var(--v2-lime);
   border-radius: 50%;
   background: var(--v2-surface);
   color: var(--v2-accent-text);
-  font-size: 3rem;
-  box-shadow: 0 0 0 8px color-mix(in srgb, var(--v2-lime) 12%, transparent);
+  font-size: 2.25rem;
+  box-shadow: 0 0 0 7px color-mix(in srgb, var(--v2-lime) 12%, transparent);
 }
 
-.profile-avatar-card__avatar img {
+.avatar-editor__avatar img {
   width: 100%;
   height: 100%;
   object-fit: cover;
 }
 
-.profile-avatar-card__body,
-.profile-avatar-card__copy {
-  display: grid;
+.avatar-editor__choose {
+  min-height: 48px;
+  justify-self: stretch;
 }
 
-.profile-avatar-card__body {
-  align-content: center;
-  gap: var(--v2-space-4);
-  min-width: 0;
-  padding: var(--v2-space-5);
-}
-
-.profile-avatar-card__copy {
-  gap: var(--v2-space-2);
-  max-width: 64ch;
-}
-
-.profile-avatar-card__copy h2,
-.profile-avatar-card__copy p,
-.profile-avatar-delete-confirmation p,
-.profile-avatar-card__message {
-  margin: 0;
-}
-
-.profile-avatar-card__copy h2 {
-  font-size: clamp(1.55rem, 3vw, 2.2rem);
-  letter-spacing: -0.03em;
-}
-
-.profile-avatar-card__copy p,
-.profile-avatar-delete-confirmation p {
-  color: var(--v2-text-secondary);
-  line-height: 1.5;
-}
-
-.profile-avatar-card__actions,
-.profile-avatar-delete-confirmation__actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--v2-space-2);
-}
-
-.profile-avatar-card__actions > button,
-.profile-avatar-delete-confirmation__actions > button {
-  min-height: 44px;
-}
-
-.profile-avatar-card__delete {
-  margin-left: auto;
-}
-
-.profile-avatar-delete-confirmation {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: var(--v2-space-4);
-  padding: var(--v2-space-4);
-  border: 1px solid var(--v2-border-strong);
-  border-radius: var(--v2-control-radius);
-  background: var(--v2-surface-secondary);
-}
-
-.profile-avatar-delete-confirmation > div:first-child {
-  display: grid;
+.avatar-editor__error {
   gap: var(--v2-space-1);
-}
-
-.profile-avatar-card__message {
   padding: var(--v2-space-3);
-  border: 1px solid currentColor;
+  border: 1px solid var(--v2-danger);
   border-radius: var(--v2-control-radius);
-  line-height: 1.4;
-}
-
-.profile-avatar-card__message.is-error {
+  background: var(--v2-danger-surface);
   color: var(--v2-danger);
 }
 
-.profile-avatar-card__message.is-success {
-  color: var(--v2-success);
+.avatar-editor__delete {
+  min-height: 44px;
+  justify-self: start;
+  color: var(--v2-danger);
+}
+
+.avatar-editor__delete-confirmation {
+  display: grid;
+  gap: var(--v2-space-4);
+  padding: var(--v2-space-4);
+  border: 1px solid var(--v2-danger);
+  border-radius: var(--v2-control-radius);
+  background: var(--v2-danger-surface);
+}
+
+.avatar-editor__delete-confirmation > div:first-child {
+  display: grid;
+  gap: var(--v2-space-2);
+}
+
+.avatar-editor__delete-confirmation p {
+  margin: 0;
+  color: var(--v2-text-secondary);
+  line-height: 1.45;
+}
+
+.avatar-editor__delete-confirmation .avatar-editor__delete-error {
+  color: var(--v2-danger);
+  font-weight: 700;
+}
+
+.avatar-editor__delete-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--v2-space-2);
+}
+
+.avatar-editor__delete-actions > button {
+  min-height: 44px;
+}
+
+.avatar-editor__actions {
+  justify-content: flex-end;
+  gap: var(--v2-space-2);
+  padding-top: var(--v2-space-3);
+  border-top: 1px solid var(--v2-border);
+}
+
+.avatar-editor__actions > button {
+  min-width: 132px;
+  min-height: 48px;
+}
+
+.avatar-editor :where(button:disabled) {
+  cursor: not-allowed;
+  opacity: 0.46;
+}
+
+.avatar-editor__actions > button:not(.secondary):disabled {
+  background: var(--v2-surface-secondary);
+  color: var(--v2-text-secondary);
+}
+
+@media (min-width: 900px) {
+  .avatar-editor-layer {
+    align-items: center;
+    padding: var(--v2-space-6);
+  }
+
+  .avatar-editor {
+    max-height: min(760px, calc(100dvh - (2 * var(--v2-space-6))));
+    padding: var(--v2-space-5);
+    border-bottom: 1px solid var(--v2-border-strong);
+    border-radius: var(--v2-region-radius);
+  }
+}
+
+@media (max-width: 420px) {
+  .avatar-editor__preview {
+    align-items: flex-start;
+  }
+
+  .avatar-editor__avatar {
+    width: 72px;
+    height: 72px;
+    flex-basis: 72px;
+    font-size: 1.9rem;
+  }
+
+  .avatar-editor__actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .avatar-editor__delete-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .avatar-editor__actions > button {
+    min-width: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .avatar-editor-layer,
+  .avatar-editor {
+    scroll-behavior: auto;
+  }
 }
 
 .profile-status-shell {
@@ -3976,6 +4107,72 @@ body:has(.standalone-page--design-v2) {
   gap: var(--v2-space-2);
   font-size: 1.1rem;
   letter-spacing: -0.01em;
+}
+
+.profile-avatar-setting {
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--v2-space-3);
+  padding: var(--v2-space-3) var(--v2-space-4);
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-control-radius);
+  background: var(--v2-surface-secondary);
+}
+
+.profile-avatar-setting__avatar {
+  overflow: hidden;
+  display: grid;
+  width: 64px;
+  height: 64px;
+  place-items: center;
+  border: 2px solid var(--v2-lime);
+  border-radius: 50%;
+  background: var(--v2-surface);
+  color: var(--v2-accent-text);
+  font-size: 1.65rem;
+}
+
+.profile-avatar-setting__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-avatar-setting__copy {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.profile-avatar-setting__copy span {
+  color: var(--v2-text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.profile-avatar-setting__action {
+  min-width: 104px;
+  min-height: 44px;
+}
+
+@media (max-width: 420px) {
+  .profile-avatar-setting {
+    grid-template-columns: 56px minmax(0, 1fr) auto;
+    gap: var(--v2-space-2);
+    padding-inline: var(--v2-space-3);
+  }
+
+  .profile-avatar-setting__avatar {
+    width: 56px;
+    height: 56px;
+    font-size: 1.45rem;
+  }
+
+  .profile-avatar-setting__action {
+    min-width: 88px;
+    padding-inline: var(--v2-space-2);
+  }
 }
 
 .app-section--profile .profile-form-grid {
@@ -6755,48 +6952,6 @@ body.public-shell-mode:has(.public-shell.public-shell--design-v2) {
 
   .profile-settings {
     gap: var(--v2-space-5);
-  }
-
-  .profile-avatar-card {
-    grid-template-columns: 1fr;
-  }
-
-  .profile-avatar-card__visual {
-    grid-template-columns: auto minmax(0, 1fr);
-    min-height: 0;
-    place-content: initial;
-    justify-items: start;
-    align-items: center;
-    padding: var(--v2-space-4);
-    border-right: 0;
-    border-bottom: 1px solid var(--v2-border);
-    text-align: left;
-  }
-
-  .profile-avatar-card__avatar {
-    width: 88px;
-    height: 88px;
-    font-size: 2.25rem;
-  }
-
-  .profile-avatar-card__body {
-    padding: var(--v2-space-4);
-  }
-
-  .profile-avatar-card__actions,
-  .profile-avatar-delete-confirmation,
-  .profile-avatar-delete-confirmation__actions {
-    display: grid;
-    grid-template-columns: 1fr;
-  }
-
-  .profile-avatar-card__actions > button,
-  .profile-avatar-delete-confirmation__actions > button {
-    width: 100%;
-  }
-
-  .profile-avatar-card__delete {
-    margin-left: 0;
   }
 
   .profile-status-shell {

--- a/frontend/tests/e2e/avatar-settings.spec.ts
+++ b/frontend/tests/e2e/avatar-settings.spec.ts
@@ -13,9 +13,16 @@ const avatarFile = {
   ),
 };
 
-async function openAvatarSettings(page: Page) {
+async function openPersonalData(page: Page) {
   await page.goto('/app?section=profile');
-  await expect(page.getByRole('heading', { name: 'Аватар', exact: true })).toBeVisible();
+  await page.getByRole('link', { name: 'Личные данные', exact: true }).click();
+  await expect(page.getByRole('button', { name: 'Изменить аватар' })).toBeVisible();
+}
+
+async function openAvatarSettings(page: Page) {
+  await openPersonalData(page);
+  await page.getByRole('button', { name: 'Изменить аватар' }).click();
+  await expect(page.getByRole('dialog', { name: 'Аватар' })).toBeVisible();
 }
 
 async function chooseAvatar(page: Page) {
@@ -42,27 +49,26 @@ test('failed upload keeps the local preview and retry updates every account avat
   await openAvatarSettings(page);
 
   await chooseAvatar(page);
-  const previewSource = await page.locator('.profile-avatar-card__avatar img').getAttribute('src');
+  const previewSource = await page.locator('.avatar-editor__avatar img').getAttribute('src');
   expect(previewSource).toMatch(/^blob:/);
 
   api.failNextAvatarUpload();
   await page.getByRole('button', { name: 'Сохранить аватар' }).click();
   await expect(page.getByRole('alert')).toContainText('Не удалось обработать изображение');
   await expect(page.getByRole('button', { name: 'Повторить сохранение' })).toBeVisible();
-  await expect(page.locator('.profile-avatar-card__avatar img')).toHaveAttribute(
-    'src',
-    previewSource!,
-  );
+  await expect(page.locator('.avatar-editor__avatar img')).toHaveAttribute('src', previewSource!);
 
   await page.getByRole('button', { name: 'Повторить сохранение' }).click();
   await expect(page.getByRole('status')).toContainText('Аватар сохранён');
   expect(api.avatarUploads()).toBe(2);
-  await expect(page.getByText('Используется свой аватар')).toBeVisible();
   await expect(page.locator('.app-desktop-account-entry img')).toHaveAttribute('src', /^blob:/);
 
   await page.reload();
-  await expect(page.getByText('Используется свой аватар')).toBeVisible();
-  await expect(page.locator('.profile-avatar-card__avatar img')).toHaveAttribute('src', /^blob:/);
+  await openAvatarSettings(page);
+  await expect(
+    page.getByRole('dialog', { name: 'Аватар' }).getByText('Используется свой аватар'),
+  ).toBeVisible();
+  await expect(page.locator('.avatar-editor__avatar img')).toHaveAttribute('src', /^blob:/);
   await context.close();
 });
 
@@ -75,12 +81,11 @@ test('deletion requires confirmation and restores the provider avatar', async ({
   await page.getByRole('button', { name: 'Удалить свой аватар' }).click();
   const confirmation = page.getByRole('alertdialog', { name: 'Удалить свой аватар?' });
   await expect(confirmation).toBeVisible();
-  await expect(confirmation.getByRole('button', { name: 'Удалить', exact: true })).toBeFocused();
+  await expect(confirmation.getByRole('button', { name: 'Отмена' })).toBeFocused();
   await confirmation.getByRole('button', { name: 'Удалить', exact: true }).click();
 
   await expect(page.getByRole('status')).toContainText('фото из способа входа');
-  await expect(page.getByText('Используется фото из способа входа')).toBeVisible();
-  await expect(page.locator('.profile-avatar-card__avatar img')).toHaveAttribute(
+  await expect(page.locator('.app-desktop-account-entry img')).toHaveAttribute(
     'src',
     /^data:image\/svg\+xml/,
   );
@@ -92,6 +97,7 @@ for (const viewport of [
   { width: 360, height: 800 },
   { width: 390, height: 844 },
   { width: 430, height: 932 },
+  { width: 768, height: 900 },
 ]) {
   test(`mobile ${viewport.width}px keeps avatar actions inside the viewport`, async ({
     browser,
@@ -105,12 +111,13 @@ for (const viewport of [
     await installPlatformApi(page, { browserSession: true, avatarState: 'custom' });
     await openAvatarSettings(page);
 
-    await expect(page.locator('.profile-avatar-card')).toBeVisible();
+    const editor = page.getByRole('dialog', { name: 'Аватар' });
+    await expect(editor).toBeVisible();
     const overflow = await page.evaluate(
       () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
     );
     expect(overflow).toBeLessThanOrEqual(1);
-    for (const button of await page.locator('.profile-avatar-card__actions button').all()) {
+    for (const button of await editor.locator('button').all()) {
       const box = await button.boundingBox();
       expect(box?.height).toBeGreaterThanOrEqual(44);
     }
@@ -136,6 +143,7 @@ test('mocked Telegram Mini App uses the same custom avatar flow', async ({ brows
   await page.getByRole('button', { name: 'Сохранить аватар' }).click();
   await expect(page.getByRole('status')).toContainText('Аватар сохранён');
   await expect(page.locator('html')).toHaveAttribute('data-color-scheme', 'dark');
+  await expect(page.locator('.profile-avatar-setting img')).toHaveAttribute('src', /^blob:/);
   await page.getByRole('button', { name: 'Открыть профиль и настройки' }).click();
   await expect(page.getByRole('dialog', { name: 'Профиль и настройки' })).toBeVisible();
   await expect(page.locator('.app-more-panel__identity img')).toHaveAttribute('src', /^blob:/);
@@ -144,77 +152,71 @@ test('mocked Telegram Mini App uses the same custom avatar flow', async ({ brows
   await context.close();
 });
 
-test('captures the owner approval matrix in matching light and dark states', async ({
-  browser,
-}) => {
-  const surfaces = [
-    { name: 'desktop-1280x900', viewport: { width: 1280, height: 900 }, hasTouch: false },
-    { name: 'mobile-390x844', viewport: { width: 390, height: 844 }, hasTouch: true },
+test('captures the exact Task 110A owner approval screenshots', async ({ browser }) => {
+  const scenarios = [
+    {
+      name: '01-mobile-390x844-light-personal-data',
+      viewport: { width: 390, height: 844 },
+      hasTouch: true,
+      theme: 'light',
+      editorOpen: false,
+    },
+    {
+      name: '02-mobile-390x844-dark-avatar-sheet',
+      viewport: { width: 390, height: 844 },
+      hasTouch: true,
+      theme: 'dark',
+      editorOpen: true,
+    },
+    {
+      name: '03-desktop-1280x900-light-personal-data',
+      viewport: { width: 1280, height: 900 },
+      hasTouch: false,
+      theme: 'light',
+      editorOpen: false,
+    },
+    {
+      name: '04-desktop-1280x900-dark-avatar-modal',
+      viewport: { width: 1280, height: 900 },
+      hasTouch: false,
+      theme: 'dark',
+      editorOpen: true,
+    },
   ] as const;
-  const states = ['default', 'provider', 'custom', 'error', 'delete-confirmation'] as const;
 
-  for (const surface of surfaces) {
-    for (const theme of ['light', 'dark'] as const) {
-      for (const state of states) {
-        const context = await browser.newContext({
-          viewport: surface.viewport,
-          hasTouch: surface.hasTouch,
-          colorScheme: theme,
-        });
-        await context.addInitScript((selectedTheme) => {
-          localStorage.setItem('app-theme', selectedTheme);
-        }, theme);
-        const page = await context.newPage();
-        const api = await installPlatformApi(page, {
-          browserSession: true,
-          avatarState:
-            state === 'provider' || state === 'error'
-              ? 'provider'
-              : state === 'custom' || state === 'delete-confirmation'
-                ? 'custom'
-                : 'default',
-        });
-        await openAvatarSettings(page);
-        await expect(page.locator('html')).toHaveAttribute('data-color-scheme', theme);
+  for (const scenario of scenarios) {
+    const context = await browser.newContext({
+      viewport: scenario.viewport,
+      hasTouch: scenario.hasTouch,
+      colorScheme: scenario.theme,
+      reducedMotion: 'reduce',
+    });
+    await context.addInitScript((selectedTheme) => {
+      localStorage.setItem('app-theme', selectedTheme);
+    }, scenario.theme);
+    const page = await context.newPage();
+    await installPlatformApi(page, { browserSession: true, avatarState: 'custom' });
 
-        if (state === 'error') {
-          await chooseAvatar(page);
-          api.failNextAvatarUpload();
-          await page.getByRole('button', { name: 'Сохранить аватар' }).click();
-          await expect(page.getByRole('alert')).toBeVisible();
-        } else if (state === 'delete-confirmation') {
-          await page.getByRole('button', { name: 'Удалить свой аватар' }).click();
-          await expect(page.getByRole('alertdialog')).toBeVisible();
-        } else {
-          const label = {
-            default: 'Используется нейтральный emoji',
-            provider: 'Используется фото из способа входа',
-            custom: 'Используется свой аватар',
-          }[state];
-          await expect(page.getByText(label)).toBeVisible();
-        }
-
-        if (surface.hasTouch) {
-          const overflow = await page.evaluate(
-            () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
-          );
-          expect(overflow).toBeLessThanOrEqual(1);
-        }
-        await page.screenshot({
-          path: `../.artifacts/screenshots/task-110/approval/${surface.name}-${theme}-${state}.png`,
-          fullPage: false,
-        });
-        const bottomNavigation = page.locator('.app-bottom-nav');
-        if (surface.hasTouch) {
-          await bottomNavigation.evaluate((element) => {
-            element.style.visibility = 'hidden';
-          });
-        }
-        await page.locator('.profile-avatar-card').screenshot({
-          path: `../.artifacts/screenshots/task-110/approval/card-${surface.name}-${theme}-${state}.png`,
-        });
-        await context.close();
-      }
+    if (scenario.editorOpen) {
+      await openAvatarSettings(page);
+      await expect(
+        page.getByRole('dialog', { name: 'Аватар' }).getByText('Используется свой аватар'),
+      ).toBeVisible();
+    } else {
+      await openPersonalData(page);
+      await expect(page.locator('.profile-avatar-card')).not.toBeAttached();
+      await expect(page.locator('.profile-avatar-setting')).toBeVisible();
     }
+
+    await expect(page.locator('html')).toHaveAttribute('data-color-scheme', scenario.theme);
+    const overflow = await page.evaluate(
+      () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+    );
+    expect(overflow).toBeLessThanOrEqual(1);
+    await page.screenshot({
+      path: `../.artifacts/screenshots/task-110A/approval/${scenario.name}.png`,
+      fullPage: false,
+    });
+    await context.close();
   }
 });

--- a/frontend/tests/e2e/avatar-settings.spec.ts
+++ b/frontend/tests/e2e/avatar-settings.spec.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 
 import { expect, test, type Browser, type Page } from '@playwright/test';
-import { installTelegramHarness } from './fixtures/mobile-tma';
+import { installTelegramHarness, TelegramHarness } from './fixtures/mobile-tma';
 import { installPlatformApi, type PlatformApiController } from './fixtures/platform-api';
 
 const avatarFile = {
@@ -136,6 +136,7 @@ test('mocked Telegram Mini App uses the same custom avatar flow', async ({ brows
     safeAreaInset: { top: 16, right: 0, bottom: 20, left: 0 },
     contentSafeAreaInset: { top: 8, right: 0, bottom: 24, left: 0 },
   });
+  const telegram = new TelegramHarness(page);
   const api: PlatformApiController = await installPlatformApi(page, { avatarState: 'default' });
   await openAvatarSettings(page);
 
@@ -144,6 +145,18 @@ test('mocked Telegram Mini App uses the same custom avatar flow', async ({ brows
   await expect(page.getByRole('status')).toContainText('Аватар сохранён');
   await expect(page.locator('html')).toHaveAttribute('data-color-scheme', 'dark');
   await expect(page.locator('.profile-avatar-setting img')).toHaveAttribute('src', /^blob:/);
+
+  await page.getByRole('button', { name: 'Изменить аватар' }).click();
+  const editor = page.getByRole('dialog', { name: 'Аватар' });
+  const deleteAvatar = editor.getByRole('button', { name: 'Удалить свой аватар' });
+  await deleteAvatar.click();
+  await expect(page.getByRole('alertdialog', { name: 'Удалить свой аватар?' })).toBeVisible();
+  await telegram.clickBack();
+  await expect(page.getByRole('alertdialog', { name: 'Удалить свой аватар?' })).not.toBeAttached();
+  await expect(editor).toBeVisible();
+  await expect(deleteAvatar).toBeFocused();
+  await editor.getByRole('button', { name: 'Закрыть редактор аватара' }).click();
+
   await page.getByRole('button', { name: 'Открыть профиль и настройки' }).click();
   await expect(page.getByRole('dialog', { name: 'Профиль и настройки' })).toBeVisible();
   await expect(page.locator('.app-more-panel__identity img')).toHaveAttribute('src', /^blob:/);

--- a/frontend/tests/unit/features/profile/AvatarSettings.test.tsx
+++ b/frontend/tests/unit/features/profile/AvatarSettings.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-li
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AvatarSettings } from '../../../../src/features/profile/AvatarSettings';
 import { FeedbackProvider } from '../../../../src/shared/ui/FeedbackProvider';
+import { createTelegramMock } from '../../../helpers/telegramMock';
 
 const { api, authState, onClose, updateUser } = vi.hoisted(() => ({
   api: vi.fn(),
@@ -63,6 +64,7 @@ describe('AvatarSettings', () => {
 
   afterEach(() => {
     cleanup();
+    delete window.Telegram;
     vi.unstubAllGlobals();
   });
 
@@ -146,6 +148,34 @@ describe('AvatarSettings', () => {
     fireEvent.keyDown(confirmation, { key: 'Escape' });
 
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Аватар' })).toBeInTheDocument();
+    await waitFor(() => expect(deleteAvatar).toHaveFocus());
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('uses Telegram Back to close only delete confirmation and restore its exact trigger', async () => {
+    const telegram = createTelegramMock();
+    window.Telegram = { WebApp: telegram.webApp };
+    authState.user.custom_avatar = {
+      content_type: 'image/webp',
+      byte_size: 10_000,
+      width: 512,
+      height: 512,
+      updated_at: '2030-01-02T12:00:00',
+    };
+    renderEditor();
+
+    const deleteAvatar = screen.getByRole('button', { name: 'Удалить свой аватар' });
+    fireEvent.click(deleteAvatar);
+    await waitFor(() =>
+      expect(
+        within(screen.getByRole('alertdialog')).getByRole('button', { name: 'Отмена' }),
+      ).toHaveFocus(),
+    );
+
+    telegram.clickBack();
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument());
     expect(screen.getByRole('dialog', { name: 'Аватар' })).toBeInTheDocument();
     await waitFor(() => expect(deleteAvatar).toHaveFocus());
     expect(onClose).not.toHaveBeenCalled();

--- a/frontend/tests/unit/features/profile/AvatarSettings.test.tsx
+++ b/frontend/tests/unit/features/profile/AvatarSettings.test.tsx
@@ -1,8 +1,9 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AvatarSettings } from '../../../../src/features/profile/AvatarSettings';
+import { FeedbackProvider } from '../../../../src/shared/ui/FeedbackProvider';
 
-const { api, authState, updateUser } = vi.hoisted(() => ({
+const { api, authState, onClose, updateUser } = vi.hoisted(() => ({
   api: vi.fn(),
   authState: {
     user: {
@@ -20,6 +21,7 @@ const { api, authState, updateUser } = vi.hoisted(() => ({
       profile: { full_name: 'Анна Петрова' },
     },
   },
+  onClose: vi.fn(),
   updateUser: vi.fn(),
 }));
 
@@ -39,9 +41,17 @@ vi.mock('../../../../src/shared/account/AccountIdentity', () => ({
 }));
 
 describe('AvatarSettings', () => {
+  const renderEditor = () =>
+    render(
+      <FeedbackProvider>
+        <AvatarSettings open onClose={onClose} />
+      </FeedbackProvider>,
+    );
+
   beforeEach(() => {
     api.mockReset();
     updateUser.mockReset();
+    onClose.mockReset();
     authState.user.photo_url = null;
     authState.user.custom_avatar = null;
     vi.stubGlobal('URL', {
@@ -58,8 +68,9 @@ describe('AvatarSettings', () => {
 
   it('keeps a selected file for preview and updates the shared user after save', async () => {
     api.mockResolvedValue({ ...authState.user, custom_avatar: { updated_at: '2030-01-02' } });
-    render(<AvatarSettings />);
+    renderEditor();
 
+    expect(screen.getByRole('dialog', { name: 'Аватар' })).toBeInTheDocument();
     expect(screen.getByText('Используется нейтральный emoji')).toBeInTheDocument();
     const file = new File(['png'], 'portrait.png', { type: 'image/png' });
     fireEvent.change(screen.getByLabelText('Выбрать изображение для аватара'), {
@@ -78,10 +89,11 @@ describe('AvatarSettings', () => {
     expect(uploadedFile).toMatchObject({ name: file.name, size: file.size, type: file.type });
     await waitFor(() => expect(updateUser).toHaveBeenCalledOnce());
     expect(screen.getByRole('status')).toHaveTextContent('Аватар сохранён');
+    expect(onClose).toHaveBeenCalledOnce();
   });
 
   it('shows a client validation error for unsupported files without a request', () => {
-    render(<AvatarSettings />);
+    renderEditor();
     fireEvent.change(screen.getByLabelText('Выбрать изображение для аватара'), {
       target: { files: [new File(['heic'], 'portrait.heic', { type: 'image/heic' })] },
     });
@@ -100,16 +112,72 @@ describe('AvatarSettings', () => {
       updated_at: '2030-01-02T12:00:00',
     };
     api.mockResolvedValue({ ...authState.user, custom_avatar: null });
-    render(<AvatarSettings />);
+    renderEditor();
 
     fireEvent.click(screen.getByRole('button', { name: 'Удалить свой аватар' }));
     const confirmation = screen.getByRole('alertdialog', { name: 'Удалить свой аватар?' });
     expect(confirmation).toHaveTextContent('Фото из способа входа или emoji');
-    fireEvent.click(screen.getByRole('button', { name: /^Удалить$/ }));
+    fireEvent.click(within(confirmation).getByRole('button', { name: /^Удалить$/ }));
 
     await waitFor(() =>
       expect(api).toHaveBeenCalledWith('/api/v1/me/avatar', { method: 'DELETE' }),
     );
     expect(updateUser).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('closes only delete confirmation on Escape and restores its exact trigger', async () => {
+    authState.user.custom_avatar = {
+      content_type: 'image/webp',
+      byte_size: 10_000,
+      width: 512,
+      height: 512,
+      updated_at: '2030-01-02T12:00:00',
+    };
+    renderEditor();
+
+    const deleteAvatar = screen.getByRole('button', { name: 'Удалить свой аватар' });
+    fireEvent.click(deleteAvatar);
+    const confirmation = screen.getByRole('alertdialog', { name: 'Удалить свой аватар?' });
+    await waitFor(() =>
+      expect(within(confirmation).getByRole('button', { name: 'Отмена' })).toHaveFocus(),
+    );
+
+    fireEvent.keyDown(confirmation, { key: 'Escape' });
+
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Аватар' })).toBeInTheDocument();
+    await waitFor(() => expect(deleteAvatar).toHaveFocus());
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('keeps delete confirmation open after an error and retries the request', async () => {
+    authState.user.custom_avatar = {
+      content_type: 'image/webp',
+      byte_size: 10_000,
+      width: 512,
+      height: 512,
+      updated_at: '2030-01-02T12:00:00',
+    };
+    api.mockRejectedValueOnce(new Error('Сервис временно недоступен')).mockResolvedValueOnce({
+      ...authState.user,
+      custom_avatar: null,
+    });
+    renderEditor();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Удалить свой аватар' }));
+    const confirmation = screen.getByRole('alertdialog', { name: 'Удалить свой аватар?' });
+    fireEvent.click(within(confirmation).getByRole('button', { name: /^Удалить$/ }));
+
+    await waitFor(() =>
+      expect(within(confirmation).getByRole('alert')).toHaveTextContent(
+        'Сервис временно недоступен',
+      ),
+    );
+    fireEvent.click(within(confirmation).getByRole('button', { name: 'Повторить удаление' }));
+
+    await waitFor(() => expect(api).toHaveBeenCalledTimes(2));
+    expect(updateUser).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/tests/unit/features/profile/ProfileForm.test.tsx
+++ b/frontend/tests/unit/features/profile/ProfileForm.test.tsx
@@ -11,6 +11,9 @@ vi.mock('../../../../src/shared/api/client', () => ({ api: apiMock }));
 vi.mock('../../../../src/app/AuthProvider', () => ({
   useAuth: () => ({ user: { id: 10, profile: null }, reloadUser }),
 }));
+vi.mock('../../../../src/features/profile/TrainingPreferencesForm', () => ({
+  TrainingPreferencesForm: () => null,
+}));
 
 const previewByGoal = {
   fat_loss: { min_bpm: 130, max_bpm: 140 },
@@ -51,6 +54,36 @@ function restingHeartRateInput(): HTMLInputElement {
   if (!input) throw new Error('Resting heart rate input not found');
   return input;
 }
+
+describe('ProfileForm avatar setting', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    apiMock.mockReset();
+    apiMock.mockResolvedValue({ items: [] });
+  });
+
+  afterEach(cleanup);
+
+  it('opens the avatar editor from Personal data and restores focus to its trigger', async () => {
+    renderForm();
+
+    const avatarSetting = screen.getByText('Фото профиля').closest('.profile-avatar-setting');
+    expect(avatarSetting).not.toBeNull();
+    expect(avatarSetting).toHaveTextContent('Используется нейтральный emoji');
+    const editAvatar = screen.getByRole('button', { name: 'Изменить аватар' });
+    editAvatar.focus();
+    expect(editAvatar).toHaveFocus();
+    fireEvent.click(editAvatar);
+
+    expect(await screen.findByRole('dialog', { name: 'Аватар' })).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Выбрать изображение' })).toHaveFocus(),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Закрыть редактор аватара' }));
+
+    await waitFor(() => expect(editAvatar).toHaveFocus());
+  });
+});
 
 describe('ProfileForm heart rate preview', () => {
   beforeEach(() => {


### PR DESCRIPTION
## Что изменено
- управление аватаром перенесено в компактную строку раздела Личные данные на mobile и desktop
- редактор работает как mobile bottom sheet и desktop modal
- сохранены preview, save/retry, toast, delete confirmation и точный focus restoration

## Проверки
- typecheck, lint, Prettier, production build
- unit: 23 passed
- Chromium: 8 passed, включая mocked TMA и viewport 360/390/430/768/1280
- owner visual approval: Telegram messages 399-402

## Findings
- NBF-20260901-110A-01 MEDIUM FIXED
- NBF-20260901-110A-02 LOW FIXED