### PR TITLE
[Task 111] feat(progress): add bento overview and flexible periods

### DIFF
--- a/backend/fitminiapp_api/api/v1/coach.py
+++ b/backend/fitminiapp_api/api/v1/coach.py
@@ -48,7 +48,7 @@ from fitminiapp_api.schemas.workout import (
     WorkoutTimelineItem,
 )
 from fitminiapp_api.services.analytics import (
-    build_training_analytics,
+    build_training_analytics_for_range,
     build_user_progress,
     build_workout_timeline,
 )
@@ -75,6 +75,7 @@ from fitminiapp_api.services.nutrition_reports import (
     build_nutrition_report,
     nutrition_report_csv,
 )
+from fitminiapp_api.services.period_bounds import PeriodBoundsError, resolve_progress_bounds
 from fitminiapp_api.services.profile import ProfileError, update_profile
 from fitminiapp_api.services.program_common import ProgramError, assignment_error_status
 from fitminiapp_api.services.program_versioning import upsert_future_program_exercise
@@ -85,7 +86,7 @@ from fitminiapp_api.services.programs import (
     list_coach_assigned_programs,
 )
 from fitminiapp_api.services.progress import (
-    build_progress_summary,
+    build_progress_summary_for_range,
     build_trainer_client_summaries,
 )
 from fitminiapp_api.services.progress_report_downloads import create_progress_report_download_token
@@ -237,12 +238,23 @@ def coach_client_analytics(
 )
 def coach_client_progress_summary(
     client_id: int,
-    period_days: ProgressPeriodDays = ProgressPeriodDays.DAYS_30,
+    period_days: ProgressPeriodDays | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
     current_user: User = Depends(require_coach),
     db: Session = Depends(get_db),
 ):
     client = _managed_client(db, current_user, client_id)
-    return build_progress_summary(db, client, period_days)
+    try:
+        bounds = resolve_progress_bounds(
+            client,
+            period_days,
+            date_from=date_from,
+            date_to=date_to,
+        )
+        return build_progress_summary_for_range(db, client, bounds.start, bounds.end)
+    except PeriodBoundsError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc))
 
 
 def _client_nutrition_report_or_422(
@@ -386,18 +398,30 @@ def coach_client_weekly_check_ins(
 )
 def coach_client_training_analytics(
     client_id: int,
-    period_days: ProgressPeriodDays = ProgressPeriodDays.DAYS_30,
+    period_days: ProgressPeriodDays | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
     exercise_history_limit: int = Query(default=20, ge=1, le=100),
     current_user: User = Depends(require_coach),
     db: Session = Depends(get_db),
 ):
     client = _managed_client(db, current_user, client_id)
-    return build_training_analytics(
-        db,
-        client,
-        period_days,
-        exercise_history_limit=exercise_history_limit,
-    )
+    try:
+        bounds = resolve_progress_bounds(
+            client,
+            period_days,
+            date_from=date_from,
+            date_to=date_to,
+        )
+        return build_training_analytics_for_range(
+            db,
+            client,
+            bounds.start,
+            bounds.end,
+            exercise_history_limit=exercise_history_limit,
+        )
+    except PeriodBoundsError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc))
 
 
 @router.get(
@@ -405,19 +429,26 @@ def coach_client_training_analytics(
     response_model=TrainerClientProgressListResponse,
 )
 def coach_client_progress_summaries(
-    period_days: ProgressPeriodDays = ProgressPeriodDays.DAYS_30,
+    period_days: ProgressPeriodDays | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0, le=10_000),
     current_user: User = Depends(require_coach),
     db: Session = Depends(get_db),
 ):
