### PR TITLE
[Task 81A] Refine hydration and nutrition layout

### DIFF
--- a/frontend/src/features/nutrition/HydrationTracker.tsx
+++ b/frontend/src/features/nutrition/HydrationTracker.tsx
@@ -293,7 +293,7 @@ export function HydrationTracker({ diaryDate }: { diaryDate: string }) {
       setPresetName('');
       setPresetVolume('');
       await refresh();
-      toast('Сосуд сохранён');
+      toast('Ёмкость добавлена');
     },
     onError: (reason) => toast((reason as Error).message, 'error'),
   });
@@ -302,7 +302,7 @@ export function HydrationTracker({ diaryDate }: { diaryDate: string }) {
       api<void>(`/api/v1/nutrition/hydration/presets/${presetId}`, { method: 'DELETE' }),
     onSuccess: async () => {
       await refresh();
-      toast('Сосуд удалён');
+      toast('Ёмкость удалена');
     },
     onError: (reason) => toast((reason as Error).message, 'error'),
   });
@@ -331,11 +331,11 @@ export function HydrationTracker({ diaryDate }: { diaryDate: string }) {
   const target = data.goal?.enabled ? data.goal.target_ml : null;
   const progress = Math.min(data.progress_percent ?? 0, 100);
   return (
-    <section className="hydration-card" aria-labelledby="hydration-title">
+    <section className="hydration-card" aria-label="Гидратация">
       <header className="hydration-card__header">
         <div>
-          <span className="eyebrow">Напитки</span>
-          <h2 id="hydration-title">Гидратация</h2>
+          <span className="eyebrow">Гидратация</span>
+          <h2 id="hydration-title">Напитки</h2>
           <p>{target ? `${data.total_ml} из ${target} мл` : `${data.total_ml} мл записано`}</p>
         </div>
         <div className="hydration-orb" aria-hidden="true">
@@ -488,24 +488,26 @@ export function HydrationTracker({ diaryDate }: { diaryDate: string }) {
                     <option value="male">Мужской — 3000 мл напитков</option>
                   </Select>
                 </Field>
-                <label className="hydration-check hydration-check--adult">
-                  <input
-                    type="checkbox"
-                    checked={adultConfirmed}
-                    onChange={(event) => setAdultConfirmed(event.target.checked)}
-                  />{' '}
-                  <span>Мне 18 лет или больше</span>
-                </label>
-                {!currentSex && (
-                  <label className="hydration-check">
+                <div className="hydration-profile-checks">
+                  <label className="hydration-check hydration-check--adult">
                     <input
                       type="checkbox"
-                      checked={saveSex}
-                      onChange={(event) => setSaveSex(event.target.checked)}
+                      checked={adultConfirmed}
+                      onChange={(event) => setAdultConfirmed(event.target.checked)}
                     />{' '}
-                    Сохранить выбранный пол в профиле
+                    <span>Мне 18 лет или больше</span>
                   </label>
-                )}
+                  {!currentSex && (
+                    <label className="hydration-check">
+                      <input
+                        type="checkbox"
+                        checked={saveSex}
+                        onChange={(event) => setSaveSex(event.target.checked)}
+                      />{' '}
+                      <span>Сохранить выбранный пол в профиле</span>
+                    </label>
+                  )}
+                </div>
                 <p className="hydration-note">
                   Ориентир относится к напиткам для здоровых взрослых в обычных условиях. Еда даёт
                   дополнительную воду; жара, нагрузка, беременность и медицинские состояния требуют
@@ -554,7 +556,7 @@ export function HydrationTracker({ diaryDate }: { diaryDate: string }) {
           </section>
 
           <section aria-labelledby="hydration-presets-title">
-            <h3 id="hydration-presets-title">Мой сосуд</h3>
+            <h3 id="hydration-presets-title">Мои кружки и бутылки</h3>
             <div className="hydration-form-row">
               <Field label="Название" labelFor="hydration-preset-name">
                 <Input
@@ -581,11 +583,11 @@ export function HydrationTracker({ diaryDate }: { diaryDate: string }) {
                 type="button"
                 onClick={() => savePreset.mutate()}
               >
-                Сохранить сосуд
+                Добавить
               </Button>
             </div>
             {data.presets.some((preset) => !preset.is_default) && (
-              <ul className="hydration-custom-presets" aria-label="Сохранённые сосуды">
+              <ul className="hydration-custom-presets" aria-label="Добавленные кружки и бутылки">
                 {data.presets
                   .filter((preset) => !preset.is_default && preset.id != null)
                   .map((preset) => (

--- a/frontend/src/features/nutrition/NutritionDiary.tsx
+++ b/frontend/src/features/nutrition/NutritionDiary.tsx
@@ -12,6 +12,7 @@ import type {
   FoodDiaryEntry,
   FoodDiaryMeal,
   FoodDiaryNutrition,
+  HydrationDay,
 } from '../../shared/api/types';
 import {
   Badge,
@@ -129,6 +130,79 @@ function MacroProgress({
   );
 }
 
+function DayBalance({
+  day,
+  hydration,
+  hydrationUnavailable,
+}: {
+  day: FoodDiaryDay;
+  hydration?: HydrationDay;
+  hydrationUnavailable: boolean;
+}) {
+  const foodTarget = day.targets ? Number(day.targets.energy_kcal) : null;
+  const hydrationTarget = hydration?.goal?.enabled ? hydration.goal.target_ml : null;
+  return (
+    <section
+      className="nutrition-section-card nutrition-day-balance"
+      aria-labelledby="nutrition-balance-title"
+    >
+      <header className="nutrition-section-card__header">
+        <div>
+          <span className="eyebrow">Сводка дня</span>
+          <h2 id="nutrition-balance-title">Баланс дня</h2>
+        </div>
+        <p>Еда и жидкость — рядом, без смешивания показателей.</p>
+      </header>
+      <div className="nutrition-day-balance__metrics">
+        <div>
+          {foodTarget ? (
+            <QuantitativeProgress
+              label="Еда"
+              maximum={foodTarget}
+              unit="ккал"
+              value={Number(day.totals.energy_kcal)}
+            />
+          ) : (
+            <div className="nutrition-day-balance__value">
+              <span>Еда</span>
+              <strong>{formatNumber(day.totals.energy_kcal)} ккал</strong>
+              <small>Ориентир не задан</small>
+            </div>
+          )}
+        </div>
+        <div>
+          {hydration && hydrationTarget ? (
+            <QuantitativeProgress
+              label="Жидкость"
+              maximum={hydrationTarget}
+              unit="мл"
+              value={hydration.total_ml}
+            />
+          ) : (
+            <div className="nutrition-day-balance__value">
+              <span>Жидкость</span>
+              <strong>
+                {hydration
+                  ? `${formatNumber(hydration.total_ml)} мл`
+                  : hydrationUnavailable
+                    ? 'Недоступно'
+                    : 'Загружается…'}
+              </strong>
+              <small>
+                {hydration
+                  ? 'Ориентир не задан'
+                  : hydrationUnavailable
+                    ? 'Проверьте карточку «Напитки»'
+                    : 'Получаем записи напитков'}
+              </small>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function DaySummary({ day }: { day: FoodDiaryDay }) {
   const { totals, targets, remaining } = day;
   const motion = useSemanticMotion<HTMLElement>(JSON.stringify([totals, targets, remaining]), {
@@ -146,8 +220,11 @@ function DaySummary({ day }: { day: FoodDiaryDay }) {
       onAnimationEnd={motion.onMotionAnimationEnd}
     >
       <div className="nutrition-day-summary__head">
-        <span className="eyebrow">Баланс дня</span>
-        <h2 id="nutrition-summary-title">Итоги и цель</h2>
+        <div>
+          <span className="eyebrow">Ориентиры дня</span>
+          <h2 id="nutrition-summary-title">КБЖУ</h2>
+        </div>
+        {day.targets ? <Badge tone="success">Цель КБЖУ настроена</Badge> : <Badge>Без цели</Badge>}
       </div>
       {targets && remaining ? (
         <div className="nutrition-targets">
@@ -543,13 +620,14 @@ function DayCompleteness({ day }: { day: FoodDiaryDay }) {
     >
       <div className="nutrition-completeness__copy">
         <div>
-          <span className="eyebrow">Полнота данных</span>
-          <h2 id="nutrition-completeness-title">{copy.label}</h2>
+          <span className="eyebrow">Статус дневника</span>
+          <h2 id="nutrition-completeness-title">Полнота данных</h2>
         </div>
         <Badge tone={day.status === 'complete' || day.status === 'fasted' ? 'success' : undefined}>
           {day.status_is_explicit ? 'Подтверждено' : 'Не подтверждено'}
         </Badge>
       </div>
+      <strong className="nutrition-completeness__status">{copy.label}</strong>
       <p>{copy.description}</p>
       <div className="nutrition-completeness__actions">
         <Button
@@ -668,6 +746,11 @@ export function NutritionDiary({
     queryKey: queryKeys.nutrition.diaryDate(selectedDate),
     queryFn: () => api<FoodDiaryDay>(`/api/v1/nutrition/diary?diary_date=${selectedDate}`),
   });
+  const hydration = useQuery({
+    queryKey: queryKeys.nutrition.hydrationDate(selectedDate),
+    queryFn: () => api<HydrationDay>(`/api/v1/nutrition/hydration?diary_date=${selectedDate}`),
+    enabled: false,
+  });
   const dateLabel = formatDate(selectedDate, today);
   const meals = useMemo(() => normalizeMeals(diary.data?.meals ?? []), [diary.data?.meals]);
   const newEntryIds = useMemo(
@@ -714,33 +797,6 @@ export function NutritionDiary({
         }}
       />
 
-      <HydrationTracker diaryDate={selectedDate} />
-
-      {diary.data && diary.data.meals.some((meal) => meal.entries.length > 0) && (
-        <div className="nutrition-day-actions">
-          <button
-            type="button"
-            onClick={() =>
-              setCopySubject({
-                scope: 'day',
-                sourceDate: selectedDate,
-                label: `Все записи за ${dateLabel.title.toLowerCase()}`,
-              })
-            }
-          >
-            Скопировать день
-          </button>
-        </div>
-      )}
-
-      <div className="nutrition-diary__status" aria-live="polite">
-        {diary.data?.targets ? (
-          <Badge tone="success">Цель КБЖУ настроена</Badge>
-        ) : diary.data ? (
-          <Badge>Без цели</Badge>
-        ) : null}
-      </div>
-
       {diary.isLoading && <LoadingState label="Загружаем дневник…" />}
       {diary.error && (
         <ErrorState message={(diary.error as Error).message} retry={() => void diary.refetch()} />
@@ -748,7 +804,36 @@ export function NutritionDiary({
       {diary.data && (
         <>
           <DayCompleteness day={diary.data} />
-          <div className="nutrition-diary__layout">
+          <DayBalance
+            day={diary.data}
+            hydration={hydration.data}
+            hydrationUnavailable={hydration.isError}
+          />
+          <section
+            className="nutrition-section-card nutrition-food-card"
+            aria-labelledby="nutrition-food-title"
+          >
+            <header className="nutrition-section-card__header nutrition-food-card__header">
+              <div>
+                <span className="eyebrow">Дневник приёмов пищи</span>
+                <h2 id="nutrition-food-title">Еда</h2>
+              </div>
+              {diary.data.meals.some((meal) => meal.entries.length > 0) && (
+                <button
+                  className="nutrition-food-card__copy"
+                  type="button"
+                  onClick={() =>
+                    setCopySubject({
+                      scope: 'day',
+                      sourceDate: selectedDate,
+                      label: `Все записи за ${dateLabel.title.toLowerCase()}`,
+                    })
+                  }
+                >
+                  Скопировать день
+                </button>
+              )}
+            </header>
             <div className="nutrition-meals">
               {meals.map((meal) => (
                 <MealSection
@@ -794,10 +879,12 @@ export function NutritionDiary({
                 />
               ))}
             </div>
-            <DaySummary day={diary.data} />
-          </div>
+          </section>
+          <DaySummary day={diary.data} />
         </>
       )}
+
+      <HydrationTracker diaryDate={selectedDate} />
 
       {addingTo && (
         <FoodPickerDialog

--- a/frontend/src/styles/design-v2.css
+++ b/frontend/src/styles/design-v2.css
@@ -1504,20 +1504,14 @@ body:has(.app-shell--design-v2) {
   color: var(--v2-text-secondary);
 }
 
-.nutrition-diary--design-v2 .nutrition-diary__status {
-  display: flex;
-  min-height: 24px;
-  justify-content: flex-end;
-}
-
-.nutrition-diary--design-v2 .nutrition-diary__layout {
-  grid-template-columns: minmax(0, 1.65fr) minmax(280px, 0.8fr);
-  gap: var(--v2-space-5);
-}
-
 .nutrition-diary--design-v2 .nutrition-meals {
   gap: 0;
   border-top: 1px solid var(--v2-border);
+}
+
+.nutrition-diary--design-v2 .nutrition-food-card .nutrition-meals {
+  padding: 0 var(--v2-space-4) var(--v2-space-4);
+  border-top: 0;
 }
 
 .nutrition-diary--design-v2 .nutrition-meal {
@@ -1525,6 +1519,11 @@ body:has(.app-shell--design-v2) {
   border-bottom: 1px solid var(--v2-border);
   border-radius: 0;
   background: transparent;
+}
+
+.nutrition-diary--design-v2 .nutrition-food-card .nutrition-meal {
+  border-top: 1px solid var(--v2-border);
+  border-bottom: 0;
 }
 
 .nutrition-diary--design-v2 .nutrition-meal__header {
@@ -2786,15 +2785,6 @@ body.public-shell-mode.public-shell-mode:has(.auth-public-shell--design-v2) {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .nutrition-diary--design-v2 .nutrition-diary__layout {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .nutrition-diary--design-v2 .nutrition-day-summary {
-    position: static;
-    order: -1;
-  }
-
   .auth-public-shell--design-v2 .login-layout {
     grid-template-columns: minmax(0, 1fr);
     gap: var(--v2-space-5);
@@ -2934,10 +2924,6 @@ body.public-shell-mode.public-shell-mode:has(.auth-public-shell--design-v2) {
 
   .nutrition-diary--design-v2 .nutrition-diary__intro h1 {
     font-size: clamp(2.55rem, 13vw, 3.25rem);
-  }
-
-  .nutrition-diary--design-v2 .nutrition-diary__status {
-    justify-content: flex-start;
   }
 
   .nutrition-diary--design-v2 .nutrition-day-summary {

--- a/frontend/src/styles/react.css
+++ b/frontend/src/styles/react.css
@@ -5468,6 +5468,13 @@ body:has(#appBottomNav) .toast:not(.hidden) {
   margin-top: 12px;
 }
 
+.hydration-profile-checks {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0 24px;
+}
+
 .hydration-form-row > .ui-button {
   align-self: end;
 }
@@ -5482,13 +5489,13 @@ body:has(#appBottomNav) .toast:not(.hidden) {
 .hydration-choice label,
 .hydration-check {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: flex-start;
   gap: 8px;
   width: fit-content;
   max-width: 100%;
-  min-height: 44px;
-  padding-block: 10px;
+  min-height: 36px;
+  padding-block: 4px;
 }
 
 .hydration-choice label {
@@ -5497,10 +5504,9 @@ body:has(#appBottomNav) .toast:not(.hidden) {
 
 .hydration-check--adult {
   align-items: center;
-  padding-block: 6px;
 }
 
-.hydration-check--adult span {
+.hydration-check span {
   white-space: nowrap;
 }
 
@@ -6841,6 +6847,13 @@ body:has(#appBottomNav) .toast:not(.hidden) {
   background: var(--card-bg);
   box-shadow: var(--shadow);
 }
+.nutrition-diary--design-v2 {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
 .nutrition-diary__intro {
   display: flex;
   align-items: flex-start;
@@ -6872,16 +6885,101 @@ body:has(#appBottomNav) .toast:not(.hidden) {
 .nutrition-picker__back:hover {
   background: var(--accent-soft);
 }
-.nutrition-diary__layout {
-  display: grid;
-  grid-template-columns: minmax(0, 1.65fr) minmax(260px, 0.85fr);
-  align-items: start;
-  gap: 16px;
-}
 .nutrition-meals {
   display: grid;
   gap: 12px;
   min-width: 0;
+}
+.nutrition-section-card {
+  min-width: 0;
+  padding: 17px;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+}
+.nutrition-section-card__header,
+.nutrition-day-summary__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+.nutrition-section-card__header h2,
+.nutrition-day-summary__head h2 {
+  margin-top: 3px;
+  font-size: 1.12rem;
+}
+.nutrition-section-card__header > p {
+  max-width: 38ch;
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.78rem;
+  line-height: 1.45;
+  text-align: right;
+}
+.nutrition-day-balance {
+  border-color: color-mix(in srgb, var(--v2-lime, var(--accent)) 34%, var(--border));
+  background:
+    linear-gradient(
+      145deg,
+      color-mix(in srgb, var(--v2-lime, var(--accent)) 7%, transparent),
+      transparent 48%
+    ),
+    var(--surface);
+}
+.nutrition-day-balance__metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+.nutrition-day-balance__metrics > div {
+  min-width: 0;
+  padding: 14px;
+  border-radius: 12px;
+  background: var(--surface-subtle);
+}
+.nutrition-day-balance__value {
+  display: grid;
+  gap: 5px;
+}
+.nutrition-day-balance__value span,
+.nutrition-day-balance__value small {
+  color: var(--muted);
+  font-size: 0.76rem;
+}
+.nutrition-day-balance__value strong {
+  font-size: 1rem;
+  font-variant-numeric: tabular-nums;
+}
+.nutrition-food-card {
+  padding: 0;
+  overflow: hidden;
+}
+.nutrition-food-card__header {
+  padding: 17px;
+}
+.nutrition-food-card__copy {
+  min-height: 36px;
+  padding: 7px 9px;
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.76rem;
+}
+.nutrition-food-card__copy:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+.nutrition-food-card .nutrition-meals {
+  gap: 0;
+  padding: 0 17px 17px;
+}
+.nutrition-food-card .nutrition-meal {
+  border: 0;
+  border-top: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
 }
 .nutrition-meal {
   min-width: 0;
@@ -6911,8 +7009,7 @@ body:has(#appBottomNav) .toast:not(.hidden) {
   padding: 7px 11px;
   font-size: 0.8rem;
 }
-.nutrition-meal__actions,
-.nutrition-day-actions {
+.nutrition-meal__actions {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -6929,6 +7026,7 @@ body:has(#appBottomNav) .toast:not(.hidden) {
   border: 1px solid var(--border);
   border-radius: 16px;
   background: var(--surface-subtle);
+  box-shadow: var(--shadow-sm);
 }
 .nutrition-completeness__copy {
   display: flex;
@@ -6939,6 +7037,9 @@ body:has(#appBottomNav) .toast:not(.hidden) {
 .nutrition-completeness__copy h2 {
   margin-top: 3px;
   font-size: 1rem;
+}
+.nutrition-completeness__status {
+  font-size: 0.9rem;
 }
 .nutrition-completeness > p {
   color: var(--muted);
@@ -6963,22 +7064,16 @@ body:has(#appBottomNav) .toast:not(.hidden) {
   font-size: 0.78rem;
   text-decoration: underline;
 }
-.nutrition-meal__secondary-actions > button,
-.nutrition-day-actions > button {
+.nutrition-meal__secondary-actions > button {
   min-height: 36px;
   padding: 7px 9px;
   background: transparent;
   color: var(--muted);
   font-size: 0.76rem;
 }
-.nutrition-meal__secondary-actions > button:hover,
-.nutrition-day-actions > button:hover {
+.nutrition-meal__secondary-actions > button:hover {
   background: var(--surface-hover);
   color: var(--text);
-}
-.nutrition-day-actions {
-  justify-content: flex-end;
-  margin-top: -7px;
 }
 .nutrition-meal__empty {
   margin: 0 14px 14px;
@@ -7123,8 +7218,6 @@ body:has(#appBottomNav) .toast:not(.hidden) {
   grid-column: 1 / -1;
 }
 .nutrition-day-summary {
-  position: sticky;
-  top: 14px;
   display: grid;
   gap: 16px;
   min-width: 0;
@@ -7132,6 +7225,7 @@ body:has(#appBottomNav) .toast:not(.hidden) {
   border: 1px solid var(--accent-line);
   border-radius: 18px;
   background: linear-gradient(155deg, var(--accent-soft), transparent 42%), var(--surface);
+  box-shadow: var(--shadow-sm);
 }
 .nutrition-day-summary[data-motion-phase='update'],
 .nutrition-completeness[data-motion-phase='update'] {
@@ -7159,9 +7253,6 @@ body:has(#appBottomNav) .toast:not(.hidden) {
     opacity: 0.68;
     transform: translateY(4px);
   }
-}
-.nutrition-day-summary__head h2 {
-  font-size: 1.12rem;
 }
 .nutrition-targets,
 .nutrition-targets__macros {
@@ -7756,19 +7847,6 @@ html[data-yfc-keyboard='visible'] .nutrition-picker :is(input, select, textarea)
   line-height: 1.45;
 }
 
-@media (max-width: 820px) {
-  .nutrition-diary__layout {
-    grid-template-columns: 1fr;
-  }
-  .nutrition-day-summary {
-    position: static;
-    grid-row: 1;
-  }
-  .nutrition-meals {
-    grid-row: 2;
-  }
-}
-
 @media (max-width: 640px) {
   body:has(.modal) .toast:not(.hidden) {
     inset: max(10px, env(safe-area-inset-top, 0px)) max(10px, env(safe-area-inset-right, 0px)) auto
@@ -7780,6 +7858,10 @@ html[data-yfc-keyboard='visible'] .nutrition-picker :is(input, select, textarea)
     margin-inline: -2px;
     padding: 15px 12px;
     border-radius: 18px;
+  }
+  .nutrition-diary--design-v2 {
+    padding: 0;
+    border-radius: 0;
   }
   .nutrition-diary__intro {
     display: grid;
@@ -7801,6 +7883,27 @@ html[data-yfc-keyboard='visible'] .nutrition-picker :is(input, select, textarea)
     gap: 13px;
     padding: 14px;
     border-radius: 15px;
+  }
+  .nutrition-section-card {
+    padding: 14px;
+    border-radius: 15px;
+  }
+  .nutrition-food-card {
+    padding: 0;
+  }
+  .nutrition-food-card__header {
+    padding: 14px;
+  }
+  .nutrition-food-card .nutrition-meals {
+    padding: 0 14px 14px;
+  }
+  .nutrition-section-card__header {
+    display: grid;
+    gap: 6px;
+  }
+  .nutrition-section-card__header > p {
+    max-width: none;
+    text-align: left;
   }
   .nutrition-entry {
     grid-template-columns: minmax(0, 1fr) auto;
@@ -7893,6 +7996,12 @@ html[data-yfc-keyboard='visible'] .nutrition-picker :is(input, select, textarea)
     border-bottom: 0;
     border-left: 0;
     border-radius: 20px 20px 0 0;
+  }
+}
+
+@media (max-width: 520px) {
+  .nutrition-day-balance__metrics {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/frontend/tests/e2e/app.spec.ts
+++ b/frontend/tests/e2e/app.spec.ts
@@ -2544,7 +2544,9 @@ test('поля адаптируются к разным iPhone, а пример 
   );
 
   await openAppDestination(page, 'Питание');
-  await expect(page.getByRole('heading', { name: 'КБЖУ' })).toBeVisible();
+  await expect(
+    page.locator('.nutrition-day-summary').getByRole('heading', { name: 'КБЖУ' }),
+  ).toBeVisible();
   expect(
     await page.evaluate(() => ({
       viewport: document.documentElement.clientWidth,

--- a/frontend/tests/e2e/motion-pilot.spec.ts
+++ b/frontend/tests/e2e/motion-pilot.spec.ts
@@ -287,7 +287,7 @@ test('workout confirmation and Nutrition add keep final production state immedia
   await expect(
     page.getByRole('progressbar', { name: /Калории: 180 из 2.*100 ккал/ }),
   ).toBeVisible();
-  await expect(page.locator('.nutrition-day-summary')).toContainText('Итоги и цель');
+  await expect(page.locator('.nutrition-day-summary')).toContainText('КБЖУ');
   const toast = page.locator('.toast');
   await expect(toast).toHaveAttribute('data-motion-phase', /opening|open/);
   await expect(addedEntry).toHaveAttribute('data-motion-phase', 'idle', { timeout: 2_000 });

--- a/frontend/tests/e2e/nutrition-diary.spec.ts
+++ b/frontend/tests/e2e/nutrition-diary.spec.ts
@@ -209,6 +209,7 @@ const externalEggFoods = [
 async function mockNutritionApi(
   page: Page,
   hydrationState: 'data' | 'empty' | 'error' | 'loading' = 'data',
+  profileSex: 'female' | null = 'female',
 ) {
   let entries: FoodDiaryEntry[] = [yogurtEntry];
   let hydrationEntries: HydrationEntry[] =
@@ -273,7 +274,7 @@ async function mockNutritionApi(
           onboarding: { status: 'complete', required_fields: [], missing_fields: [] },
           profile: {
             full_name: 'Анна Петрова',
-            sex: 'female',
+            sex: profileSex,
             timezone: 'Europe/Moscow',
             goal: 'maintenance',
             kbju: null,
@@ -578,6 +579,88 @@ async function mockNutritionApi(
   });
 }
 
+test('Task 81A groups nutrition into five cards and keeps profile choices compact', async ({
+  page,
+}) => {
+  await page.clock.setFixedTime(new Date('2026-08-19T13:00:00+03:00'));
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await mockNutritionApi(page, 'data', null);
+  await page.goto('/app?section=nutrition&date=2026-08-19&hydration=quick');
+
+  const cardTitles = [
+    page.locator('.nutrition-completeness > .nutrition-completeness__copy h2'),
+    page.locator('.nutrition-day-balance h2'),
+    page.locator('.nutrition-food-card__header h2'),
+    page.locator('.nutrition-day-summary h2'),
+    page.locator('.hydration-card h2'),
+  ];
+  const titlePositions: number[] = [];
+  for (const heading of cardTitles) {
+    await expect(heading).toBeVisible();
+    titlePositions.push((await heading.boundingBox())?.y ?? 0);
+  }
+  expect(titlePositions).toEqual([...titlePositions].sort((left, right) => left - right));
+  const balance = page.locator('.nutrition-day-balance');
+  await expect(balance.getByRole('progressbar', { name: /Еда:/ })).toBeVisible();
+  await expect(balance.getByRole('progressbar', { name: /Жидкость:/ })).toBeVisible();
+  const foodCard = page.locator('.nutrition-food-card');
+  const firstMeal = foodCard.locator('.nutrition-meal').first();
+  const [foodCardBox, firstMealBox] = await Promise.all([
+    foodCard.boundingBox(),
+    firstMeal.boundingBox(),
+  ]);
+  expect(firstMealBox!.x - foodCardBox!.x).toBeGreaterThanOrEqual(14);
+  expect(
+    foodCardBox!.x + foodCardBox!.width - firstMealBox!.x - firstMealBox!.width,
+  ).toBeGreaterThanOrEqual(14);
+  await expect(page.getByRole('heading', { name: 'Мои кружки и бутылки' })).toBeVisible();
+  await page.screenshot({
+    fullPage: true,
+    path: '../.artifacts/screenshots/task-81A/desktop-light-five-cards.png',
+  });
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.evaluate(() => window.scrollTo(0, 0));
+  expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(390);
+  const mobileCards = [
+    page.getByRole('navigation', { name: 'Неделя дневника' }),
+    page.locator('.nutrition-completeness'),
+    page.locator('.nutrition-day-balance'),
+    page.locator('.nutrition-food-card'),
+    page.locator('.nutrition-day-summary'),
+    page.locator('.hydration-card'),
+  ];
+  const mobileCardPositions: number[] = [];
+  for (const card of mobileCards) {
+    await expect(card).toBeVisible();
+    mobileCardPositions.push((await card.boundingBox())?.y ?? 0);
+  }
+  expect(mobileCardPositions).toEqual([...mobileCardPositions].sort((left, right) => left - right));
+  const [mobileFoodCardBox, mobileFirstMealBox] = await Promise.all([
+    foodCard.boundingBox(),
+    firstMeal.boundingBox(),
+  ]);
+  expect(mobileFirstMealBox!.x - mobileFoodCardBox!.x).toBeGreaterThanOrEqual(12);
+  expect(
+    mobileFoodCardBox!.x +
+      mobileFoodCardBox!.width -
+      mobileFirstMealBox!.x -
+      mobileFirstMealBox!.width,
+  ).toBeGreaterThanOrEqual(12);
+  const saveSex = page.getByText('Сохранить выбранный пол в профиле', { exact: true });
+  await expect(saveSex).toBeVisible();
+  expect(await saveSex.evaluate((element) => getComputedStyle(element).whiteSpace)).toBe('nowrap');
+  expect((await saveSex.boundingBox())?.height).toBeLessThanOrEqual(24);
+  await page.locator('.nutrition-diary').screenshot({
+    path: '../.artifacts/screenshots/task-81A/mobile-light-ordered-cards-round-2.png',
+  });
+  const hydration = page.getByRole('region', { name: 'Гидратация' });
+  await hydration.scrollIntoViewIfNeeded();
+  await hydration.screenshot({
+    path: '../.artifacts/screenshots/task-81A/mobile-light-expanded-profile-and-containers.png',
+  });
+});
+
 test('hydration visual evidence: mobile web compact and quick add', async ({ page }) => {
   await page.clock.setFixedTime(new Date('2026-08-19T13:00:00+03:00'));
   await page.setViewportSize({ width: 390, height: 844 });
@@ -781,7 +864,9 @@ test('nutrition diary is responsive, keyboard-safe and supports local quick add'
 
   await expect(page.getByRole('heading', { name: 'Питание', exact: true })).toBeVisible();
   await expect(page.getByText('Греческий йогурт')).toBeVisible();
-  await expect(page.getByRole('heading', { name: 'КБЖУ' })).toBeVisible();
+  await expect(
+    page.locator('.nutrition-day-summary').getByRole('heading', { name: 'КБЖУ' }),
+  ).toBeVisible();
   await expect(page.getByText('Немного выше ориентира: 20 ккал')).toBeVisible();
   await expect(page.locator('.nutrition-target').first()).not.toHaveClass(/is-over/);
   for (const viewport of [
@@ -802,17 +887,17 @@ test('nutrition diary is responsive, keyboard-safe and supports local quick add'
     expect((await selectedDay.boundingBox())?.height).toBeGreaterThanOrEqual(44);
     const borderTop = await week.evaluate((element) => getComputedStyle(element).borderTopWidth);
     expect(borderTop).toBe(viewport.width <= 640 ? '0px' : '1px');
-    const status = page.locator('.nutrition-diary__status');
-    const targetBadge = status.getByText('Цель КБЖУ настроена', { exact: true });
-    const [weekBox, statusBox, targetBadgeBox] = await Promise.all([
+    const summary = page.locator('.nutrition-day-summary');
+    const targetBadge = summary.getByText('Цель КБЖУ настроена', { exact: true });
+    const [weekBox, summaryBox, targetBadgeBox] = await Promise.all([
       week.boundingBox(),
-      status.boundingBox(),
+      summary.boundingBox(),
       targetBadge.boundingBox(),
     ]);
     expect(weekBox).not.toBeNull();
-    expect(statusBox).not.toBeNull();
+    expect(summaryBox).not.toBeNull();
     expect(targetBadgeBox).not.toBeNull();
-    expect(statusBox!.y).toBeGreaterThanOrEqual(weekBox!.y + weekBox!.height);
+    expect(summaryBox!.y).toBeGreaterThanOrEqual(weekBox!.y + weekBox!.height);
     expect(targetBadgeBox!.y).toBeGreaterThanOrEqual(weekBox!.y + weekBox!.height);
   }
 

--- a/frontend/tests/e2e/semantic-card-visual-system.spec.ts
+++ b/frontend/tests/e2e/semantic-card-visual-system.spec.ts
@@ -136,13 +136,13 @@ test('hover and focus use the restrained brand and neutral palette', async ({ br
   await context.close();
 });
 
-test('shared card effects preserve sticky summaries and viewport modals', async ({ browser }) => {
+test('shared card effects preserve summary flow and viewport modals', async ({ browser }) => {
   const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
   const page = await context.newPage();
   await openSurface(page, '/app?section=nutrition', 'light');
   await waitForSemanticSurface(page, '/app?section=nutrition');
 
-  await expect(page.locator('.nutrition-day-summary')).toHaveCSS('position', 'sticky');
+  await expect(page.locator('.nutrition-day-summary')).toHaveCSS('position', 'static');
 
   await page.goto('/app?section=profile');
   await expect(page.getByRole('heading', { name: 'Профиль и настройки' })).toBeVisible();

--- a/frontend/tests/e2e/tma-smoke.spec.ts
+++ b/frontend/tests/e2e/tma-smoke.spec.ts
@@ -2191,7 +2191,10 @@ test('manual nutrition targets validate, preserve keyboard flow and expose effec
   ]);
 
   for (const currentPage of [tmaPage, mobilePage]) {
-    await currentPage.getByRole('heading', { name: 'КБЖУ', exact: true }).click();
+    await currentPage
+      .locator('#nutrition-target-settings')
+      .getByRole('heading', { name: 'КБЖУ', exact: true })
+      .click();
     if (currentPage === mobilePage) {
       await expect(currentPage.getByText('Назначено тренером', { exact: true })).toBeVisible();
       await expect(
@@ -2272,7 +2275,10 @@ test('manual nutrition targets validate, preserve keyboard flow and expose effec
 
   const targetCard = tmaPage.locator('#nutrition-target-settings > details');
   if ((await targetCard.getAttribute('open')) === null) {
-    await tmaPage.getByRole('heading', { name: 'КБЖУ', exact: true }).click();
+    await tmaPage
+      .locator('#nutrition-target-settings')
+      .getByRole('heading', { name: 'КБЖУ', exact: true })
+      .click();
   }
   for (const viewport of Object.values(MOBILE_CONTEXTS)) {
     await tmaPage.setViewportSize(viewport);
@@ -2316,7 +2322,10 @@ test('manual nutrition target history screenshots cover all responsive surfaces 
     }
 
     await page.goto('/app?section=nutrition');
-    await page.getByRole('heading', { name: 'КБЖУ', exact: true }).click();
+    await page
+      .locator('#nutrition-target-settings')
+      .getByRole('heading', { name: 'КБЖУ', exact: true })
+      .click();
     if (current.surface === 'tma-mock') {
       await expect(page.getByText('Назначено тренером', { exact: true })).toBeVisible();
       await page.getByRole('button', { name: 'Указать вручную' }).click();
@@ -2412,7 +2421,10 @@ test('contextual help covers workout, nutrition and Progress without a TMA libra
   await expect(rirDetails).not.toHaveAttribute('open', '');
 
   await tmaPage.getByRole('link', { name: 'Питание', exact: true }).click();
-  await tmaPage.getByRole('heading', { name: 'КБЖУ', exact: true }).click();
+  await tmaPage
+    .locator('#nutrition-target-settings')
+    .getByRole('heading', { name: 'КБЖУ', exact: true })
+    .click();
   await tmaPage.getByRole('button', { name: 'Рассчитать ориентиры' }).click();
   const nutritionHelp = tmaPage.locator('.contextual-help').getByText('Что это?', { exact: true });
   await nutritionHelp.click();

--- a/frontend/tests/unit/features/nutrition/HydrationTracker.test.tsx
+++ b/frontend/tests/unit/features/nutrition/HydrationTracker.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { HydrationTracker } from '../../../../src/features/nutrition/HydrationTracker';
@@ -77,7 +77,7 @@ describe('HydrationTracker', () => {
 
   it('shows a compact factual summary and quick presets', async () => {
     renderTracker();
-    expect(await screen.findByRole('heading', { name: 'Гидратация' })).toBeVisible();
+    expect(await screen.findByRole('heading', { name: 'Напитки' })).toBeVisible();
     expect(screen.getByText('850 из 2200 мл')).toBeVisible();
     expect(screen.getByRole('progressbar', { name: 'Прогресс гидратации' })).toHaveAttribute(
       'aria-valuetext',
@@ -154,5 +154,10 @@ describe('HydrationTracker', () => {
     expect(screen.getByRole('radio', { name: 'По справочному ориентиру' })).toBeChecked();
     expect(screen.getByLabelText('Пол для справочного ориентира')).toHaveValue('male');
     expect(screen.getByLabelText('Мне 18 лет или больше')).toBeChecked();
+    expect(screen.getByLabelText('Сохранить выбранный пол в профиле')).toBeVisible();
+    const presets = screen
+      .getByRole('heading', { name: 'Мои кружки и бутылки' })
+      .closest('section') as HTMLElement;
+    expect(within(presets).getByRole('button', { name: 'Добавить' })).toBeVisible();
   });
 });

--- a/frontend/tests/unit/features/nutrition/NutritionDiary.test.tsx
+++ b/frontend/tests/unit/features/nutrition/NutritionDiary.test.tsx
@@ -17,7 +17,10 @@ vi.mock('../../../../src/shared/api/client', () => ({ api: apiMock }));
 vi.mock('../../../../src/app/AuthProvider', () => ({ useAuth: useAuthMock }));
 vi.mock('../../../../src/features/nutrition/HydrationTracker', () => ({
   HydrationTracker: ({ diaryDate }: { diaryDate: string }) => (
-    <section aria-label="Гидратация">Гидратация за {diaryDate}</section>
+    <section aria-label="Гидратация">
+      <h2>Напитки</h2>
+      Гидратация за {diaryDate}
+    </section>
   ),
 }));
 
@@ -143,7 +146,26 @@ describe('NutritionDiary', () => {
     expect(await screen.findByText('Овсяная каша')).toBeInTheDocument();
     expect(
       screen.getAllByRole('heading', { level: 2 }).map((heading) => heading.textContent),
-    ).toEqual(expect.arrayContaining(['Завтрак', 'Обед', 'Ужин', 'Перекусы', 'Итоги и цель']));
+    ).toEqual(
+      expect.arrayContaining([
+        'Полнота данных',
+        'Баланс дня',
+        'Еда',
+        'Завтрак',
+        'Обед',
+        'Ужин',
+        'Перекусы',
+        'КБЖУ',
+        'Напитки',
+      ]),
+    );
+    const sectionOrder = screen
+      .getAllByRole('heading', { level: 2 })
+      .map((heading) => heading.textContent)
+      .filter((heading) =>
+        ['Полнота данных', 'Баланс дня', 'Еда', 'КБЖУ', 'Напитки'].includes(heading ?? ''),
+      );
+    expect(sectionOrder).toEqual(['Полнота данных', 'Баланс дня', 'Еда', 'КБЖУ', 'Напитки']);
     expect(screen.getByRole('progressbar', { name: /Калории: 420 из 2.+000 ккал/ })).toBeVisible();
     expect(screen.getByText('Б 18,5')).toBeVisible();
 
@@ -210,7 +232,7 @@ describe('NutritionDiary', () => {
     });
     renderDiary();
 
-    expect(await screen.findByRole('heading', { name: 'День без приёмов пищи' })).toBeVisible();
+    expect(await screen.findByText('День без приёмов пищи', { selector: 'strong' })).toBeVisible();
     expect(screen.getByText(/только если сознательно не ели весь день/i)).toBeVisible();
     expect(screen.queryByText(/пост/i)).not.toBeInTheDocument();
   });
@@ -379,7 +401,7 @@ describe('NutritionDiary', () => {
       throw new Error(`Unexpected API call: ${path}`);
     });
     renderDiary();
-    expect(await screen.findByRole('heading', { name: 'Заполнен частично' })).toBeVisible();
+    expect(await screen.findByText('Заполнен частично', { selector: 'strong' })).toBeVisible();
 
     fireEvent.click(screen.getByRole('button', { name: 'День заполнен' }));
 
@@ -407,7 +429,7 @@ describe('NutritionDiary', () => {
     });
 
     renderDiary();
-    expect(await screen.findByRole('heading', { name: 'Заполнен частично' })).toBeVisible();
+    expect(await screen.findByText('Заполнен частично', { selector: 'strong' })).toBeVisible();
     fireEvent.click(screen.getByRole('button', { name: 'Заполнен частично' }));
 
     await waitFor(() =>


### PR DESCRIPTION
## Что изменено
- выстроены карточки питания в порядке: статус, баланс, еда, КБЖУ, напитки
- баланс дня объединяет прогресс еды и жидкости без смешивания единиц
- уплотнён блок личного ориентира, обновлена терминология кружек и бутылок
- сохранён одинаковый порядок карточек на desktop и mobile, добавлены боковые отступы в дневнике еды

## Проверки
- unit: 26 passed
- affected Playwright: 17 passed
- TypeScript typecheck, ESLint, Prettier, production build: passed
- representative screenshots показаны владельцу; получен явный visual approval

No backend/API/schema/migration/config changes.