### PR TITLE
[Task 110B] Clarify profile action affordances

### DIFF
--- a/frontend/src/features/profile/AvatarSettings.tsx
+++ b/frontend/src/features/profile/AvatarSettings.tsx
@@ -223,39 +223,41 @@ export function AvatarSettings({ open, onClose }: { open: boolean; onClose(): vo
             onChange={(event) => chooseFile(event.target.files?.[0] ?? null)}
           />
 
-          <button
-            type="button"
-            className="secondary avatar-editor__choose"
-            disabled={blocking}
-            onClick={() => inputRef.current?.click()}
-          >
-            {selectedFile
-              ? 'Выбрать другое'
-              : hasCustomAvatar
-                ? 'Заменить изображение'
-                : 'Выбрать изображение'}
-          </button>
+          <div className="avatar-editor__media-actions">
+            <button
+              type="button"
+              className="secondary avatar-editor__choose"
+              disabled={blocking}
+              onClick={() => inputRef.current?.click()}
+            >
+              {selectedFile
+                ? 'Выбрать другое'
+                : hasCustomAvatar
+                  ? 'Заменить изображение'
+                  : 'Выбрать изображение'}
+            </button>
+
+            {hasCustomAvatar && !selectedFile && (
+              <button
+                ref={deleteButtonRef}
+                type="button"
+                className="avatar-editor__delete"
+                disabled={blocking}
+                onClick={() => {
+                  setError(null);
+                  setConfirmDelete(true);
+                }}
+              >
+                Удалить свой аватар
+              </button>
+            )}
+          </div>
 
           {error && !confirmDelete && (
             <div className="avatar-editor__error" role="alert">
               <strong>Изменение не сохранено</strong>
               <span>{error}</span>
             </div>
-          )}
-
-          {hasCustomAvatar && !selectedFile && (
-            <button
-              ref={deleteButtonRef}
-              type="button"
-              className="text-button avatar-editor__delete"
-              disabled={blocking}
-              onClick={() => {
-                setError(null);
-                setConfirmDelete(true);
-              }}
-            >
-              Удалить свой аватар
-            </button>
           )}
         </div>
 

--- a/frontend/src/styles/design-system.css
+++ b/frontend/src/styles/design-system.css
@@ -8,6 +8,7 @@
   --v2-text-primary: #eef0ea;
   --v2-text-secondary: #afb5ad;
   --v2-border: #3a413a;
+  --v2-border-strong: #6d756e;
   --v2-lime: #a8e83a;
   --v2-lime-hover: #98d62f;
   --v2-accent-text: #b9ea72;
@@ -146,6 +147,7 @@
   --v2-text-primary: #161a17;
   --v2-text-secondary: #59605b;
   --v2-border: #c9cdc8;
+  --v2-border-strong: #7f8680;
   --v2-lime: #9ee02b;
   --v2-lime-hover: #8dce20;
   --v2-accent-text: #486414;

--- a/frontend/src/styles/design-v2.css
+++ b/frontend/src/styles/design-v2.css
@@ -722,6 +722,10 @@ body:has(.app-shell--design-v2) {
   outline-offset: 3px;
 }
 
+.app-shell--design-v2 .app-more-panel__item[aria-current='page'] {
+  box-shadow: inset 3px 0 0 var(--v2-lime);
+}
+
 .today-dashboard--design-v2,
 .nutrition-diary--design-v2,
 .active-workout--design-v2 {
@@ -3630,6 +3634,18 @@ body:has(.standalone-page--design-v2) {
   justify-self: stretch;
 }
 
+.avatar-editor__media-actions {
+  display: grid;
+  gap: var(--v2-space-2);
+}
+
+.avatar-editor__choose,
+.avatar-editor__actions > .secondary {
+  border: 1px solid var(--v2-border-strong);
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+}
+
 .avatar-editor__error {
   gap: var(--v2-space-1);
   padding: var(--v2-space-3);
@@ -3640,9 +3656,15 @@ body:has(.standalone-page--design-v2) {
 }
 
 .avatar-editor__delete {
-  min-height: 44px;
-  justify-self: start;
+  width: 100%;
+  min-height: 48px;
+  border: 1px solid color-mix(in srgb, var(--v2-danger) 56%, var(--v2-border));
+  background: transparent;
   color: var(--v2-danger);
+}
+
+.avatar-editor__delete:hover:not(:disabled) {
+  background: var(--v2-danger-surface);
 }
 
 .avatar-editor__delete-confirmation {
@@ -3688,16 +3710,19 @@ body:has(.standalone-page--design-v2) {
 }
 
 .avatar-editor__actions > button {
+  flex: 1 1 0;
   min-width: 132px;
   min-height: 48px;
+  border: 1px solid var(--v2-lime);
 }
 
 .avatar-editor :where(button:disabled) {
   cursor: not-allowed;
-  opacity: 0.46;
+  opacity: 0.64;
 }
 
 .avatar-editor__actions > button:not(.secondary):disabled {
+  border-color: var(--v2-border-strong);
   background: var(--v2-surface-secondary);
   color: var(--v2-text-secondary);
 }
@@ -4154,6 +4179,14 @@ body:has(.standalone-page--design-v2) {
 .profile-avatar-setting__action {
   min-width: 104px;
   min-height: 44px;
+  border: 1px solid var(--v2-border-strong);
+  background: var(--v2-surface);
+  color: var(--v2-text-primary);
+}
+
+.profile-avatar-setting__action:hover:not(:disabled) {
+  border-color: var(--v2-lime);
+  background: var(--v2-surface);
 }
 
 @media (max-width: 420px) {
@@ -4236,7 +4269,7 @@ body:has(.standalone-page--design-v2) {
   align-items: center;
   justify-content: space-between;
   gap: var(--v2-space-4);
-  padding-top: var(--v2-space-5);
+  padding: var(--v2-space-4) 0 calc(var(--v2-space-4) - var(--v2-space-1));
   border-top: 1px solid var(--v2-border);
 }
 
@@ -4560,6 +4593,10 @@ button.notification-row__main:focus-visible {
 .app-section--profile .profile-settings > details.card-disclosure {
   gap: 0;
   padding: var(--v2-space-5);
+}
+
+.app-section--profile .profile-settings > details.profile-primary-card[open] {
+  padding-bottom: 0;
 }
 
 @media (min-width: 900px) {
@@ -6993,6 +7030,10 @@ body.public-shell-mode:has(.public-shell.public-shell--design-v2) {
 
   .app-section--profile .profile-settings > details.card-disclosure {
     padding: var(--v2-space-4);
+  }
+
+  .app-section--profile .profile-settings > details.profile-primary-card[open] {
+    padding-bottom: 0;
   }
 
   .app-section--profile .profile-settings > details.card-disclosure:not([open]) {

--- a/frontend/src/styles/design-v2.css
+++ b/frontend/src/styles/design-v2.css
@@ -4269,7 +4269,7 @@ body:has(.standalone-page--design-v2) {
   align-items: center;
   justify-content: space-between;
   gap: var(--v2-space-4);
-  padding: var(--v2-space-4) 0 calc(var(--v2-space-4) - var(--v2-space-1));
+  padding-block: var(--v2-space-4);
   border-top: 1px solid var(--v2-border);
 }
 

--- a/frontend/tests/e2e/avatar-settings.spec.ts
+++ b/frontend/tests/e2e/avatar-settings.spec.ts
@@ -149,6 +149,11 @@ test('mocked Telegram Mini App uses the same custom avatar flow', async ({ brows
   await page.getByRole('button', { name: 'Изменить аватар' }).click();
   const editor = page.getByRole('dialog', { name: 'Аватар' });
   const deleteAvatar = editor.getByRole('button', { name: 'Удалить свой аватар' });
+  await expect(editor.getByRole('button', { name: 'Заменить изображение' })).toHaveCSS(
+    'border-top-width',
+    '1px',
+  );
+  await expect(deleteAvatar).toHaveCSS('border-top-width', '1px');
   await deleteAvatar.click();
   await expect(page.getByRole('alertdialog', { name: 'Удалить свой аватар?' })).toBeVisible();
   await telegram.clickBack();
@@ -162,6 +167,135 @@ test('mocked Telegram Mini App uses the same custom avatar flow', async ({ brows
   await expect(page.locator('.app-more-panel__identity img')).toHaveAttribute('src', /^blob:/);
   expect(api.authInitCalls()).toBe(1);
   expect(api.avatarUploads()).toBe(1);
+  await context.close();
+});
+
+test('light mobile keeps avatar actions outlined and current account boundary lime', async ({
+  browser,
+}) => {
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    hasTouch: true,
+    colorScheme: 'light',
+    reducedMotion: 'reduce',
+  });
+  await context.addInitScript(() => localStorage.setItem('app-theme', 'light'));
+  const page = await context.newPage();
+  await installPlatformApi(page, { browserSession: true, avatarState: 'custom' });
+  await openAvatarSettings(page);
+
+  const editor = page.getByRole('dialog', { name: 'Аватар' });
+  const outlinedActions = [
+    editor.getByRole('button', { name: 'Заменить изображение' }),
+    editor.getByRole('button', { name: 'Удалить свой аватар' }),
+    editor.getByRole('button', { name: 'Отмена', exact: true }),
+    editor.getByRole('button', { name: 'Сохранить аватар' }),
+  ];
+  for (const action of outlinedActions) {
+    await expect(action).toHaveCSS('border-top-style', 'solid');
+    await expect(action).toHaveCSS('border-top-width', '1px');
+    expect((await action.boundingBox())?.height).toBeGreaterThanOrEqual(44);
+  }
+
+  const [chooseBox, deleteBox] = await Promise.all(
+    outlinedActions.slice(0, 2).map((action) => action.boundingBox()),
+  );
+  expect(chooseBox).not.toBeNull();
+  expect(deleteBox).not.toBeNull();
+  expect(Math.abs(chooseBox!.x - deleteBox!.x)).toBeLessThanOrEqual(1);
+  expect(Math.abs(chooseBox!.width - deleteBox!.width)).toBeLessThanOrEqual(1);
+
+  await page.screenshot({
+    path: '../.artifacts/screenshots/task-110B/mobile-light-avatar-actions.png',
+    fullPage: false,
+  });
+  await context.close();
+
+  const accountContext = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    hasTouch: true,
+    colorScheme: 'light',
+    reducedMotion: 'reduce',
+  });
+  await accountContext.addInitScript(() => localStorage.setItem('app-theme', 'light'));
+  const accountPage = await accountContext.newPage();
+  await installPlatformApi(accountPage, { browserSession: true, avatarState: 'custom' });
+  await accountPage.goto('/app?section=profile');
+  const accountTrigger = accountPage.getByRole('button', {
+    name: 'Открыть профиль и настройки',
+  });
+  await expect(accountTrigger).toBeInViewport();
+  await accountTrigger.click();
+  const accountPanel = accountPage.getByRole('dialog', { name: 'Профиль и настройки' });
+  const currentProfile = accountPanel.getByRole('link', {
+    name: 'Профиль и настройки',
+    exact: true,
+  });
+  await expect(accountPanel).toBeVisible();
+  await expect(currentProfile).toBeVisible();
+  const boundary = await currentProfile.evaluate((element) => {
+    const probe = document.createElement('span');
+    probe.style.color = 'var(--v2-lime)';
+    document.body.append(probe);
+    const result = {
+      boxShadow: getComputedStyle(element).boxShadow,
+      lime: getComputedStyle(probe).color,
+    };
+    probe.remove();
+    return result;
+  });
+  expect(boundary.boxShadow).toContain(boundary.lime);
+  await accountPage.screenshot({
+    path: '../.artifacts/screenshots/task-110B/mobile-light-account-boundary.png',
+    fullPage: false,
+  });
+  await accountContext.close();
+});
+
+test('desktop profile actions have persistent outline and symmetric save spacing', async ({
+  browser,
+}) => {
+  const { context, page } = await createBrowserProfile(browser, { avatarState: 'custom' });
+  await context.addInitScript(() => localStorage.setItem('app-theme', 'light'));
+  await openPersonalData(page);
+
+  const editAvatar = page.getByRole('button', { name: 'Изменить аватар' });
+  await expect(editAvatar).toHaveCSS('border-top-style', 'solid');
+  await expect(editAvatar).toHaveCSS('border-top-width', '1px');
+  const editBoundary = await editAvatar.evaluate((element) => {
+    const probe = document.createElement('span');
+    probe.style.color = 'var(--v2-border-strong)';
+    document.body.append(probe);
+    const result = {
+      border: getComputedStyle(element).borderTopColor,
+      expected: getComputedStyle(probe).color,
+    };
+    probe.remove();
+    return result;
+  });
+  expect(editBoundary.border).toBe(editBoundary.expected);
+
+  const geometry = await page.locator('.profile-primary-card').evaluate((card) => {
+    const footer = card.querySelector<HTMLElement>('.profile-form__save');
+    const save = footer?.querySelector<HTMLElement>('button[type="submit"]');
+    if (!footer || !save) throw new Error('Profile save footer is missing');
+    const cardRect = card.getBoundingClientRect();
+    const footerRect = footer.getBoundingClientRect();
+    const saveRect = save.getBoundingClientRect();
+    const footerStyle = getComputedStyle(footer);
+    const cardStyle = getComputedStyle(card);
+    return {
+      top: saveRect.top - footerRect.top - Number.parseFloat(footerStyle.borderTopWidth),
+      bottom: cardRect.bottom - Number.parseFloat(cardStyle.borderBottomWidth) - saveRect.bottom,
+    };
+  });
+  expect(Math.abs(geometry.top - geometry.bottom), JSON.stringify(geometry)).toBeLessThanOrEqual(1);
+  expect(geometry.top).toBeGreaterThanOrEqual(17);
+
+  await page.screenshot({
+    path: '../.artifacts/screenshots/task-110B/desktop-light-profile-actions.png',
+    fullPage: true,
+  });
   await context.close();
 });
 

--- a/frontend/tests/e2e/avatar-settings.spec.ts
+++ b/frontend/tests/e2e/avatar-settings.spec.ts
@@ -286,11 +286,14 @@ test('desktop profile actions have persistent outline and symmetric save spacing
     const cardStyle = getComputedStyle(card);
     return {
       top: saveRect.top - footerRect.top - Number.parseFloat(footerStyle.borderTopWidth),
-      bottom: cardRect.bottom - Number.parseFloat(cardStyle.borderBottomWidth) - saveRect.bottom,
+      bottom: footerRect.bottom - saveRect.bottom,
+      cardResidual:
+        cardRect.bottom - Number.parseFloat(cardStyle.borderBottomWidth) - footerRect.bottom,
     };
   });
   expect(Math.abs(geometry.top - geometry.bottom), JSON.stringify(geometry)).toBeLessThanOrEqual(1);
   expect(geometry.top).toBeGreaterThanOrEqual(17);
+  expect(geometry.cardResidual).toBeLessThanOrEqual(5);
 
   await page.screenshot({
     path: '../.artifacts/screenshots/task-110B/desktop-light-profile-actions.png',


### PR DESCRIPTION
## Что изменено
- действия avatar editor собраны в две предсказуемые группы и получили постоянные контуры
- desktop-кнопка «Изменить» получила neutral outline, save footer — симметричный ритм
- current boundary mobile account sheet использует canonical lime
- добавлен отсутствовавший Light/Dark token сильной границы с contrast >= 3:1

## Проверки
- frontend typecheck, lint, production build
- unit: AvatarSettings + AppShell, 19 passed
- Chromium affected matrix: avatar + profile settings, 14 passed
- independent review APPROVED; QA PASS; unresolved BLOCKER/HIGH/MEDIUM: 0