-    return build_trainer_client_summaries(
-        db,
-        current_user,
-        period_days,
-        limit=limit,
-        offset=offset,
-    )
+    try:
+        return build_trainer_client_summaries(
+            db,
+            current_user,
+            period_days,
+            limit=limit,
+            offset=offset,
+            date_from=date_from,
+            date_to=date_to,
+        )
+    except PeriodBoundsError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc))
 
 
 @router.get(

--- a/backend/fitminiapp_api/api/v1/workouts.py
+++ b/backend/fitminiapp_api/api/v1/workouts.py
@@ -54,7 +54,10 @@ from fitminiapp_api.schemas.workout import (
     WorkoutStatusResponse,
     WorkoutTodayResponse,
 )
-from fitminiapp_api.services.analytics import build_training_analytics, build_user_progress
+from fitminiapp_api.services.analytics import (
+    build_training_analytics_for_range,
+    build_user_progress,
+)
 from fitminiapp_api.services.cardio import (
     CardioSessionError,
     complete_cardio_session,
@@ -81,8 +84,11 @@ from fitminiapp_api.services.nutrition_reports import (
     build_nutrition_report,
     nutrition_report_csv,
 )
+from fitminiapp_api.services.period_bounds import PeriodBoundsError, resolve_progress_bounds
 from fitminiapp_api.services.program_common import ProgramError
-from fitminiapp_api.services.progress import build_progress_summary
+from fitminiapp_api.services.progress import (
+    build_progress_summary_for_range,
+)
 from fitminiapp_api.services.progress_report_downloads import (
     create_progress_report_download_token,
     read_progress_report_download_token,
@@ -595,11 +601,22 @@ def workout_progress(
 
 @router.get("/progress/summary", response_model=ProgressSummaryResponse)
 def workout_progress_summary(
-    period_days: ProgressPeriodDays = ProgressPeriodDays.DAYS_30,
+    period_days: ProgressPeriodDays | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
     current_user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
-    return build_progress_summary(db, current_user, period_days)
+    try:
+        bounds = resolve_progress_bounds(
+            current_user,
+            period_days,
+            date_from=date_from,
+            date_to=date_to,
+        )
+        return build_progress_summary_for_range(db, current_user, bounds.start, bounds.end)
+    except PeriodBoundsError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc))
 
 
 def _nutrition_report_or_422(
@@ -769,17 +786,29 @@ def workout_nutrition_report_export(
 
 @router.get("/progress/training-analytics", response_model=TrainingAnalyticsResponse)
 def workout_training_analytics(
-    period_days: ProgressPeriodDays = ProgressPeriodDays.DAYS_30,
+    period_days: ProgressPeriodDays | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
     exercise_history_limit: int = Query(default=20, ge=1, le=100),
     current_user: User = Depends(require_user),
     db: Session = Depends(get_db),
 ):
-    return build_training_analytics(
-        db,
-        current_user,
-        period_days,
-        exercise_history_limit=exercise_history_limit,
-    )
+    try:
+        bounds = resolve_progress_bounds(
+            current_user,
+            period_days,
+            date_from=date_from,
+            date_to=date_to,
+        )
+        return build_training_analytics_for_range(
+            db,
+            current_user,
+            bounds.start,
+            bounds.end,
+            exercise_history_limit=exercise_history_limit,
+        )
+    except PeriodBoundsError as exc:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(exc))
 
 
 @router.delete("/today", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/fitminiapp_api/schemas/progress.py
+++ b/backend/fitminiapp_api/schemas/progress.py
@@ -10,15 +10,19 @@ from fitminiapp_api.schemas.user import BodyPriorityPreference
 
 
 class ProgressPeriodDays(IntEnum):
+    DAYS_1 = 1
     DAYS_7 = 7
     DAYS_30 = 30
     DAYS_90 = 90
+    DAYS_365 = 365
 
 
 class NutritionReportPeriod(StrEnum):
+    DAYS_1 = "days_1"
     DAYS_7 = "days_7"
     DAYS_30 = "days_30"
     DAYS_90 = "days_90"
+    DAYS_365 = "days_365"
     CURRENT_WEEK = "current_week"
     CURRENT_MONTH = "current_month"
     PREVIOUS_MONTH = "previous_month"
@@ -234,7 +238,7 @@ class BodyPeriodSummary(BaseModel):
 
 class ProgressSummaryResponse(BaseModel):
     user_id: int
-    period_days: ProgressPeriodDays
+    period_days: int = Field(ge=1, le=366)
     period_start: date
     period_end: date
     training: TrainingPeriodSummary

--- a/backend/fitminiapp_api/services/analytics.py
+++ b/backend/fitminiapp_api/services/analytics.py
@@ -26,6 +26,7 @@ from fitminiapp_api.services.data_quality import (
     collect_training_data_counts,
 )
 from fitminiapp_api.services.exercise_catalog import get_visible_exercise_display_map
+from fitminiapp_api.services.period_bounds import MAX_REPORT_DAYS, resolve_progress_bounds
 from fitminiapp_api.services.workouts import (
     counts_toward_working_volume,
     working_volume_set_filter,
@@ -413,15 +414,12 @@ def build_training_analytics(
     *,
     exercise_history_limit: int,
 ) -> dict:
-    if period_days not in {7, 30, 90}:
-        raise ValueError("period_days must be 7, 30, or 90")
-    period_end = today_for_user(user)
-    period_start = period_end - timedelta(days=period_days - 1)
+    bounds = resolve_progress_bounds(user, period_days)
     return _build_training_analytics(
         db,
         user,
-        period_start,
-        period_end,
+        bounds.start,
+        bounds.end,
         exercise_history_limit=exercise_history_limit,
     )
 
@@ -436,6 +434,8 @@ def build_training_analytics_for_range(
 ) -> dict:
     if period_end < period_start:
         raise ValueError("period_end must not be before period_start")
+    if (period_end - period_start).days + 1 > MAX_REPORT_DAYS:
+        raise ValueError(f"period cannot exceed {MAX_REPORT_DAYS} days")
     return _build_training_analytics(
         db,
         user,

--- a/backend/fitminiapp_api/services/nutrition_reports.py
+++ b/backend/fitminiapp_api/services/nutrition_reports.py
@@ -15,21 +15,16 @@ from fitminiapp_api.models.hydration import HydrationEntry, HydrationGoal
 from fitminiapp_api.models.nutrition import NutritionTarget
 from fitminiapp_api.models.user import User
 from fitminiapp_api.schemas.progress import NutritionReportPeriod
+from fitminiapp_api.services.period_bounds import (
+    PeriodBoundsError,
+    ReportBounds,
+    resolve_report_bounds,
+)
 from fitminiapp_api.services.progress import is_calorie_target_met, is_protein_target_met
 
-MAX_REPORT_DAYS = 366
 METRICS = ("calories", "protein_g", "fat_g", "carbs_g")
 
-
-class NutritionReportError(ValueError):
-    pass
-
-
-@dataclass(frozen=True)
-class ReportBounds:
-    period: NutritionReportPeriod
-    start: date
-    end: date
+NutritionReportError = PeriodBoundsError
 
 
 @dataclass(frozen=True)
@@ -40,47 +35,6 @@ class AggregatedDiaryDay:
     fat_g: Decimal | None
     carbs_g: Decimal | None
     has_entries: bool
-
-
-def resolve_report_bounds(
-    user: User,
-    period: NutritionReportPeriod,
-    *,
-    date_from: date | None = None,
-    date_to: date | None = None,
-) -> ReportBounds:
-    today = today_for_user(user)
-    if period == NutritionReportPeriod.CUSTOM:
-        if date_from is None or date_to is None:
-            raise NutritionReportError("Для произвольного периода укажите обе даты")
-        start, end = date_from, date_to
-    else:
-        if date_from is not None or date_to is not None:
-            raise NutritionReportError("Даты можно передавать только для произвольного периода")
-        if period == NutritionReportPeriod.DAYS_7:
-            start, end = today - timedelta(days=6), today
-        elif period == NutritionReportPeriod.DAYS_30:
-            start, end = today - timedelta(days=29), today
-        elif period == NutritionReportPeriod.DAYS_90:
-            start, end = today - timedelta(days=89), today
-        elif period == NutritionReportPeriod.CURRENT_WEEK:
-            start, end = today - timedelta(days=today.weekday()), today
-        elif period == NutritionReportPeriod.CURRENT_MONTH:
-            start, end = today.replace(day=1), today
-        elif period == NutritionReportPeriod.PREVIOUS_MONTH:
-            previous_end = today.replace(day=1) - timedelta(days=1)
-            start = previous_end.replace(day=1)
-            end = previous_end
-        else:  # pragma: no cover - enum validation owns this boundary
-            raise NutritionReportError("Неизвестный период отчёта")
-
-    if end < start:
-        raise NutritionReportError("Дата окончания не может быть раньше даты начала")
-    if end > today:
-        raise NutritionReportError("Отчёт нельзя построить за будущие даты")
-    if (end - start).days + 1 > MAX_REPORT_DAYS:
-        raise NutritionReportError(f"Период отчёта не может превышать {MAX_REPORT_DAYS} дней")
-    return ReportBounds(period=period, start=start, end=end)
 
 
 def _entry_value(quick_column, regular_column):

--- a/backend/fitminiapp_api/services/period_bounds.py
+++ b/backend/fitminiapp_api/services/period_bounds.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+from fitminiapp_api.core.timezone import today_for_user
+from fitminiapp_api.models.user import User
+from fitminiapp_api.schemas.progress import NutritionReportPeriod, ProgressPeriodDays
+
+MAX_REPORT_DAYS = 366
+
+
+class PeriodBoundsError(ValueError):
+    """Raised when a requested reporting period cannot be evaluated safely."""
+
+
+@dataclass(frozen=True)
+class ReportBounds:
+    period: NutritionReportPeriod
+    start: date
+    end: date
+
+
+def resolve_report_bounds(
+    user: User,
+    period: NutritionReportPeriod,
+    *,
+    date_from: date | None = None,
+    date_to: date | None = None,
+) -> ReportBounds:
+    """Resolve one timezone-aware, inclusive date range for every progress consumer."""
+    today = today_for_user(user)
+    period = NutritionReportPeriod(period)
+
+    if period == NutritionReportPeriod.CUSTOM:
+        if date_from is None or date_to is None:
+            raise PeriodBoundsError("Для произвольного периода укажите обе даты")
+        start, end = date_from, date_to
+    else:
+        if date_from is not None or date_to is not None:
+            raise PeriodBoundsError("Даты можно передавать только для произвольного периода")
+        if period == NutritionReportPeriod.DAYS_1:
+            start, end = today, today
+        elif period == NutritionReportPeriod.DAYS_7:
+            start, end = today - timedelta(days=6), today
+        elif period == NutritionReportPeriod.DAYS_30:
+            start, end = today - timedelta(days=29), today
+        elif period == NutritionReportPeriod.DAYS_90:
+            start, end = today - timedelta(days=89), today
+        elif period == NutritionReportPeriod.DAYS_365:
+            start, end = today - timedelta(days=364), today
+        elif period == NutritionReportPeriod.CURRENT_WEEK:
+            start, end = today - timedelta(days=today.weekday()), today
+        elif period == NutritionReportPeriod.CURRENT_MONTH:
+            start, end = today.replace(day=1), today
+        elif period == NutritionReportPeriod.PREVIOUS_MONTH:
+            previous_end = today.replace(day=1) - timedelta(days=1)
+            start = previous_end.replace(day=1)
+            end = previous_end
+        else:  # pragma: no cover - enum validation owns this boundary
+            raise PeriodBoundsError("Неизвестный период отчёта")
+
+    if end < start:
+        raise PeriodBoundsError("Дата окончания не может быть раньше даты начала")
+    if end > today:
+        raise PeriodBoundsError("Отчёт нельзя построить за будущие даты")
+    if (end - start).days + 1 > MAX_REPORT_DAYS:
+        raise PeriodBoundsError(f"Период отчёта не может превышать {MAX_REPORT_DAYS} дней")
+    return ReportBounds(period=period, start=start, end=end)
+
+
+def progress_period_for_days(period_days: int) -> NutritionReportPeriod:
+    try:
+        progress_period = ProgressPeriodDays(period_days)
+    except ValueError as exc:
+        raise PeriodBoundsError("Период должен быть 1, 7, 30, 90 или 365 дней") from exc
+    return {
+        ProgressPeriodDays.DAYS_1: NutritionReportPeriod.DAYS_1,
+        ProgressPeriodDays.DAYS_7: NutritionReportPeriod.DAYS_7,
+        ProgressPeriodDays.DAYS_30: NutritionReportPeriod.DAYS_30,
+        ProgressPeriodDays.DAYS_90: NutritionReportPeriod.DAYS_90,
+        ProgressPeriodDays.DAYS_365: NutritionReportPeriod.DAYS_365,
+    }[progress_period]
+
+
+def resolve_progress_bounds(
+    user: User,
+    period_days: int | None = None,
+    *,
+    date_from: date | None = None,
+    date_to: date | None = None,
+) -> ReportBounds:
+    if date_from is not None or date_to is not None:
+        if period_days is not None:
+            raise PeriodBoundsError(
+                "Нельзя одновременно передавать количество дней и произвольные даты"
+            )
+        return resolve_report_bounds(
+            user,
+            NutritionReportPeriod.CUSTOM,
+            date_from=date_from,
+            date_to=date_to,
+        )
+    return resolve_report_bounds(
+        user,
+        progress_period_for_days(30 if period_days is None else int(period_days)),
+    )

--- a/backend/fitminiapp_api/services/progress.py
+++ b/backend/fitminiapp_api/services/progress.py
@@ -41,6 +41,10 @@ from fitminiapp_api.services.data_quality import (
     build_training_data_sufficiency,
     collect_training_data_counts,
 )
+from fitminiapp_api.services.period_bounds import (
+    MAX_REPORT_DAYS,
+    resolve_progress_bounds,
+)
 from fitminiapp_api.services.profile import serialize_body_priority
 from fitminiapp_api.services.workouts import working_volume_set_filter
 
@@ -250,18 +254,51 @@ def _active_clients(
 def build_trainer_client_summaries(
     db: Session,
     coach: User,
-    period_days: int,
+    period_days: int | None = None,
     *,
     limit: int,
     offset: int,
+    date_from: date | None = None,
+    date_to: date | None = None,
 ) -> dict:
     client_rows, total = _active_clients(db, coach, limit=limit, offset=offset)
     clients = [client for client, _private_name in client_rows]
+    period_bounds = None
+    effective_period_days = 30 if period_days is None else int(period_days)
+    if date_from is not None or date_to is not None:
+        if period_days is not None:
+            resolve_progress_bounds(
+                coach,
+                period_days,
+                date_from=date_from,
+                date_to=date_to,
+            )
+        period_bounds = {
+            client.id: (
+                bounds.start,
+                bounds.end,
+            )
+            for client in clients
+            for bounds in [
+                resolve_progress_bounds(
+                    client,
+                    date_from=date_from,
+                    date_to=date_to,
+                )
+            ]
+        }
+        if period_bounds:
+            first_start, first_end = next(iter(period_bounds.values()))
+            effective_period_days = (first_end - first_start).days + 1
+        else:
+            bounds = resolve_progress_bounds(coach, date_from=date_from, date_to=date_to)
+            effective_period_days = (bounds.end - bounds.start).days + 1
     summaries = build_progress_summaries(
         db,
         clients,
-        period_days,
+        effective_period_days,
         nutrition_visible_user_ids={client.id for client in clients},
+        period_bounds=period_bounds,
     )
     names = {
         client.id: private_name or (client.profile.full_name if client.profile else None)
@@ -278,11 +315,13 @@ def build_trainer_client_summaries(
 
 
 def build_progress_summary(db: Session, user: User, period_days: int) -> dict:
+    bounds = resolve_progress_bounds(user, period_days)
     return build_progress_summaries(
         db,
         [user],
-        period_days,
+        (bounds.end - bounds.start).days + 1,
         nutrition_visible_user_ids={user.id},
+        period_bounds={user.id: (bounds.start, bounds.end)},
     )[0]
 
 
@@ -294,10 +333,13 @@ def build_progress_summary_for_range(
 ) -> dict:
     if period_end < period_start:
         raise ValueError("period_end must not be before period_start")
+    period_days = (period_end - period_start).days + 1
+    if period_days > MAX_REPORT_DAYS:
+        raise ValueError(f"period cannot exceed {MAX_REPORT_DAYS} days")
     return build_progress_summaries(
         db,
         [user],
-        (period_end - period_start).days + 1,
+        period_days,
         nutrition_visible_user_ids={user.id},
         period_bounds={user.id: (period_start, period_end)},
     )[0]
@@ -311,8 +353,10 @@ def build_progress_summaries(
     nutrition_visible_user_ids: set[int],
     period_bounds: dict[int, tuple[date, date]] | None = None,
 ) -> list[dict]:
-    if period_bounds is None and period_days not in {7, 30, 90}:
-        raise ValueError("period_days must be 7, 30, or 90")
+    if period_days < 1 or period_days > MAX_REPORT_DAYS:
+        raise ValueError(f"period_days must be between 1 and {MAX_REPORT_DAYS}")
+    if period_bounds is None and period_days not in {1, 7, 30, 90, 365}:
+        raise ValueError("period_days must be 1, 7, 30, or 90, or 365")
     if not users:
         return []
 

--- a/backend/tests/test_progress_periods.py
+++ b/backend/tests/test_progress_periods.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from fitminiapp_api.core.timezone import today_for_user
+from fitminiapp_api.db.session import get_session_context
+from fitminiapp_api.models.user import User
+
+
+def _auth(client, telegram_user_id: int) -> dict[str, str]:
+    response = client.post(
+        "/api/v1/auth/dev-login",
+        json={"telegram_user_id": telegram_user_id},
+    )
+    assert response.status_code == 200
+    return {"Authorization": f"Bearer {response.json()['access_token']}"}
+
+
+def _today(telegram_user_id: int):
+    with get_session_context() as db:
+        user = db.query(User).filter(User.telegram_user_id == telegram_user_id).one()
+        return today_for_user(user)
+
+
+def test_summary_and_training_analytics_share_inclusive_preset_bounds(client) -> None:
+    telegram_user_id = 111_001
+    headers = _auth(client, telegram_user_id)
+    today = _today(telegram_user_id)
+
+    for period_days in (1, 7, 30, 90, 365):
+        summary_response = client.get(
+            "/api/v1/workouts/progress/summary",
+            params={"period_days": period_days},
+            headers=headers,
+        )
+        analytics_response = client.get(
+            "/api/v1/workouts/progress/training-analytics",
+            params={"period_days": period_days},
+            headers=headers,
+        )
+
+        assert summary_response.status_code == 200, summary_response.text
+        assert analytics_response.status_code == 200, analytics_response.text
+        summary = summary_response.json()
+        analytics = analytics_response.json()
+        expected_start = (today - timedelta(days=period_days - 1)).isoformat()
+        assert (summary["period_start"], summary["period_end"], summary["period_days"]) == (
+            expected_start,
+            today.isoformat(),
+            period_days,
+        )
+        assert (analytics["period_start"], analytics["period_end"], analytics["period_days"]) == (
+            expected_start,
+            today.isoformat(),
+            period_days,
+        )
+
+
+def test_custom_period_is_shared_and_counts_leap_day_inclusively(client) -> None:
+    telegram_user_id = 111_002
+    headers = _auth(client, telegram_user_id)
+    params = {"date_from": "2024-02-28", "date_to": "2024-03-01"}
+
+    summary_response = client.get(
+        "/api/v1/workouts/progress/summary",
+        params=params,
+        headers=headers,
+    )
+    analytics_response = client.get(
+        "/api/v1/workouts/progress/training-analytics",
+        params=params,
+        headers=headers,
+    )
+
+    assert summary_response.status_code == 200, summary_response.text
+    assert analytics_response.status_code == 200, analytics_response.text
+    assert summary_response.json()["period_days"] == 3
+    assert analytics_response.json()["period_days"] == 3
+    assert summary_response.json()["period_start"] == "2024-02-28"
+    assert summary_response.json()["period_end"] == "2024-03-01"
+    assert analytics_response.json()["period_start"] == "2024-02-28"
+    assert analytics_response.json()["period_end"] == "2024-03-01"
+
+
+def test_progress_period_validation_rejects_partial_invalid_and_future_ranges(client) -> None:
+    telegram_user_id = 111_003
+    headers = _auth(client, telegram_user_id)
+    today = _today(telegram_user_id)
+
+    invalid_requests = (
+        {"date_from": "2024-01-01"},
+        {"date_from": "2024-02-01", "date_to": "2024-01-31"},
+        {
+            "date_from": (today - timedelta(days=366)).isoformat(),
+            "date_to": today.isoformat(),
+        },
+        {
+            "date_from": today.isoformat(),
+            "date_to": (today + timedelta(days=1)).isoformat(),
+        },
+        {
+            "period_days": 30,
+            "date_from": (today - timedelta(days=2)).isoformat(),
+            "date_to": today.isoformat(),
+        },
+    )
+
+    for params in invalid_requests:
+        response = client.get(
+            "/api/v1/workouts/progress/summary",
+            params=params,
+            headers=headers,
+        )
+        assert response.status_code == 422, (params, response.text)
+
+    unsupported = client.get(
+        "/api/v1/workouts/progress/training-analytics",
+        params={"period_days": 14},
+        headers=headers,
+    )
+    assert unsupported.status_code == 422
+
+
+def test_custom_period_with_no_data_keeps_factual_empty_payload(client) -> None:
+    telegram_user_id = 111_004
+    headers = _auth(client, telegram_user_id)
+    response = client.get(
+        "/api/v1/workouts/progress/summary",
+        params={"date_from": "2024-01-01", "date_to": "2024-01-01"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["period_days"] == 1
+    assert payload["training"]["completed_workouts"] == 0
+    assert payload["body"]["trends"] == []
+    assert payload["nutrition"]["average_calories"] is None

--- a/frontend/src/features/cardio/CardioLogging.tsx
+++ b/frontend/src/features/cardio/CardioLogging.tsx
@@ -669,15 +669,20 @@ export function CardioQuickLog({
 
 export function CardioHistory({
   periodDays,
+  dateFrom: requestedDateFrom,
+  dateTo: requestedDateTo,
   summary,
   timeZone = detectedTimeZone(),
 }: {
-  periodDays: number;
+  periodDays?: number;
+  dateFrom?: string;
+  dateTo?: string;
   summary: CardioSummary;
   timeZone?: string;
 }) {
-  const dateTo = dateInputValue(new Date(), timeZone);
-  const dateFrom = addCalendarDays(dateTo, -(periodDays - 1));
+  const dateTo = requestedDateTo ?? dateInputValue(new Date(), timeZone);
+  const dateFrom =
+    requestedDateFrom ?? addCalendarDays(dateTo, -((periodDays ?? 30) - 1));
   const sessions = useQuery({
     queryKey: queryKeys.cardio.range(dateFrom, dateTo),
     queryFn: () =>

--- a/frontend/src/features/cardio/CardioLogging.tsx
+++ b/frontend/src/features/cardio/CardioLogging.tsx
@@ -681,8 +681,7 @@ export function CardioHistory({
   timeZone?: string;
 }) {
   const dateTo = requestedDateTo ?? dateInputValue(new Date(), timeZone);
-  const dateFrom =
-    requestedDateFrom ?? addCalendarDays(dateTo, -((periodDays ?? 30) - 1));
+  const dateFrom = requestedDateFrom ?? addCalendarDays(dateTo, -((periodDays ?? 30) - 1));
   const sessions = useQuery({
     queryKey: queryKeys.cardio.range(dateFrom, dateTo),
     queryFn: () =>

--- a/frontend/src/features/workouts/NutritionReport.tsx
+++ b/frontend/src/features/workouts/NutritionReport.tsx
@@ -20,9 +20,11 @@ import {
 } from '../../shared/ui/common';
 
 const reportPeriods = [
+  { value: 'days_1', label: 'День' },
   { value: 'days_7', label: '7 дней' },
   { value: 'days_30', label: '30 дней' },
   { value: 'days_90', label: '90 дней' },
+  { value: 'days_365', label: 'Год' },
   { value: 'current_week', label: 'Эта неделя' },
   { value: 'current_month', label: 'Этот месяц' },
   { value: 'previous_month', label: 'Прошлый месяц' },
@@ -389,7 +391,21 @@ function DailyTable({
   );
 }
 
-export function NutritionPeriodReport({ clientId }: { clientId?: number }) {
+export type ControlledNutritionPeriod = {
+  period: NutritionReportPeriod;
+  dateFrom: string;
+  dateTo: string;
+};
+
+export function NutritionPeriodReport({
+  clientId,
+  controlledPeriod,
+  showSelector = true,
+}: {
+  clientId?: number;
+  controlledPeriod?: ControlledNutritionPeriod;
+  showSelector?: boolean;
+}) {
   const initial = useMemo(
     () =>
       clientId == null
@@ -404,9 +420,21 @@ export function NutritionPeriodReport({ clientId }: { clientId?: number }) {
   const [customError, setCustomError] = useState('');
   const [exportState, setExportState] = useState<'idle' | 'loading' | 'done' | 'error'>('idle');
   const dayLink = clientId == null ? diaryLink : null;
+  const activePeriod = controlledPeriod?.period ?? period;
+  const activeDateFrom = controlledPeriod?.dateFrom ?? dateFrom;
+  const activeDateTo = controlledPeriod?.dateTo ?? dateTo;
+  const visibleSelectedPeriod = controlledPeriod?.period ?? selectedPeriod;
+  const visibleDateFrom = controlledPeriod?.dateFrom ?? dateFrom;
+  const visibleDateTo = controlledPeriod?.dateTo ?? dateTo;
   const report = useQuery({
-    queryKey: queryKeys.progress.nutritionReport(clientId ?? 'me', period, dateFrom, dateTo),
-    queryFn: () => api<NutritionReport>(reportPath(period, dateFrom, dateTo, false, clientId)),
+    queryKey: queryKeys.progress.nutritionReport(
+      clientId ?? 'me',
+      activePeriod,
+      activeDateFrom,
+      activeDateTo,
+    ),
+    queryFn: () =>
+      api<NutritionReport>(reportPath(activePeriod, activeDateFrom, activeDateTo, false, clientId)),
     placeholderData: keepPreviousData,
   });
   const today = report.data
@@ -457,7 +485,9 @@ export function NutritionPeriodReport({ clientId }: { clientId?: number }) {
   async function downloadCsv(): Promise<void> {
     setExportState('loading');
     try {
-      const file = await apiFile(reportPath(period, dateFrom, dateTo, true, clientId));
+      const file = await apiFile(
+        reportPath(activePeriod, activeDateFrom, activeDateTo, true, clientId),
+      );
       const url = URL.createObjectURL(file.blob);
       const link = document.createElement('a');
       link.href = url;
@@ -503,18 +533,22 @@ export function NutritionPeriodReport({ clientId }: { clientId?: number }) {
         </Button>
       </header>
 
-      <div className="nutrition-period-report__selector">
-        <SegmentedControl
-          ariaLabel="Период отчёта по питанию"
-          value={selectedPeriod}
-          options={reportPeriods}
-          onChange={selectPeriod}
-        />
-      </div>
-      <p className="nutrition-period-report__selector-hint" aria-hidden="true">
-        Ещё периоды — свайпните влево
-      </p>
-      {selectedPeriod === 'custom' && (
+      {showSelector && (
+        <>
+          <div className="nutrition-period-report__selector">
+            <SegmentedControl
+              ariaLabel="Период отчёта по питанию"
+              value={selectedPeriod}
+              options={reportPeriods}
+              onChange={selectPeriod}
+            />
+          </div>
+          <p className="nutrition-period-report__selector-hint" aria-hidden="true">
+            Ещё периоды — свайпните влево
+          </p>
+        </>
+      )}
+      {showSelector && visibleSelectedPeriod === 'custom' && (
         <div
           className="nutrition-period-report__custom"
           aria-describedby={customError ? 'nutrition-report-custom-error' : undefined}
@@ -522,18 +556,18 @@ export function NutritionPeriodReport({ clientId }: { clientId?: number }) {
           <Field label="Начало периода" labelFor="nutrition-report-from">
             <DateInput
               id="nutrition-report-from"
-              max={dateTo || today}
+              max={visibleDateTo || today}
               onChange={(event) => setDateFrom(event.target.value)}
-              value={dateFrom}
+              value={visibleDateFrom}
             />
           </Field>
           <Field label="Конец периода" labelFor="nutrition-report-to">
             <DateInput
               id="nutrition-report-to"
               max={today}
-              min={dateFrom}
+              min={visibleDateFrom}
               onChange={(event) => setDateTo(event.target.value)}
-              value={dateTo}
+              value={visibleDateTo}
             />
           </Field>
           <Button onClick={applyCustomPeriod} type="button" variant="secondary">

--- a/frontend/src/features/workouts/ProgressExperience.tsx
+++ b/frontend/src/features/workouts/ProgressExperience.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, type FormEvent, type ReactNode } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { api } from '../../shared/api/client';
 import type { ApiSchemas, ProgressSummary, TrainingAnalytics } from '../../shared/api/types';
 import { queryKeys } from '../../shared/queryKeys';
@@ -174,8 +174,8 @@ function LatestMeasurementPoints({ summary }: { summary: ProgressSummary }) {
         </ul>
       ) : (
         <p className="progress-note">
-          Добавьте фактический замер, чтобы увидеть первую точку истории. Одна точка ещё не
-          образует тренд.
+          Добавьте фактический замер, чтобы увидеть первую точку истории. Одна точка ещё не образует
+          тренд.
         </p>
       )}
     </article>
@@ -235,10 +235,7 @@ function SummaryOverview({ summary }: { summary: ProgressSummary }) {
           {weight ? (
             <>
               <BodyChart trend={weight} />
-              <DataConfidence
-                kind="weight"
-                signal={summary.data_sufficiency.weight_trend}
-              />
+              <DataConfidence kind="weight" signal={summary.data_sufficiency.weight_trend} />
             </>
           ) : (
             <EmptyState
@@ -694,7 +691,9 @@ function BodySection({
                         </div>
                       </header>
                       {weightChartInOverview && trend.metric === 'weight_kg' ? (
-                        <p className="progress-note">График веса вынесен в сводку выбранного периода.</p>
+                        <p className="progress-note">
+                          График веса вынесен в сводку выбранного периода.
+                        </p>
                       ) : (
                         <BodyChart trend={trend} />
                       )}
@@ -954,9 +953,7 @@ function ProgressPeriodControls({
         />
       </div>
       <div className="progress-period-controls__meta" aria-live="polite">
-        <strong>
-          Период: {periodDateLabel(range.dateFrom, range.dateTo)}
-        </strong>
+        <strong>Период: {periodDateLabel(range.dateFrom, range.dateTo)}</strong>
         <span>Часовой пояс: {timeZone}</span>
       </div>
       {customOpen && (
@@ -1018,6 +1015,7 @@ function useTrainingAnalytics(selection: ProgressSelection) {
       api<TrainingAnalytics>(
         `/api/v1/workouts/progress/training-analytics${progressApiQuery(selection)}`,
       ),
+    placeholderData: keepPreviousData,
   });
 }
 
@@ -1034,9 +1032,8 @@ export function ProgressExperience({
   const summary = useQuery({
     queryKey: queryKeys.progress.summary(selectionKey),
     queryFn: () =>
-      api<ProgressSummary>(
-        `/api/v1/workouts/progress/summary${progressApiQuery(selection)}`,
-      ),
+      api<ProgressSummary>(`/api/v1/workouts/progress/summary${progressApiQuery(selection)}`),
+    placeholderData: keepPreviousData,
   });
   const analytics = useTrainingAnalytics(selection);
   const controlledNutritionPeriod = useMemo<ControlledNutritionPeriod>(
@@ -1044,12 +1041,19 @@ export function ProgressExperience({
     [selection],
   );
 
+  function navigateWithinProgress(to: string): void {
+    const scrollX = window.scrollX;
+    const scrollY = window.scrollY;
+    navigate(to);
+    window.scrollTo({ left: scrollX, top: scrollY, behavior: 'instant' });
+  }
+
   function selectPreset(days: 7 | 30 | 90): void {
-    navigate(progressPath(search, { kind: 'preset', days }));
+    navigateWithinProgress(progressPath(search, { kind: 'preset', days }));
   }
 
   function applyCustom(nextSelection: Extract<ProgressSelection, { kind: 'custom' }>): void {
-    navigate(progressPath(search, nextSelection));
+    navigateWithinProgress(progressPath(search, nextSelection));
   }
 
   return (
@@ -1105,7 +1109,10 @@ export function ProgressExperience({
               weightChartInOverview
             />
             <NutritionSection summary={summary.data} />
-            <NutritionPeriodReport controlledPeriod={controlledNutritionPeriod} showSelector={false} />
+            <NutritionPeriodReport
+              controlledPeriod={controlledNutritionPeriod}
+              showSelector={false}
+            />
             <AdherenceSection summary={summary.data} />
           </div>
         </>

--- a/frontend/src/features/workouts/ProgressExperience.tsx
+++ b/frontend/src/features/workouts/ProgressExperience.tsx
@@ -1,35 +1,42 @@
-import { useState, type ReactNode } from 'react';
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useMemo, useState, type FormEvent, type ReactNode } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { api } from '../../shared/api/client';
 import type { ApiSchemas, ProgressSummary, TrainingAnalytics } from '../../shared/api/types';
 import { queryKeys } from '../../shared/queryKeys';
-import { AppLink } from '../../shared/navigation/router';
+import { AppLink, useNavigation } from '../../shared/navigation/router';
 import { ContextualHelp } from '../../shared/ui/ContextualHelp';
 import { DataConfidence } from '../../shared/ui/DataConfidence';
 import { QuantitativeProgress, RankedBars, TimeSeriesChart } from '../../shared/ui/DataViz';
-import { formatCalendarDate } from '../../shared/dateTime';
+import { dateInputValue, detectedTimeZone, formatCalendarDate } from '../../shared/dateTime';
 import {
   Badge,
+  Button,
   DisclosureIcon,
   EmptyState,
   ErrorState,
+  Field,
   LoadingState,
   SegmentedControl,
   SemanticArtwork,
 } from '../../shared/ui/common';
-import { NutritionPeriodReport } from './NutritionReport';
+import { NutritionPeriodReport, type ControlledNutritionPeriod } from './NutritionReport';
 import { Icon } from '../../shared/ui/Icon';
 import { CardioHistory } from '../cardio/CardioLogging';
+import {
+  nutritionPeriodForProgress,
+  parseProgressSelection,
+  progressApiQuery,
+  progressPath,
+  progressPeriodOptions,
+  progressReportPath,
+  progressSelectionKey,
+  selectionDateRange,
+  validateCustomProgressRange,
+  type ProgressSelection,
+} from './progressPeriods';
 
-type PeriodDays = 7 | 30 | 90;
 type BodyTrend = ProgressSummary['body']['trends'][number];
 type AdherenceComponent = ProgressSummary['adherence']['workouts'];
-
-const periodOptions = [
-  { value: '7', label: '7 дней' },
-  { value: '30', label: '30 дней' },
-  { value: '90', label: '90 дней' },
-] as const;
 
 const bodyMetricLabels: Record<BodyTrend['metric'], string> = {
   weight_kg: 'Вес',
@@ -115,56 +122,159 @@ function SectionHeading({
   );
 }
 
+function periodDateLabel(start: string, end: string): string {
+  return start === end
+    ? formatDate(start, true)
+    : `${formatDate(start, true)} — ${formatDate(end, true)}`;
+}
+
+function ProgressBentoMetric({
+  detail,
+  label,
+  value,
+}: {
+  detail: string;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="progress-bento__metric">
+      <dt>{label}</dt>
+      <dd>{value}</dd>
+      <small>{detail}</small>
+    </div>
+  );
+}
+
+function LatestMeasurementPoints({ summary }: { summary: ProgressSummary }) {
+  const trend =
+    summary.body.trends.find((item) => item.metric === 'weight_kg') ?? summary.body.trends[0];
+  const points = trend?.points.slice(-4).reverse() ?? [];
+  return (
+    <article className="progress-bento__journal">
+      <div className="progress-bento__journal-head">
+        <div>
+          <span className="progress-bento__eyebrow">Последние факты</span>
+          <h3>Журнал замеров</h3>
+        </div>
+        <span className="progress-bento__journal-count">
+          {points.length ? `${points.length} точек` : 'Нет точек'}
+        </span>
+      </div>
+      {points.length ? (
+        <ul aria-label="Последние замеры за выбранный период">
+          {points.map((point) => (
+            <li key={point.measured_on}>
+              <span>{formatDate(point.measured_on, true)}</span>
+              <strong>
+                {formatNumber(point.value)} {bodyMetricUnits[trend?.metric ?? 'weight_kg']}
+              </strong>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="progress-note">
+          Добавьте фактический замер, чтобы увидеть первую точку истории. Одна точка ещё не
+          образует тренд.
+        </p>
+      )}
+    </article>
+  );
+}
+
 function SummaryOverview({ summary }: { summary: ProgressSummary }) {
   const weight = summary.body.trends.find((trend) => trend.metric === 'weight_kg');
+  const confirmedNutritionDays = summary.nutrition.complete_days + summary.nutrition.fasted_days;
+  const latestWeight = weight ? `${formatNumber(weight.latest_value)} кг` : 'Нет данных';
   return (
     <section
-      className="progress-summary semantic-card semantic-card--summary semantic-card--progress"
+      className="progress-summary progress-bento semantic-card semantic-card--summary semantic-card--progress"
       data-card-variant="summary"
       data-semantic-family="progress"
+      data-testid="progress-bento-overview"
       aria-labelledby="progress-overview-title"
     >
-      <div className="progress-summary__lead">
-        <span>Соблюдение плана</span>
-        <strong
-          id="progress-overview-title"
-          className={
-            summary.adherence.overall_percent == null ? undefined : 'progress-summary__score'
-          }
-        >
-          {summary.adherence.overall_percent == null
-            ? 'Пока не оценить'
-            : `${formatNumber(summary.adherence.overall_percent)}%`}
-        </strong>
-        <p>
-          {summary.adherence.overall_percent == null
-            ? 'Добавляйте тренировки и питание — оценка появится, когда будет что сравнивать с планом.'
-            : 'Расчёт учитывает только доступные компоненты плана за выбранный период.'}
-        </p>
+      <div className="progress-bento__context">
+        <div>
+          <span className="progress-bento__eyebrow">Сводка выбранного периода</span>
+          <h2 id="progress-overview-title">Прогресс по фактам</h2>
+          <p>
+            {periodDateLabel(summary.period_start, summary.period_end)}. Показаны только записи,
+            попавшие в этот диапазон.
+          </p>
+        </div>
+        <Badge>{summary.period_days} дн.</Badge>
       </div>
-      <dl className="progress-summary__facts">
-        <div>
-          <dt>Тренировки</dt>
-          <dd>
-            {summary.training.completed_workouts} из {summary.training.planned_workouts}
-          </dd>
-          <small>завершено по плану</small>
-        </div>
-        <div>
-          <dt>Новые рекорды</dt>
-          <dd>{summary.training.new_personal_records}</dd>
-          <small>по данным завершённых подходов</small>
-        </div>
-        <div>
-          <dt>{weight ? 'Изменение веса' : 'Дней с питанием'}</dt>
-          <dd>
-            {weight
-              ? formatChange(weight.change, bodyMetricUnits[weight.metric])
-              : summary.nutrition.complete_days + summary.nutrition.fasted_days}
-          </dd>
-          <small>{weight ? 'сравнение с собой' : 'подтверждено за период'}</small>
-        </div>
-      </dl>
+      <div className="progress-bento__grid">
+        <article className="progress-bento__adherence">
+          <span className="progress-bento__eyebrow">Ритм плана</span>
+          <strong className="progress-summary__score">
+            {summary.adherence.overall_percent == null
+              ? 'Пока не оценить'
+              : `${formatNumber(summary.adherence.overall_percent)}%`}
+          </strong>
+          <p>
+            {summary.adherence.overall_percent == null
+              ? 'Появится, когда за период будет что сравнивать с планом.'
+              : 'Расчёт учитывает только доступные компоненты плана.'}
+          </p>
+        </article>
+        <article className="progress-bento__trend">
+          <div className="progress-bento__trend-head">
+            <div>
+              <span className="progress-bento__eyebrow">Главная динамика</span>
+              <h3>{weight ? 'Вес' : 'Замеры тела'}</h3>
+            </div>
+            {weight && (
+              <strong>
+                {latestWeight}
+                <small>{formatChange(weight.change, 'кг')}</small>
+              </strong>
+            )}
+          </div>
+          {weight ? (
+            <>
+              <BodyChart trend={weight} />
+              <DataConfidence
+                kind="weight"
+                signal={summary.data_sufficiency.weight_trend}
+              />
+            </>
+          ) : (
+            <EmptyState
+              title="Недостаточно точек для динамики"
+              text="Добавьте замеры тела: первая запись сохранит факт, но не станет трендом сама по себе."
+            />
+          )}
+        </article>
+        <dl className="progress-bento__metrics" aria-label="Факты за выбранный период">
+          <ProgressBentoMetric
+            detail={`${summary.training.planned_workouts} запланировано`}
+            label="Тренировки"
+            value={`${summary.training.completed_workouts} из ${summary.training.planned_workouts}`}
+          />
+          <ProgressBentoMetric
+            detail={
+              summary.nutrition.visible
+                ? `${summary.nutrition.incomplete_days} частичных, не входят в средние`
+                : 'Доступ закрыт для этой роли'
+            }
+            label="Питание"
+            value={summary.nutrition.visible ? `${confirmedNutritionDays} дней` : 'Недоступно'}
+          />
+          <ProgressBentoMetric
+            detail={`${summary.cardio.duration_minutes} мин фактической длительности`}
+            label="Кардио"
+            value={`${summary.cardio.completed_sessions} сессий`}
+          />
+          <ProgressBentoMetric
+            detail={weight ? `${weight.point_count} точек веса в периоде` : 'Нет фактических точек'}
+            label="Замеры"
+            value={latestWeight}
+          />
+        </dl>
+        <LatestMeasurementPoints summary={summary} />
+      </div>
     </section>
   );
 }
@@ -449,10 +559,12 @@ function BodySection({
   isStale,
   measurementDiary,
   summary,
+  weightChartInOverview = false,
 }: {
   isStale?: boolean;
   measurementDiary?: ReactNode;
   summary: ProgressSummary;
+  weightChartInOverview?: boolean;
 }) {
   const { body } = summary;
   const priorityOptions = useQuery({
@@ -581,7 +693,11 @@ function BodySection({
                           <span>{formatChange(trend.change, unit)}</span>
                         </div>
                       </header>
-                      <BodyChart trend={trend} />
+                      {weightChartInOverview && trend.metric === 'weight_kg' ? (
+                        <p className="progress-note">График веса вынесен в сводку выбранного периода.</p>
+                      ) : (
+                        <BodyChart trend={trend} />
+                      )}
                       {interpretation && <p className="progress-note">{interpretation}</p>}
                     </article>
                   );
@@ -775,12 +891,133 @@ function AdherenceSection({ summary }: { summary: ProgressSummary }) {
   );
 }
 
-function useTrainingAnalytics(period: PeriodDays) {
+function ProgressPeriodControls({
+  onSelectPreset,
+  onApplyCustom,
+  selection,
+  timeZone,
+  today,
+}: {
+  onApplyCustom: (selection: Extract<ProgressSelection, { kind: 'custom' }>) => void;
+  onSelectPreset: (days: 7 | 30 | 90) => void;
+  selection: ProgressSelection;
+  timeZone: string;
+  today: string;
+}) {
+  const initialRange = selectionDateRange(selection, today);
+  const [customOpen, setCustomOpen] = useState(false);
+  const [customDateFrom, setCustomDateFrom] = useState(initialRange.dateFrom);
+  const [customDateTo, setCustomDateTo] = useState(initialRange.dateTo);
+  const [customError, setCustomError] = useState('');
+  const range = selectionDateRange(selection, today);
+  const selectedValue = selection.kind === 'custom' ? 'custom' : String(selection.days);
+  const onTabChange = (value: string) => {
+    if (value === 'custom') {
+      const nextRange = selectionDateRange(selection, today);
+      setCustomDateFrom(nextRange.dateFrom);
+      setCustomDateTo(nextRange.dateTo);
+      setCustomError('');
+      setCustomOpen(true);
+      return;
+    }
+    setCustomOpen(false);
+    setCustomError('');
+    onSelectPreset(Number(value) as 7 | 30 | 90);
+  };
+
+  function applyCustom(): void {
+    const error = validateCustomProgressRange(customDateFrom, customDateTo, today);
+    if (error) {
+      setCustomError(error);
+      return;
+    }
+    setCustomError('');
+    setCustomOpen(false);
+    onApplyCustom({ kind: 'custom', dateFrom: customDateFrom, dateTo: customDateTo });
+  }
+
+  function cancelCustom(): void {
+    setCustomError('');
+    setCustomOpen(false);
+    setCustomDateFrom(range.dateFrom);
+    setCustomDateTo(range.dateTo);
+  }
+
+  return (
+    <div className="progress-period-controls">
+      <div className="progress-period-controls__tabs">
+        <SegmentedControl
+          ariaLabel="Период прогресса"
+          options={progressPeriodOptions}
+          value={selectedValue}
+          onChange={onTabChange}
+        />
+      </div>
+      <div className="progress-period-controls__meta" aria-live="polite">
+        <strong>
+          Период: {periodDateLabel(range.dateFrom, range.dateTo)}
+        </strong>
+        <span>Часовой пояс: {timeZone}</span>
+      </div>
+      {customOpen && (
+        <form
+          className="progress-period-controls__custom"
+          onSubmit={(event: FormEvent<HTMLFormElement>) => {
+            event.preventDefault();
+            applyCustom();
+          }}
+          aria-describedby={customError ? 'progress-custom-period-error' : undefined}
+        >
+          <Field label="Начало периода" labelFor="progress-period-from">
+            <input
+              aria-label="Начало периода"
+              className="ui-input"
+              id="progress-period-from"
+              max={customDateTo || today}
+              onChange={(event) => setCustomDateFrom(event.target.value)}
+              type="date"
+              value={customDateFrom}
+            />
+          </Field>
+          <Field label="Конец периода" labelFor="progress-period-to">
+            <input
+              aria-label="Конец периода"
+              className="ui-input"
+              id="progress-period-to"
+              max={today}
+              min={customDateFrom}
+              onChange={(event) => setCustomDateTo(event.target.value)}
+              type="date"
+              value={customDateTo}
+            />
+          </Field>
+          <div className="progress-period-controls__custom-actions">
+            <Button type="submit" variant="secondary">
+              Показать период
+            </Button>
+            <Button onClick={cancelCustom} type="button" variant="ghost">
+              Отмена
+            </Button>
+          </div>
+          {customError && (
+            <p className="ui-field__error" id="progress-custom-period-error" role="alert">
+              {customError}
+            </p>
+          )}
+        </form>
+      )}
+    </div>
+  );
+}
+
+function useTrainingAnalytics(selection: ProgressSelection) {
+  const selectionKey = progressSelectionKey(selection);
   return useQuery({
-    queryKey: ['workout', 'training-analytics', period],
+    queryKey: ['workout', 'training-analytics', selectionKey],
     queryFn: () =>
-      api<TrainingAnalytics>(`/api/v1/workouts/progress/training-analytics?period_days=${period}`),
-    placeholderData: keepPreviousData,
+      api<TrainingAnalytics>(
+        `/api/v1/workouts/progress/training-analytics${progressApiQuery(selection)}`,
+      ),
   });
 }
 
@@ -788,16 +1025,35 @@ export function ProgressExperience({
   measurementDiary,
   timeZone,
 }: { measurementDiary?: ReactNode; timeZone?: string | null } = {}) {
-  const [period, setPeriod] = useState<PeriodDays>(30);
+  const { navigate, search } = useNavigation();
+  const selection = useMemo(() => parseProgressSelection(search), [search]);
+  const resolvedTimeZone = timeZone ?? detectedTimeZone();
+  const today = dateInputValue(new Date(), resolvedTimeZone);
+
+  const selectionKey = progressSelectionKey(selection);
   const summary = useQuery({
-    queryKey: queryKeys.progress.summary(period),
-    queryFn: () => api<ProgressSummary>(`/api/v1/workouts/progress/summary?period_days=${period}`),
-    placeholderData: keepPreviousData,
+    queryKey: queryKeys.progress.summary(selectionKey),
+    queryFn: () =>
+      api<ProgressSummary>(
+        `/api/v1/workouts/progress/summary${progressApiQuery(selection)}`,
+      ),
   });
-  const analytics = useTrainingAnalytics(period);
+  const analytics = useTrainingAnalytics(selection);
+  const controlledNutritionPeriod = useMemo<ControlledNutritionPeriod>(
+    () => nutritionPeriodForProgress(selection),
+    [selection],
+  );
+
+  function selectPreset(days: 7 | 30 | 90): void {
+    navigate(progressPath(search, { kind: 'preset', days }));
+  }
+
+  function applyCustom(nextSelection: Extract<ProgressSelection, { kind: 'custom' }>): void {
+    navigate(progressPath(search, nextSelection));
+  }
 
   return (
-    <div className="progress-experience">
+    <div className="progress-experience progress-experience--bento">
       <header className="progress-hero">
         <div className="progress-hero__copy">
           <span className="eyebrow">Ваша динамика</span>
@@ -811,13 +1067,15 @@ export function ProgressExperience({
           </ContextualHelp>
         </div>
         <div className="progress-hero__actions">
-          <SegmentedControl
-            ariaLabel="Период прогресса"
-            value={String(period)}
-            options={periodOptions}
-            onChange={(value) => setPeriod(Number(value) as PeriodDays)}
+          <ProgressPeriodControls
+            key={selectionKey}
+            onApplyCustom={applyCustom}
+            onSelectPreset={selectPreset}
+            selection={selection}
+            timeZone={resolvedTimeZone}
+            today={today}
           />
-          <AppLink className="button-link secondary-link" to={`/app/report?period=days_${period}`}>
+          <AppLink className="button-link secondary-link" to={progressReportPath(selection)}>
             <Icon name="print" size={16} /> Скачать отчёт
           </AppLink>
         </div>
@@ -833,20 +1091,23 @@ export function ProgressExperience({
       ) : summary.data ? (
         <>
           <SummaryOverview summary={summary.data} />
-          <TrainingSection analytics={analytics} summary={summary.data} />
-          <CardioHistory
-            periodDays={period}
-            summary={summary.data.cardio}
-            timeZone={timeZone ?? undefined}
-          />
-          <BodySection
-            isStale={summary.isPlaceholderData}
-            measurementDiary={measurementDiary}
-            summary={summary.data}
-          />
-          <NutritionSection isStale={summary.isPlaceholderData} summary={summary.data} />
-          <NutritionPeriodReport />
-          <AdherenceSection summary={summary.data} />
+          <div className="progress-details" aria-label="Подробности прогресса">
+            <TrainingSection analytics={analytics} summary={summary.data} />
+            <CardioHistory
+              dateFrom={summary.data.period_start}
+              dateTo={summary.data.period_end}
+              summary={summary.data.cardio}
+              timeZone={resolvedTimeZone}
+            />
+            <BodySection
+              measurementDiary={measurementDiary}
+              summary={summary.data}
+              weightChartInOverview
+            />
+            <NutritionSection summary={summary.data} />
+            <NutritionPeriodReport controlledPeriod={controlledNutritionPeriod} showSelector={false} />
+            <AdherenceSection summary={summary.data} />
+          </div>
         </>
       ) : null}
 

--- a/frontend/src/features/workouts/ProgressExperience.tsx
+++ b/frontend/src/features/workouts/ProgressExperience.tsx
@@ -1056,6 +1056,14 @@ export function ProgressExperience({
     navigateWithinProgress(progressPath(search, nextSelection));
   }
 
+  const summaryMatchesSelection = summary.data
+    ? selection.kind === 'custom'
+      ? summary.data.period_start === selection.dateFrom &&
+        summary.data.period_end === selection.dateTo
+      : summary.data.period_days === selection.days
+    : false;
+  const isSummaryUpdating = Boolean(summary.data && !summaryMatchesSelection);
+
   return (
     <div className="progress-experience progress-experience--bento">
       <header className="progress-hero">
@@ -1094,6 +1102,11 @@ export function ProgressExperience({
         />
       ) : summary.data ? (
         <>
+          {isSummaryUpdating && (
+            <p className="progress-note" role="status">
+              Обновляем динамику за период…
+            </p>
+          )}
           <SummaryOverview summary={summary.data} />
           <div className="progress-details" aria-label="Подробности прогресса">
             <TrainingSection analytics={analytics} summary={summary.data} />

--- a/frontend/src/features/workouts/progressPeriods.ts
+++ b/frontend/src/features/workouts/progressPeriods.ts
@@ -1,0 +1,134 @@
+import { addCalendarDays } from '../../shared/dateTime';
+
+export const PROGRESS_PERIODS = [7, 30, 90] as const;
+export type ProgressPeriodDays = (typeof PROGRESS_PERIODS)[number];
+export type ProgressSelection =
+  | { kind: 'preset'; days: ProgressPeriodDays }
+  | { kind: 'custom'; dateFrom: string; dateTo: string };
+
+export const progressPeriodOptions = [
+  { value: '7', label: '7 дней' },
+  { value: '30', label: '30 дней' },
+  { value: '90', label: '90 дней' },
+  { value: 'custom', label: 'Свой период' },
+] as const;
+
+const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+function preset(value: string | null): ProgressSelection | null {
+  if (value === 'days_7' || value === '7') return { kind: 'preset', days: 7 };
+  if (value === 'days_30' || value === '30') return { kind: 'preset', days: 30 };
+  if (value === 'days_90' || value === '90') return { kind: 'preset', days: 90 };
+  return null;
+}
+
+export function parseProgressSelection(search: string): ProgressSelection {
+  const params = new URLSearchParams(search);
+  const rawPeriod = params.get('progress_period') ?? params.get('period');
+  const selectedPreset = preset(rawPeriod);
+  if (selectedPreset) return selectedPreset;
+
+  if (rawPeriod === 'custom') {
+    const dateFrom = params.get('progress_from') ?? params.get('date_from') ?? '';
+    const dateTo = params.get('progress_to') ?? params.get('date_to') ?? '';
+    if (datePattern.test(dateFrom) && datePattern.test(dateTo)) {
+      return { kind: 'custom', dateFrom, dateTo };
+    }
+  }
+  return { kind: 'preset', days: 30 };
+}
+
+export function progressSelectionKey(selection: ProgressSelection): string {
+  return selection.kind === 'custom'
+    ? `custom:${selection.dateFrom}:${selection.dateTo}`
+    : `days:${selection.days}`;
+}
+
+export function progressApiQuery(selection: ProgressSelection): string {
+  const params = new URLSearchParams();
+  if (selection.kind === 'custom') {
+    params.set('date_from', selection.dateFrom);
+    params.set('date_to', selection.dateTo);
+  } else {
+    params.set('period_days', String(selection.days));
+  }
+  return `?${params.toString()}`;
+}
+
+export function progressPath(search: string, selection: ProgressSelection): string {
+  const url = new URL(
+    `${window.location.pathname}${search}${window.location.hash}`,
+    window.location.origin,
+  );
+  url.searchParams.set('section', 'progress');
+  url.searchParams.set(
+    'progress_period',
+    selection.kind === 'custom' ? 'custom' : `days_${selection.days}`,
+  );
+  url.searchParams.delete('period');
+  url.searchParams.delete('nutrition_period');
+  url.searchParams.delete('progress_from');
+  url.searchParams.delete('progress_to');
+  url.searchParams.delete('date_from');
+  url.searchParams.delete('date_to');
+  if (selection.kind === 'custom') {
+    url.searchParams.set('progress_from', selection.dateFrom);
+    url.searchParams.set('progress_to', selection.dateTo);
+  }
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function progressReportPath(selection: ProgressSelection): string {
+  const params = new URLSearchParams({
+    period: selection.kind === 'custom' ? 'custom' : `days_${selection.days}`,
+  });
+  if (selection.kind === 'custom') {
+    params.set('date_from', selection.dateFrom);
+    params.set('date_to', selection.dateTo);
+  }
+  return `/app/report?${params.toString()}`;
+}
+
+export function nutritionPeriodForProgress(selection: ProgressSelection): {
+  period: `days_${ProgressPeriodDays}` | 'custom';
+  dateFrom: string;
+  dateTo: string;
+} {
+  if (selection.kind === 'custom') {
+    return { period: 'custom', dateFrom: selection.dateFrom, dateTo: selection.dateTo };
+  }
+  return { period: `days_${selection.days}`, dateFrom: '', dateTo: '' };
+}
+
+export function selectionDateRange(
+  selection: ProgressSelection,
+  today: string,
+): { dateFrom: string; dateTo: string } {
+  if (selection.kind === 'custom') {
+    return { dateFrom: selection.dateFrom, dateTo: selection.dateTo };
+  }
+  return { dateFrom: addCalendarDays(today, -(selection.days - 1)), dateTo: today };
+}
+
+export function inclusiveDays(dateFrom: string, dateTo: string): number {
+  return (
+    Math.floor(
+      (Date.parse(`${dateTo}T00:00:00Z`) - Date.parse(`${dateFrom}T00:00:00Z`)) / 86_400_000,
+    ) + 1
+  );
+}
+
+export function validateCustomProgressRange(
+  dateFrom: string,
+  dateTo: string,
+  today: string,
+): string | null {
+  if (!dateFrom || !dateTo) return 'Укажите дату начала и окончания.';
+  const days = inclusiveDays(dateFrom, dateTo);
+  if (!Number.isFinite(days) || days < 1) {
+    return 'Дата окончания не может быть раньше даты начала.';
+  }
+  if (days > 366) return 'Период не может превышать 366 дней.';
+  if (dateTo > today) return 'Нельзя выбрать будущую дату.';
+  return null;
+}

--- a/frontend/src/shared/api/schema.d.ts
+++ b/frontend/src/shared/api/schema.d.ts
@@ -6059,7 +6059,7 @@ export interface components {
          * NutritionReportPeriod
          * @enum {string}
          */
-        NutritionReportPeriod: "days_7" | "days_30" | "days_90" | "current_week" | "current_month" | "previous_month" | "custom";
+        NutritionReportPeriod: "days_1" | "days_7" | "days_30" | "days_90" | "days_365" | "current_week" | "current_month" | "previous_month" | "custom";
         /** NutritionReportResponse */
         NutritionReportResponse: {
             period: components["schemas"]["NutritionReportPeriod"];
@@ -6660,7 +6660,7 @@ export interface components {
          * ProgressPeriodDays
          * @enum {integer}
          */
-        ProgressPeriodDays: 7 | 30 | 90;
+        ProgressPeriodDays: 1 | 7 | 30 | 90 | 365;
         /** ProgressReportCheckIn */
         ProgressReportCheckIn: {
             /**
@@ -6875,7 +6875,8 @@ export interface components {
         ProgressSummaryResponse: {
             /** User Id */
             user_id: number;
-            period_days: components["schemas"]["ProgressPeriodDays"];
+            /** Period Days */
+            period_days: number;
             /**
              * Period Start
              * Format: date
@@ -7256,7 +7257,8 @@ export interface components {
         TrainerClientProgressSummary: {
             /** User Id */
             user_id: number;
-            period_days: components["schemas"]["ProgressPeriodDays"];
+            /** Period Days */
+            period_days: number;
             /**
              * Period Start
              * Format: date
@@ -10668,7 +10670,9 @@ export interface operations {
     coach_client_progress_summary_api_v1_coach_clients__client_id__summary_get: {
         parameters: {
             query?: {
-                period_days?: components["schemas"]["ProgressPeriodDays"];
+                period_days?: components["schemas"]["ProgressPeriodDays"] | null;
+                date_from?: string | null;
+                date_to?: string | null;
             };
             header?: never;
             path: {
@@ -10875,7 +10879,9 @@ export interface operations {
     coach_client_training_analytics_api_v1_coach_clients__client_id__training_analytics_get: {
         parameters: {
             query?: {
-                period_days?: components["schemas"]["ProgressPeriodDays"];
+                period_days?: components["schemas"]["ProgressPeriodDays"] | null;
+                date_from?: string | null;
+                date_to?: string | null;
                 exercise_history_limit?: number;
             };
             header?: never;
@@ -10909,7 +10915,9 @@ export interface operations {
     coach_client_progress_summaries_api_v1_coach_client_summaries_get: {
         parameters: {
             query?: {
-                period_days?: components["schemas"]["ProgressPeriodDays"];
+                period_days?: components["schemas"]["ProgressPeriodDays"] | null;
+                date_from?: string | null;
+                date_to?: string | null;
                 limit?: number;
                 offset?: number;
             };
@@ -11702,7 +11710,9 @@ export interface operations {
     workout_progress_summary_api_v1_workouts_progress_summary_get: {
         parameters: {
             query?: {
-                period_days?: components["schemas"]["ProgressPeriodDays"];
+                period_days?: components["schemas"]["ProgressPeriodDays"] | null;
+                date_from?: string | null;
+                date_to?: string | null;
             };
             header?: never;
             path?: never;
@@ -11896,7 +11906,9 @@ export interface operations {
     workout_training_analytics_api_v1_workouts_progress_training_analytics_get: {
         parameters: {
             query?: {
-                period_days?: components["schemas"]["ProgressPeriodDays"];
+                period_days?: components["schemas"]["ProgressPeriodDays"] | null;
+                date_from?: string | null;
+                date_to?: string | null;
                 exercise_history_limit?: number;
             };
             header?: never;

--- a/frontend/src/shared/queryKeys.ts
+++ b/frontend/src/shared/queryKeys.ts
@@ -11,7 +11,7 @@ export const queryKeys = {
   },
   progress: {
     summaries: ['workout', 'progress-summary'] as const,
-    summary: (periodDays: number) => ['workout', 'progress-summary', periodDays] as const,
+    summary: (periodDays: number | string) => ['workout', 'progress-summary', periodDays] as const,
     nutritionReport: (subject: number | 'me', period: string, dateFrom?: string, dateTo?: string) =>
       ['workout', 'nutrition-report', subject, period, dateFrom ?? null, dateTo ?? null] as const,
   },

--- a/frontend/src/styles/design-v2.css
+++ b/frontend/src/styles/design-v2.css
@@ -3098,6 +3098,469 @@ body.public-shell-mode.public-shell-mode:has(.auth-public-shell--design-v2) {
   }
 }
 
+/* Task 111: one period contract and compact factual progress bento. */
+.app-section--progress .progress-experience--bento {
+  gap: var(--v2-space-5);
+  color: var(--v2-text-primary);
+}
+
+.app-section--progress .progress-experience--bento .progress-hero {
+  align-items: start;
+  padding-block: var(--v2-space-2) 0;
+}
+
+.app-section--progress .progress-experience--bento .progress-hero__actions {
+  display: grid;
+  justify-items: stretch;
+  gap: var(--v2-space-3);
+  min-width: min(100%, 620px);
+}
+
+.app-section--progress .progress-period-controls {
+  display: grid;
+  gap: var(--v2-space-2);
+  min-width: 0;
+}
+
+.app-section--progress .progress-period-controls__tabs {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.app-section--progress .progress-period-controls .ui-tabs {
+  display: flex;
+  justify-content: flex-start;
+  max-width: 100%;
+  padding: 3px;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  scrollbar-width: thin;
+}
+
+.app-section--progress .progress-period-controls .ui-tab {
+  flex: 0 0 auto;
+  min-height: 44px;
+  white-space: nowrap;
+}
+
+.app-section--progress .progress-period-controls__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: flex-end;
+  gap: 4px 10px;
+  color: var(--v2-text-secondary);
+  font-size: 0.74rem;
+  line-height: 1.4;
+}
+
+.app-section--progress .progress-period-controls__meta strong {
+  color: var(--v2-text-primary);
+  font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.app-section--progress .progress-period-controls__custom {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(150px, 1fr)) auto;
+  align-items: end;
+  gap: var(--v2-space-2);
+  padding: var(--v2-space-3);
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-control-radius);
+  background: var(--v2-surface-secondary);
+}
+
+.app-section--progress .progress-period-controls__custom .ui-field {
+  min-width: 0;
+}
+
+.app-section--progress .progress-period-controls__custom-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--v2-space-2);
+}
+
+.app-section--progress .progress-period-controls__custom .ui-field__error,
+.app-section--progress .progress-period-controls__custom > .ui-field__error {
+  grid-column: 1 / -1;
+  margin: 0;
+}
+
+.app-section--progress .progress-bento.progress-summary {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--v2-space-4);
+  overflow: hidden;
+  padding: clamp(18px, 3vw, 28px);
+  border: 1px solid color-mix(in srgb, var(--semantic-progress-line) 72%, var(--v2-border));
+  border-radius: var(--v2-panel-radius);
+  background: var(--v2-surface);
+  box-shadow: 0 14px 34px color-mix(in srgb, var(--semantic-progress-line) 12%, transparent);
+}
+
+.app-section--progress .progress-bento__context,
+.app-section--progress .progress-bento__trend-head,
+.app-section--progress .progress-bento__journal-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--v2-space-3);
+}
+
+.app-section--progress .progress-bento__context h2,
+.app-section--progress .progress-bento__trend h3,
+.app-section--progress .progress-bento__journal h3 {
+  margin: 0;
+  color: var(--v2-text-primary);
+  letter-spacing: -0.035em;
+}
+
+.app-section--progress .progress-bento__context h2 {
+  font-size: clamp(1.4rem, 2.6vw, 2rem);
+}
+
+.app-section--progress .progress-bento__context p {
+  max-width: 58ch;
+  margin: 5px 0 0;
+  color: var(--v2-text-secondary);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.app-section--progress .progress-bento__context > .ui-badge {
+  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+}
+
+.app-section--progress .progress-bento__eyebrow {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--v2-accent-text);
+  font-size: 0.68rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.app-section--progress .progress-bento__grid {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: var(--v2-space-3);
+}
+
+.app-section--progress .progress-bento__adherence,
+.app-section--progress .progress-bento__trend,
+.app-section--progress .progress-bento__journal,
+.app-section--progress .progress-bento__metrics {
+  min-width: 0;
+  border: 1px solid var(--v2-border);
+  border-radius: var(--v2-region-radius);
+}
+
+.app-section--progress .progress-bento__adherence {
+  display: grid;
+  align-content: center;
+  align-self: start;
+  grid-column: span 4;
+  height: fit-content;
+  min-height: 236px;
+  gap: 7px;
+  padding: clamp(20px, 3vw, 30px);
+  background: var(--v2-lime);
+  color: var(--v2-on-lime);
+}
+
+.app-section--progress .progress-bento__adherence .progress-bento__eyebrow {
+  color: var(--v2-on-lime);
+  opacity: 0.72;
+}
+
+.app-section--progress .progress-bento__adherence .progress-summary__score {
+  color: var(--v2-on-lime);
+}
+
+.app-section--progress .progress-bento__adherence strong {
+  max-width: 8ch;
+  font-size: clamp(2.15rem, 4vw, 3.65rem);
+  font-variant-numeric: tabular-nums;
+  line-height: 0.98;
+  letter-spacing: -0.06em;
+}
+
+.app-section--progress .progress-bento__adherence p {
+  max-width: 30ch;
+  margin: 0;
+  color: inherit;
+  font-size: 0.8rem;
+  line-height: 1.45;
+  opacity: 0.78;
+}
+
+.app-section--progress .progress-bento__trend {
+  display: grid;
+  grid-column: span 8;
+  gap: var(--v2-space-3);
+  padding: clamp(16px, 2.5vw, 24px);
+  background: var(--v2-surface-secondary);
+}
+
+.app-section--progress .progress-bento__trend-head > strong {
+  display: grid;
+  justify-items: end;
+  gap: 3px;
+  color: var(--v2-text-primary);
+  font-size: 1.2rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.app-section--progress .progress-bento__trend-head > strong small {
+  color: var(--v2-text-secondary);
+  font-size: 0.72rem;
+  font-weight: 650;
+}
+
+.app-section--progress .progress-bento__trend .data-viz-chart {
+  gap: var(--v2-space-2);
+}
+
+.app-section--progress .progress-bento__trend .data-viz-chart__plot svg {
+  min-height: 170px;
+  max-height: 240px;
+}
+
+.app-section--progress .progress-bento__trend .data-viz-chart__table {
+  max-height: 132px;
+  overflow: auto;
+}
+
+.app-section--progress .progress-bento__trend .data-confidence {
+  margin: 0;
+}
+
+.app-section--progress .progress-bento__metrics {
+  display: grid;
+  grid-column: span 8;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  overflow: hidden;
+  background: var(--v2-surface);
+}
+
+.app-section--progress .progress-bento__metric {
+  display: grid;
+  align-content: start;
+  gap: 5px;
+  min-width: 0;
+  min-height: 120px;
+  padding: 16px;
+  border-right: 1px solid var(--v2-border);
+  border-bottom: 1px solid var(--v2-border);
+}
+
+.app-section--progress .progress-bento__metric:nth-child(2n) {
+  border-right: 0;
+}
+
+.app-section--progress .progress-bento__metric:nth-last-child(-n + 2) {
+  border-bottom: 0;
+}
+
+.app-section--progress .progress-bento__metric dt,
+.app-section--progress .progress-bento__metric small {
+  color: var(--v2-text-secondary);
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.app-section--progress .progress-bento__metric dt {
+  font-weight: 800;
+}
+
+.app-section--progress .progress-bento__metric dd {
+  margin: 0;
+  color: var(--v2-text-primary);
+  font-size: clamp(1.1rem, 2vw, 1.45rem);
+  font-variant-numeric: tabular-nums;
+  font-weight: 900;
+  line-height: 1.05;
+  letter-spacing: -0.035em;
+  overflow-wrap: anywhere;
+}
+
+.app-section--progress .progress-bento__journal {
+  display: grid;
+  grid-column: span 4;
+  align-content: start;
+  gap: var(--v2-space-3);
+  padding: clamp(16px, 2.5vw, 24px);
+  background: var(--v2-surface);
+}
+
+.app-section--progress .progress-bento__journal-count {
+  flex: 0 0 auto;
+  color: var(--v2-text-secondary);
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.app-section--progress .progress-bento__journal ul {
+  display: grid;
+  gap: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.app-section--progress .progress-bento__journal li {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--v2-space-2);
+  padding-block: 10px;
+  border-bottom: 1px solid var(--v2-border);
+}
+
+.app-section--progress .progress-bento__journal li:first-child {
+  padding-top: 0;
+}
+
+.app-section--progress .progress-bento__journal li:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.app-section--progress .progress-bento__journal li span {
+  color: var(--v2-text-secondary);
+  font-size: 0.76rem;
+}
+
+.app-section--progress .progress-bento__journal li strong {
+  color: var(--v2-text-primary);
+  font-size: 0.88rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.app-section--progress .progress-details {
+  display: grid;
+  gap: var(--v2-space-5);
+  min-width: 0;
+}
+
+@media (max-width: 1100px) {
+  .app-section--progress .progress-experience--bento .progress-hero {
+    flex-direction: column;
+    gap: var(--v2-space-3);
+  }
+
+  .app-section--progress .progress-experience--bento .progress-hero__actions {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .app-section--progress .progress-bento__grid {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .app-section--progress .progress-bento__adherence,
+  .app-section--progress .progress-bento__journal {
+    grid-column: span 2;
+  }
+
+  .app-section--progress .progress-bento__trend,
+  .app-section--progress .progress-bento__metrics {
+    grid-column: span 4;
+  }
+}
+
+@media (max-width: 767px) {
+  .app-section--progress .progress-experience--bento .progress-hero {
+    flex-direction: column;
+    gap: var(--v2-space-3);
+  }
+
+  .app-section--progress .progress-experience--bento .progress-hero__actions {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .app-section--progress .progress-period-controls__meta {
+    justify-content: flex-start;
+  }
+
+  .app-section--progress .progress-period-controls__custom {
+    grid-template-columns: 1fr;
+  }
+
+  .app-section--progress .progress-period-controls__custom-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .app-section--progress .progress-period-controls__custom-actions .ui-button {
+    width: 100%;
+  }
+
+  .app-section--progress .progress-bento.progress-summary {
+    padding: var(--v2-space-4);
+    border-radius: var(--v2-region-radius);
+  }
+
+  .app-section--progress .progress-bento__context {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .app-section--progress .progress-bento__context > .ui-badge {
+    justify-self: start;
+    width: fit-content;
+  }
+
+  .app-section--progress .progress-bento__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .app-section--progress .progress-bento__adherence,
+  .app-section--progress .progress-bento__trend,
+  .app-section--progress .progress-bento__metrics,
+  .app-section--progress .progress-bento__journal {
+    grid-column: 1;
+  }
+
+  .app-section--progress .progress-bento__adherence {
+    min-height: 184px;
+  }
+
+  .app-section--progress .progress-bento__metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .app-section--progress .progress-bento__metric,
+  .app-section--progress .progress-bento__metric:nth-child(2n),
+  .app-section--progress .progress-bento__metric:nth-last-child(-n + 2) {
+    border-right: 0;
+    border-bottom: 1px solid var(--v2-border);
+  }
+
+  .app-section--progress .progress-bento__metric:last-child {
+    border-bottom: 0;
+  }
+
+  .app-section--progress .progress-bento__trend-head > strong {
+    font-size: 1rem;
+  }
+}
+
+@media (max-width: 379px) {
+  .app-section--progress .progress-bento.progress-summary {
+    padding: var(--v2-space-3);
+  }
+
+  .app-section--progress .progress-period-controls__custom-actions {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .app-shell--design-v2 *,
   .auth-public-shell--design-v2 * {

--- a/frontend/tests/e2e/progress-experience.spec.ts
+++ b/frontend/tests/e2e/progress-experience.spec.ts
@@ -777,12 +777,12 @@ test('progress remains clear and free of horizontal overflow at supported widths
     .click();
   await expect(
     page
-      .getByRole('heading', { name: 'Прогресс' })
+      .getByRole('heading', { name: 'Прогресс', exact: true })
       .or(page.getByRole('heading', { name: 'Приложение не смогло продолжить работу' })),
   ).toBeVisible();
   expect(consoleErrors).toEqual([]);
   expect(runtimeErrors).toEqual([]);
-  await expect(page.getByRole('heading', { name: 'Прогресс' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Прогресс', exact: true })).toBeVisible();
   await expect(page.getByText('84%').first()).toBeVisible();
 
   await page.getByText('Жим штанги лёжа').click();
@@ -848,6 +848,7 @@ test('shared data confidence keeps analytics factual, responsive and explicit wh
     .click();
 
   const trainingConfidence = page
+    .locator('#progress-training')
     .getByLabel('Достаточно ли данных: Данных достаточно для оценки')
     .first();
   const limitedConfidence = page.getByLabel('Достаточно ли данных: Вывод пока предварительный');
@@ -925,16 +926,16 @@ test('shared data confidence keeps analytics factual, responsive and explicit wh
 
   await page.locator('.progress-hero').getByRole('tab', { name: '7 дней' }).click();
   await refreshStarted;
-  const staleConfidence = page.getByLabel('Достаточно ли данных: Показана сохранённая оценка');
-  await expect(staleConfidence.first()).toBeVisible();
-  await expect(staleConfidence.first()).toContainText('Новые данные загружаются');
+  const loadingState = page.getByRole('status').filter({ hasText: 'Собираем динамику за период' });
+  await expect(loadingState).toBeVisible();
+  await expect(page.getByTestId('progress-bento-overview')).toHaveCount(0);
   await page.setViewportSize({ width: 390, height: 844 });
-  await staleConfidence.first().scrollIntoViewIfNeeded();
+  await loadingState.scrollIntoViewIfNeeded();
   await page.screenshot({
-    path: '../.artifacts/screenshots/task-61/mobile-web-390x844-light-stale.png',
+    path: '../.artifacts/screenshots/task-61/mobile-web-390x844-light-period-loading.png',
   });
   releaseRefresh();
-  await expect(staleConfidence).toHaveCount(0);
+  await expect(page.getByTestId('progress-bento-overview')).toBeVisible();
 });
 
 test('measurements keep priority context, units, mobile order and add/edit history', async ({
@@ -1035,7 +1036,7 @@ test('nutrition report preserves truthful period context, daily drill-down and r
 }) => {
   await page.emulateMedia({ reducedMotion: 'reduce', colorScheme: 'light' });
   await mockProgress(page, 'long');
-  await page.goto('/app?section=progress&nutrition_period=days_7');
+  await page.goto('/app?section=progress&progress_period=days_7');
   await page.getByRole('button', { name: 'Клиент' }).click();
   await page
     .getByRole('navigation', { name: 'Основная навигация' })
@@ -1043,7 +1044,9 @@ test('nutrition report preserves truthful period context, daily drill-down and r
     .click();
 
   const report = page.locator('#nutrition-period-report');
-  const selector = report.getByRole('tablist', { name: 'Период отчёта по питанию' });
+  const selector = page
+    .locator('.progress-period-controls')
+    .getByRole('tablist', { name: 'Период прогресса' });
   await expect(report.getByRole('heading', { name: 'Отчёт по питанию' })).toBeVisible();
   await selector.getByRole('tab', { name: '7 дней' }).click();
   await expect(report.getByText('Заполнено 2 из 7 дней')).toBeVisible();
@@ -1083,14 +1086,14 @@ test('nutrition report preserves truthful period context, daily drill-down and r
       )?.height,
     ).toBeGreaterThanOrEqual(44);
   }
-  await expect(page).toHaveURL(/nutrition_period=days_90/);
+  await expect(page).toHaveURL(/progress_period=days_90/);
   await expect(report.getByText(/Заполнено \d+ из 90 дней/)).toBeVisible();
 
   await selector.getByRole('tab', { name: 'Свой период' }).click();
-  await report.getByLabel('Начало периода').fill('2025-01-01');
-  await report.getByLabel('Конец периода').fill('2025-12-31');
-  await report.getByRole('button', { name: 'Показать период' }).click();
-  await expect(page).toHaveURL(/nutrition_period=custom/);
+  await page.getByLabel('Начало периода').fill('2025-01-01');
+  await page.getByLabel('Конец периода').fill('2025-12-31');
+  await page.getByRole('button', { name: 'Показать период' }).click();
+  await expect(page).toHaveURL(/progress_period=custom/);
   await expect(report.getByText(/Заполнено \d+ из 365 дней/)).toBeVisible();
   const longRangeNavigation = report.getByRole('group', {
     name: 'Навигация по точкам графика',
@@ -1162,37 +1165,39 @@ test('nutrition report preserves truthful period context, daily drill-down and r
       .evaluateAll((tabs) => tabs.map((tab) => tab.getBoundingClientRect().height));
     expect(selectorTargets.every((height) => height >= 44)).toBe(true);
     if (viewport.width <= 430) {
-      const selectorScroller = report.locator('.nutrition-period-report__selector');
+      const selectorScroller = page.locator('.progress-period-controls .ui-tabs');
       const selectorScrollState = await selectorScroller.evaluate((element) => {
         const style = getComputedStyle(element);
         return {
           clientWidth: element.clientWidth,
           overflowX: style.overflowX,
           scrollWidth: element.scrollWidth,
-          touchAction: style.touchAction,
         };
       });
-      expect(selectorScrollState.scrollWidth).toBeGreaterThan(selectorScrollState.clientWidth);
+      expect(selectorScrollState.scrollWidth).toBeGreaterThanOrEqual(
+        selectorScrollState.clientWidth,
+      );
       expect(selectorScrollState.overflowX).toBe('auto');
-      expect(selectorScrollState.touchAction).toBe('pan-x');
-      await selectorScroller.evaluate((element) => {
-        element.scrollLeft = element.scrollWidth;
-      });
-      await expect
-        .poll(() => selectorScroller.evaluate((element) => element.scrollLeft))
-        .toBeGreaterThan(0);
-      expect(
-        await selector.getByRole('tab', { name: 'Свой период' }).evaluate((tab) => {
-          const scroller = tab.closest('.nutrition-period-report__selector');
-          if (!scroller) return false;
-          const tabBox = tab.getBoundingClientRect();
-          const scrollerBox = scroller.getBoundingClientRect();
-          return tabBox.left >= scrollerBox.left && tabBox.right <= scrollerBox.right;
-        }),
-      ).toBe(true);
-      await selectorScroller.evaluate((element) => {
-        element.scrollLeft = 0;
-      });
+      if (selectorScrollState.scrollWidth > selectorScrollState.clientWidth) {
+        await selectorScroller.evaluate((element) => {
+          element.scrollLeft = element.scrollWidth;
+        });
+        await expect
+          .poll(() => selectorScroller.evaluate((element) => element.scrollLeft))
+          .toBeGreaterThan(0);
+        expect(
+          await selector.getByRole('tab', { name: 'Свой период' }).evaluate((tab) => {
+            const scroller = tab.closest('.progress-period-controls .ui-tabs');
+            if (!scroller) return false;
+            const tabBox = tab.getBoundingClientRect();
+            const scrollerBox = scroller.getBoundingClientRect();
+            return tabBox.left >= scrollerBox.left && tabBox.right <= scrollerBox.right;
+          }),
+        ).toBe(true);
+        await selectorScroller.evaluate((element) => {
+          element.scrollLeft = 0;
+        });
+      }
     }
     const reportBox = await report.boundingBox();
     const nextSectionBox = await page.locator('.progress-adherence').boundingBox();
@@ -1255,7 +1260,7 @@ test('nutrition report no-data state keeps missing days distinct from zero', asy
   await page.setViewportSize({ width: 430, height: 932 });
   await page.emulateMedia({ reducedMotion: 'reduce', colorScheme: 'light' });
   await mockProgress(page, 'no-data');
-  await page.goto('/app?section=progress&nutrition_period=days_30');
+  await page.goto('/app?section=progress&progress_period=days_30');
   await page.getByRole('button', { name: 'Клиент' }).click();
   await page
     .getByRole('navigation', { name: 'Основная навигация' })
@@ -1286,7 +1291,7 @@ test('notification deep-link opens exact workout feedback and preserves back nav
   await expect(page.getByRole('heading', { name: /^Сегодня ·/ })).toBeVisible();
   await page.goto('/app?workout_id=43&comment_id=7&workout_exercise_id=55');
 
-  await expect(page.getByRole('heading', { name: 'Прогресс' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Прогресс', exact: true })).toBeVisible();
   await expect(
     page.getByText('Держите колени по направлению носков.', { exact: false }),
   ).toBeVisible();
@@ -1362,7 +1367,7 @@ test('notification deep-link opens exact workout feedback and preserves back nav
   await expect(page.getByRole('heading', { name: /^Сегодня ·/ })).toBeVisible();
 });
 
-test('dark progress uses one lime accent for the adherence outcome', async ({ page }) => {
+test('dark progress keeps the bento adherence score readable on lime', async ({ page }) => {
   await page.addInitScript(() => localStorage.setItem('app-theme', 'dark'));
   await mockProgress(page);
   await page.goto('/app?section=progress');
@@ -1372,13 +1377,15 @@ test('dark progress uses one lime accent for the adherence outcome', async ({ pa
     .getByRole('link', { name: 'Прогресс' })
     .click();
 
-  const summaryScore = page.locator('.progress-summary__score');
+  const summaryScore = page.locator('.progress-bento__adherence .progress-summary__score');
   const adherenceScore = page.locator('.progress-adherence__score');
   await expect(summaryScore).toHaveText('84%');
   await expect(adherenceScore).toHaveText('84%');
 
   const colors = await page.evaluate(() => ({
-    summary: getComputedStyle(document.querySelector('.progress-summary__score')!).color,
+    summary: getComputedStyle(
+      document.querySelector('.progress-bento__adherence .progress-summary__score')!,
+    ).color,
     adherence: getComputedStyle(document.querySelector('.progress-adherence__score')!).color,
     accent: (() => {
       const probe = document.createElement('span');
@@ -1389,11 +1396,11 @@ test('dark progress uses one lime accent for the adherence outcome', async ({ pa
       return color;
     })(),
   }));
-  expect(colors.summary).toBe(colors.adherence);
-  expect(colors.summary).toBe(colors.accent);
+  expect(colors.summary).not.toBe(colors.accent);
+  expect(colors.adherence).toBe(colors.accent);
 });
 
-test('light progress uses the restrained green accent for the adherence outcome', async ({
+test('light progress keeps the bento adherence score readable on lime', async ({
   page,
 }) => {
   await page.addInitScript(() => localStorage.setItem('app-theme', 'light'));
@@ -1405,13 +1412,15 @@ test('light progress uses the restrained green accent for the adherence outcome'
     .getByRole('link', { name: 'Прогресс' })
     .click();
 
-  const summaryScore = page.locator('.progress-summary__score');
+  const summaryScore = page.locator('.progress-bento__adherence .progress-summary__score');
   const adherenceScore = page.locator('.progress-adherence__score');
   await expect(summaryScore).toHaveText('84%');
   await expect(adherenceScore).toHaveText('84%');
 
   const colors = await page.evaluate(() => ({
-    summary: getComputedStyle(document.querySelector('.progress-summary__score')!).color,
+    summary: getComputedStyle(
+      document.querySelector('.progress-bento__adherence .progress-summary__score')!,
+    ).color,
     adherence: getComputedStyle(document.querySelector('.progress-adherence__score')!).color,
     accent: (() => {
       const probe = document.createElement('span');
@@ -1422,8 +1431,8 @@ test('light progress uses the restrained green accent for the adherence outcome'
       return color;
     })(),
   }));
-  expect(colors.summary).toBe(colors.adherence);
-  expect(colors.summary).toBe(colors.accent);
+  expect(colors.summary).not.toBe(colors.accent);
+  expect(colors.adherence).toBe(colors.accent);
 });
 
 test('canonical charts and icons remain operable in forced colors and reduced motion', async ({
@@ -1502,4 +1511,123 @@ test('exercise catalogue uses the selected folder and dumbbell glyph on desktop 
     path: '../.artifacts/screenshots/task-69b/exercise-catalog-mobile-dark.png',
   });
   expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(390);
+});
+
+test('progress bento keeps matching light and dark visual forms for the same data', async ({
+  browser,
+}) => {
+  test.setTimeout(120_000);
+  const surfaces = [
+    { name: 'desktop-1440x900', width: 1440, height: 900 },
+    { name: 'desktop-1280x900', width: 1280, height: 900 },
+    { name: 'tablet-1024x900', width: 1024, height: 900 },
+    { name: 'tablet-768x900', width: 768, height: 900 },
+    { name: 'mobile-430x932', width: 430, height: 932 },
+    { name: 'mobile-390x844', width: 390, height: 844 },
+    { name: 'mobile-360x800', width: 360, height: 800 },
+  ];
+
+  for (const surface of surfaces) {
+    for (const theme of ['light', 'dark'] as const) {
+      const context = await browser.newContext({
+        baseURL: 'http://127.0.0.1:4173',
+        colorScheme: theme,
+        viewport: { width: 1440, height: 900 },
+      });
+      await context.addInitScript((selectedTheme) => {
+        localStorage.setItem('app-theme', selectedTheme);
+      }, theme);
+      await context.addInitScript(() => {
+        const RealDate = globalThis.Date;
+        const fixedNow = RealDate.parse('2030-01-30T12:00:00Z');
+        globalThis.Date = class extends RealDate {
+          constructor(value?: string | number | Date) {
+            super(value ?? fixedNow);
+          }
+
+          static now() {
+            return fixedNow;
+          }
+        } as DateConstructor;
+      });
+      const page = await context.newPage();
+      await page.emulateMedia({ colorScheme: theme, reducedMotion: 'reduce' });
+      await mockProgress(page);
+      await page.goto('/app?section=progress&progress_period=days_30');
+      await page.getByRole('button', { name: 'Клиент' }).click();
+      await page
+        .getByRole('navigation', { name: 'Основная навигация' })
+        .getByRole('link', { name: 'Прогресс' })
+        .click();
+      await page.locator('.progress-period-controls').getByRole('tab', { name: '30 дней' }).click();
+      await page.setViewportSize({ width: surface.width, height: surface.height });
+
+      await expect(page.getByRole('heading', { name: 'Прогресс', exact: true })).toBeVisible();
+      await expect(page.getByTestId('progress-bento-overview')).toBeVisible();
+      await expect(page.locator('html')).toHaveAttribute('data-color-scheme', theme);
+      await expect(
+        page.locator('.progress-period-controls').getByRole('tab', { name: '30 дней' }),
+      ).toHaveAttribute('aria-selected', 'true');
+      expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(
+        surface.width,
+      );
+      await page.screenshot({
+        path: `../.artifacts/screenshots/task-111/progress-bento-${surface.name}-${theme}.png`,
+      });
+      await context.close();
+    }
+  }
+});
+
+test('progress period controls drive one exact URL and API range through history', async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 430, height: 932 });
+  await page.emulateMedia({ colorScheme: 'light', reducedMotion: 'reduce' });
+  await mockProgress(page);
+  const requests: string[] = [];
+  page.on('request', (request) => {
+    const url = new URL(request.url());
+    if (/\/workouts\/progress\/(summary|training-analytics|nutrition-report)$/.test(url.pathname)) {
+      requests.push(`${url.pathname}${url.search}`);
+    }
+  });
+
+  await page.goto('/app?section=progress&progress_period=days_30');
+  await page.getByRole('button', { name: 'Клиент' }).click();
+  await page
+    .getByRole('navigation', { name: 'Основная навигация' })
+    .getByRole('link', { name: 'Прогресс' })
+    .click();
+  const controls = page.locator('.progress-period-controls');
+  await expect(controls.getByRole('tab')).toHaveCount(4);
+  await controls.getByRole('tab', { name: '30 дней' }).click();
+  await expect(page.getByTestId('progress-bento-overview')).toBeVisible();
+
+  for (const period of [7, 30, 90] as const) {
+    const label = `${period} дней`;
+    await controls.getByRole('tab', { name: label }).click();
+    await expect(page).toHaveURL(new RegExp(`progress_period=days_${period}(?:&|$)`));
+    await expect(controls.getByRole('tab', { name: label })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    await expect(page.getByTestId('progress-bento-overview')).toBeVisible();
+  }
+
+  await controls.getByRole('tab', { name: 'Свой период' }).click();
+  await page.getByLabel('Начало периода').fill('2025-01-01');
+  await page.getByLabel('Конец периода').fill('2025-01-30');
+  await page.getByRole('button', { name: 'Показать период' }).click();
+  await expect(page).toHaveURL(/progress_period=custom/);
+  await expect(page).toHaveURL(/progress_from=2025-01-01/);
+  await expect(page).toHaveURL(/progress_to=2025-01-30/);
+  expect(requests.some((request) => request.includes('date_from=2025-01-01'))).toBe(true);
+  expect(requests.some((request) => request.includes('date_to=2025-01-30'))).toBe(true);
+
+  await page.goBack();
+  await expect(page).toHaveURL(/progress_period=days_90/);
+  await page.goForward();
+  await expect(page).toHaveURL(/progress_period=custom/);
+  await expect(page.getByTestId('progress-bento-overview')).toBeVisible();
 });

--- a/frontend/tests/e2e/progress-experience.spec.ts
+++ b/frontend/tests/e2e/progress-experience.spec.ts
@@ -924,11 +924,12 @@ test('shared data confidence keeps analytics factual, responsive and explicit wh
     path: '../.artifacts/screenshots/task-61/mobile-web-360x800-light-analytics.png',
   });
 
+  await expect(page.getByTestId('progress-bento-overview')).toBeVisible();
   await page.locator('.progress-hero').getByRole('tab', { name: '7 дней' }).click();
   await refreshStarted;
-  const loadingState = page.getByRole('status').filter({ hasText: 'Собираем динамику за период' });
+  const loadingState = page.getByRole('status').filter({ hasText: 'Обновляем динамику за период' });
   await expect(loadingState).toBeVisible();
-  await expect(page.getByTestId('progress-bento-overview')).toHaveCount(0);
+  await expect(page.getByTestId('progress-bento-overview')).toBeVisible();
   await page.setViewportSize({ width: 390, height: 844 });
   await loadingState.scrollIntoViewIfNeeded();
   await page.screenshot({
@@ -1179,12 +1180,7 @@ test('nutrition report preserves truthful period context, daily drill-down and r
       );
       expect(selectorScrollState.overflowX).toBe('auto');
       if (selectorScrollState.scrollWidth > selectorScrollState.clientWidth) {
-        await selectorScroller.evaluate((element) => {
-          element.scrollLeft = element.scrollWidth;
-        });
-        await expect
-          .poll(() => selectorScroller.evaluate((element) => element.scrollLeft))
-          .toBeGreaterThan(0);
+        await selector.getByRole('tab', { name: 'Свой период' }).scrollIntoViewIfNeeded();
         expect(
           await selector.getByRole('tab', { name: 'Свой период' }).evaluate((tab) => {
             const scroller = tab.closest('.progress-period-controls .ui-tabs');
@@ -1194,9 +1190,6 @@ test('nutrition report preserves truthful period context, daily drill-down and r
             return tabBox.left >= scrollerBox.left && tabBox.right <= scrollerBox.right;
           }),
         ).toBe(true);
-        await selectorScroller.evaluate((element) => {
-          element.scrollLeft = 0;
-        });
       }
     }
     const reportBox = await report.boundingBox();

--- a/frontend/tests/e2e/progress-experience.spec.ts
+++ b/frontend/tests/e2e/progress-experience.spec.ts
@@ -1400,9 +1400,7 @@ test('dark progress keeps the bento adherence score readable on lime', async ({ 
   expect(colors.adherence).toBe(colors.accent);
 });
 
-test('light progress keeps the bento adherence score readable on lime', async ({
-  page,
-}) => {
+test('light progress keeps the bento adherence score readable on lime', async ({ page }) => {
   await page.addInitScript(() => localStorage.setItem('app-theme', 'light'));
   await mockProgress(page);
   await page.goto('/app?section=progress');
@@ -1568,9 +1566,7 @@ test('progress bento keeps matching light and dark visual forms for the same dat
       await expect(
         page.locator('.progress-period-controls').getByRole('tab', { name: '30 дней' }),
       ).toHaveAttribute('aria-selected', 'true');
-      expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(
-        surface.width,
-      );
+      expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(surface.width);
       await page.screenshot({
         path: `../.artifacts/screenshots/task-111/progress-bento-${surface.name}-${theme}.png`,
       });

--- a/frontend/tests/e2e/progress-experience.spec.ts
+++ b/frontend/tests/e2e/progress-experience.spec.ts
@@ -1179,21 +1179,21 @@ test('nutrition report preserves truthful period context, daily drill-down and r
         selectorScrollState.clientWidth,
       );
       expect(selectorScrollState.overflowX).toBe('auto');
-      if (selectorScrollState.scrollWidth > selectorScrollState.clientWidth) {
-        await selector.getByRole('tab', { name: 'Свой период' }).scrollIntoViewIfNeeded();
-        expect(
-          await selector.getByRole('tab', { name: 'Свой период' }).evaluate((tab) => {
-            const scroller = tab.closest('.progress-period-controls .ui-tabs');
-            if (!scroller) return false;
-            const tabBox = tab.getBoundingClientRect();
-            const scrollerBox = scroller.getBoundingClientRect();
-            return tabBox.left >= scrollerBox.left && tabBox.right <= scrollerBox.right;
-          }),
-        ).toBe(true);
-      }
     }
+    const nextSection = page.locator('.progress-adherence');
+    await expect
+      .poll(async () => {
+        const [reportBox, nextSectionBox] = await Promise.all([
+          report.boundingBox(),
+          nextSection.boundingBox(),
+        ]);
+        return Boolean(
+          reportBox && nextSectionBox && reportBox.y + reportBox.height <= nextSectionBox.y + 1,
+        );
+      })
+      .toBe(true);
     const reportBox = await report.boundingBox();
-    const nextSectionBox = await page.locator('.progress-adherence').boundingBox();
+    const nextSectionBox = await nextSection.boundingBox();
     expect(reportBox).not.toBeNull();
     expect(nextSectionBox).not.toBeNull();
     expect(reportBox!.y + reportBox!.height).toBeLessThanOrEqual(nextSectionBox!.y + 1);

--- a/frontend/tests/e2e/pulse-concepts-pilot.spec.ts
+++ b/frontend/tests/e2e/pulse-concepts-pilot.spec.ts
@@ -320,7 +320,7 @@ test('frequent current action feedback is interruptible, repeatable and reduced-
   ).toBe(0);
 });
 
-test('weight insight keeps smooth truthful geometry, area fill and measurement alternative', async ({
+test('weight bento trend keeps smooth truthful geometry, area fill and measurement alternative', async ({
   page,
 }) => {
   await page.setViewportSize({ width: 390, height: 844 });
@@ -330,11 +330,10 @@ test('weight insight keeps smooth truthful geometry, area fill and measurement a
     workoutStatus: 'completed',
   });
   await page.goto('/app?section=progress');
-  const insight = page.locator('.progress-body-metric--data-insight');
+  const insight = page.getByTestId('progress-bento-overview').locator('.progress-bento__trend');
   await insight.scrollIntoViewIfNeeded();
   const chart = insight.locator('.data-viz-chart');
   await expect(chart).toBeVisible();
-  await expect(insight.locator('.ui-semantic-artwork--data-insight')).toHaveCount(1);
   await expect(chart.locator('.data-viz-chart__area')).toHaveCount(1);
   await expect(chart.getByRole('table', { name: /Вес/ })).toBeAttached();
   const lineContract = await chart.locator('.data-viz-chart__actual').evaluate((line) => ({
@@ -346,28 +345,11 @@ test('weight insight keeps smooth truthful geometry, area fill and measurement a
   expect(lineContract.caps).toBe('round');
   expect(lineContract.joins).toBe('round');
   expect(lineContract.path).toContain(' C ');
-  expect(lineContract.width).toBeGreaterThanOrEqual(4);
-  const insightImpact = await insight.evaluate((element) => {
-    const surface = getComputedStyle(element);
-    const artwork = getComputedStyle(
-      element.querySelector<HTMLElement>('.ui-semantic-artwork--data-insight')!,
-    );
-    const areaStart = getComputedStyle(
-      element.querySelector<SVGStopElement>('.data-viz-chart__area-start')!,
-    );
-    return {
-      areaOpacity: Number.parseFloat(areaStart.stopOpacity),
-      artworkOpacity: Number.parseFloat(artwork.opacity),
-      artworkWidth: Number.parseFloat(artwork.width),
-      background: surface.backgroundImage,
-      borderLeftWidth: Number.parseFloat(surface.borderLeftWidth),
-    };
-  });
-  expect(insightImpact.areaOpacity).toBeGreaterThanOrEqual(0.45);
-  expect(insightImpact.artworkOpacity).toBeGreaterThanOrEqual(0.8);
-  expect(insightImpact.artworkWidth).toBeGreaterThanOrEqual(230);
-  expect(insightImpact.borderLeftWidth).toBeGreaterThanOrEqual(7);
-  expect(insightImpact.background).toContain('radial-gradient');
+  expect(lineContract.width).toBeGreaterThanOrEqual(2.5);
+  const areaOpacity = await chart
+    .locator('.data-viz-chart__area-start')
+    .evaluate((stop) => Number.parseFloat(getComputedStyle(stop).stopOpacity));
+  expect(areaOpacity).toBeGreaterThanOrEqual(0.28);
   await expect(chart).toHaveAttribute('data-motion-phase', 'idle');
   await expectNoHorizontalOverflow(page);
   await expectNoOverlap(chart, page.locator('#appBottomNav'));
@@ -390,7 +372,9 @@ test('weight insight keeps smooth truthful geometry, area fill and measurement a
 
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto('/app?section=progress');
-  const desktopInsight = page.locator('.progress-body-metric--data-insight');
+  const desktopInsight = page
+    .getByTestId('progress-bento-overview')
+    .locator('.progress-bento__trend');
   await desktopInsight.scrollIntoViewIfNeeded();
   await expect(desktopInsight.locator('.data-viz-chart__area')).toHaveCount(1);
   if (capture) {
@@ -411,7 +395,7 @@ test('mocked TMA dark uses the same chart and safe-area floating dock', async ({
   await installPlatformApi(page, { measurementHistory: 'many', workoutStatus: 'completed' });
   await page.goto('/app?section=progress');
   const dock = page.locator('#appBottomNav');
-  const insight = page.locator('.progress-body-metric--data-insight');
+  const insight = page.getByTestId('progress-bento-overview').locator('.progress-bento__trend');
   await insight.scrollIntoViewIfNeeded();
   await expect(page.locator('html')).toHaveAttribute('data-color-scheme', 'dark');
   await expect(insight.locator('.data-viz-chart__area')).toHaveCount(1);

--- a/frontend/tests/e2e/tma-smoke.spec.ts
+++ b/frontend/tests/e2e/tma-smoke.spec.ts
@@ -832,8 +832,8 @@ test('nutrition report keeps period analytics and diary return aligned in Mobile
   const tmaApi = await installPlatformApi(tmaPage);
   const mobileApi = await installPlatformApi(mobilePage, { browserSession: true });
   await Promise.all([
-    tmaPage.goto('/app?section=progress&nutrition_period=days_7'),
-    mobilePage.goto('/app?section=progress&nutrition_period=days_7'),
+    tmaPage.goto('/app?section=progress&progress_period=days_7'),
+    mobilePage.goto('/app?section=progress&progress_period=days_7'),
   ]);
 
   for (const currentPage of [tmaPage, mobilePage]) {
@@ -850,10 +850,8 @@ test('nutrition report keeps period analytics and diary return aligned in Mobile
   expect(await sharedSurfaceSignature(tmaPage)).toEqual(await sharedSurfaceSignature(mobilePage));
 
   const tmaReport = tmaPage.locator('#nutrition-period-report');
-  const tmaSelector = tmaReport.getByRole('tablist', { name: 'Период отчёта по питанию' });
-  const mobileSelector = mobilePage
-    .locator('#nutrition-period-report')
-    .getByRole('tablist', { name: 'Период отчёта по питанию' });
+  const tmaSelector = tmaPage.getByRole('tablist', { name: 'Период прогресса' });
+  const mobileSelector = mobilePage.getByRole('tablist', { name: 'Период прогресса' });
   for (const period of ['30 дней', '90 дней', '7 дней']) {
     await Promise.all([
       tmaSelector.getByRole('tab', { name: period }).click(),
@@ -915,7 +913,7 @@ test('nutrition report keeps period analytics and diary return aligned in Mobile
   await expect(tmaPage).toHaveURL(/section=nutrition&date=.*return_to=/);
   await expect(tmaPage.getByRole('heading', { name: 'Питание', exact: true })).toBeVisible();
   await tmaPage.getByRole('link', { name: 'К отчёту по питанию' }).click();
-  await expect(tmaPage).toHaveURL(/section=progress&nutrition_period=days_7/);
+  await expect(tmaPage).toHaveURL(/section=progress&progress_period=days_7/);
   await expect(tmaSelector.getByRole('tab', { name: '7 дней' })).toHaveAttribute(
     'aria-selected',
     'true',

--- a/frontend/tests/unit/features/workouts/progressPeriods.test.ts
+++ b/frontend/tests/unit/features/workouts/progressPeriods.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  inclusiveDays,
+  nutritionPeriodForProgress,
+  parseProgressSelection,
+  progressApiQuery,
+  progressPath,
+  progressPeriodOptions,
+  progressReportPath,
+  selectionDateRange,
+  validateCustomProgressRange,
+} from '../../../../src/features/workouts/progressPeriods';
+
+describe('progress period contract', () => {
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/app?section=progress');
+  });
+
+  it('normalizes supported preset aliases and keeps exact inclusive ranges', () => {
+    expect(progressPeriodOptions.map((option) => option.label)).toEqual([
+      '7 дней',
+      '30 дней',
+      '90 дней',
+      'Свой период',
+    ]);
+    expect(parseProgressSelection('?progress_period=days_1')).toEqual({
+      kind: 'preset',
+      days: 30,
+    });
+    expect(parseProgressSelection('?period=year')).toEqual({ kind: 'preset', days: 30 });
+    expect(selectionDateRange({ kind: 'preset', days: 7 }, '2026-09-02')).toEqual({
+      dateFrom: '2026-08-27',
+      dateTo: '2026-09-02',
+    });
+    expect(selectionDateRange({ kind: 'preset', days: 90 }, '2026-09-02')).toEqual({
+      dateFrom: '2026-06-05',
+      dateTo: '2026-09-02',
+    });
+    expect(progressApiQuery({ kind: 'preset', days: 7 })).toBe('?period_days=7');
+    expect(nutritionPeriodForProgress({ kind: 'preset', days: 90 })).toEqual({
+      period: 'days_90',
+      dateFrom: '',
+      dateTo: '',
+    });
+  });
+
+  it('keeps custom dates in dashboard, API and report links', () => {
+    const selection = { kind: 'custom' as const, dateFrom: '2024-02-29', dateTo: '2024-03-01' };
+    expect(
+      parseProgressSelection(
+        '?progress_period=custom&progress_from=2024-02-29&progress_to=2024-03-01',
+      ),
+    ).toEqual(selection);
+    expect(inclusiveDays(selection.dateFrom, selection.dateTo)).toBe(2);
+    expect(progressApiQuery(selection)).toBe('?date_from=2024-02-29&date_to=2024-03-01');
+    expect(progressReportPath(selection)).toBe(
+      '/app/report?period=custom&date_from=2024-02-29&date_to=2024-03-01',
+    );
+    expect(
+      progressPath(
+        '?section=progress&progress_period=days_30&period=custom&nutrition_period=days_30&progress_from=old&date_from=old',
+        selection,
+      ),
+    ).toBe(
+      '/app?section=progress&progress_period=custom&progress_from=2024-02-29&progress_to=2024-03-01',
+    );
+  });
+
+  it('validates empty, reversed, oversized and future custom ranges', () => {
+    expect(validateCustomProgressRange('', '', '2026-09-02')).toBe(
+      'Укажите дату начала и окончания.',
+    );
+    expect(validateCustomProgressRange('2026-09-03', '2026-09-02', '2026-09-02')).toBe(
+      'Дата окончания не может быть раньше даты начала.',
+    );
+    expect(validateCustomProgressRange('2025-09-02', '2026-09-02', '2026-09-02')).toBeNull();
+    expect(validateCustomProgressRange('2025-09-02', '2026-09-03', '2026-09-02')).toBe(
+      'Период не может превышать 366 дней.',
+    );
+    expect(validateCustomProgressRange('2026-09-01', '2026-09-03', '2026-09-02')).toBe(
+      'Нельзя выбрать будущую дату.',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add the factual progress bento overview and shared inclusive period bounds
- keep progress controls to 7/30/90 days plus a custom range
- compact the desktop plan-rhythm card and cover light/dark responsive forms

## Verification
- backend focused pytest: 19 passed
- frontend focused unit: 13 passed
- progress Playwright spec: 12 passed
- frontend build, typecheck, lint; Ruff and targeted mypy passed
- browser/mock-TMA screenshots: 14 captures across 7 viewports and both themes

Production deploy is intentionally handled only after this PR is merged and the exact merged master CI is green.