### PR TITLE
[Recovery approved] Align production GHCR image repositories

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,8 +65,8 @@ jobs:
       PROD_URL: https://app.your-fitness-coach.ru
       PROD_PUBLIC_URL: https://your-fitness-coach.ru
       PROD_ROLLOUT_MODE: single-slot
-      GHCR_BACKEND_IMAGE: ghcr.io/mikemoore1337/fit-mini-app-backend
-      GHCR_BOT_IMAGE: ghcr.io/mikemoore1337/fit-mini-app-bot
+      GHCR_BACKEND_IMAGE: ghcr.io/mikemoore1337/your-fitness-coach-backend
+      GHCR_BOT_IMAGE: ghcr.io/mikemoore1337/your-fitness-coach-bot
 
     steps:
       - name: Configure production SSH access

--- a/tests/test_release_safeguards.py
+++ b/tests/test_release_safeguards.py
@@ -17,6 +17,8 @@ def test_automated_deploy_keeps_revision_provenance_and_stale_run_guards() -> No
     deploy_script = (root / "scripts" / "deploy_production.sh").read_text(encoding="utf-8")
 
     assert "org.opencontainers.image.revision=${{ github.sha }}" in ci_workflow
+    assert "GHCR_BACKEND_IMAGE: ghcr.io/mikemoore1337/your-fitness-coach-backend" in deploy_workflow
+    assert "GHCR_BOT_IMAGE: ghcr.io/mikemoore1337/your-fitness-coach-bot" in deploy_workflow
     assert "workflow_dispatch:" not in deploy_workflow
     assert "pull-requests: read" in deploy_workflow
     assert '"repos/$REPOSITORY/commits/$DEPLOY_SHA/pulls"' in deploy_workflow


### PR DESCRIPTION
## Recovery

Align production deploy image references with the repositories published by the current repository CI workflow.

- deploy now pulls ghcr.io/mikemoore1337/your-fitness-coach-backend and ghcr.io/mikemoore1337/your-fitness-coach-bot
- add release-safeguard assertions to prevent namespace drift
- no application code or production data changes

This is an owner-approved infrastructure recovery after Release production run 33641487733 stopped on manifest unknown before service rollout.