### PR TITLE
[Task 134] Stabilize Playwright E2E contracts and remove stale UI test debt

### DIFF
--- a/docs/mobile-tma-quality-gate.md
+++ b/docs/mobile-tma-quality-gate.md
@@ -44,6 +44,49 @@ Playwright harness задаёт `360x800`, `390x844` и `430x932`, настоя�
 fixed/sticky UI с action/content. Network helper переключает offline/reconnect на уровне browser
 context; feature API mock может одновременно моделировать отказ только backend-запросов.
 
+## Playwright E2E contract
+
+Этот раздел является общим контрактом для `frontend/tests/e2e/**` и применяется вместе с
+требованиями конкретного сценария. Он не меняет продуктовую семантику и не разрешает добавлять
+production hooks только ради удобства теста.
+
+### Локаторы и assertions
+
+1. Сначала используется доступная семантика: role и accessible name, затем scoped landmark,
+   dialog, section, form или card. Повторяемый сценарий выносит такой scope в helper с явным
+   именем, а не скрывает глобальный поиск.
+2. `.first()`, `.last()`, `.nth()` и positional/CSS selectors допустимы только когда тест сначала
+   фиксирует cardinality или связывает элемент с активным продуктовым идентификатором, именем,
+   ролью, состоянием (`aria-current`, `aria-selected`) либо иным действующим инвариантом.
+   Исторический порядок DOM сам по себе инвариантом не является.
+3. `data-testid` добавляется только если действующий role/name и scoped semantic locator не могут
+   выразить контракт. Ненужный production hook удаляется после миграции потребителей на семантику.
+4. `toHaveCSS` и bounding-box assertions описывают только действующий visual/platform contract:
+   active design source, touch target, overflow, safe area, keyboard/fixed/sticky overlap или
+   доказуемую responsive order. Цвет, размер, radius, `position` и DOM-порядок без такой опоры не
+   являются regression contract.
+5. Ожидания должны быть event-, response-, state- или assertion-driven. `waitForTimeout`,
+   произвольные sleeps, увеличенные retries/timeouts, `skip`/`fixme` и обход strict locator
+   errors не используются для закрытия регрессии. Внешний runtime prerequisite остаётся
+   отдельным явно обозначенным lane и не считается PASS обычного smoke.
+
+### Lanes и evidence
+
+- `npm run e2e:ci` — authoritative Chromium suite; в CI он выполняется тремя shards и включает
+  `tma-smoke.spec.ts` и `demo-mode.spec.ts`.
+- `npm run e2e:migrated-stack` — отдельный authoritative Chromium lane с FastAPI и PostgreSQL;
+  он проверяет реальный browser/API/database path и не заменяется route mock.
+- `playwright.cross-browser.config.ts` — дополнительный локальный Chromium/Firefox/WebKit lane;
+  он не является CI gate, пока не подключён отдельной job.
+- `csp-theme-bootstrap.spec.ts` требует `YFC_FASTAPI_ORIGIN=1`; без поднятого FastAPI это
+  отдельный неисполненный prerequisite, а не успешная проверка.
+- Owner-checkpoint screenshot scenarios (`YFC_CAPTURE_*`) — opt-in visual evidence и не входят в
+  regression count без соответствующего флага. Их `skip` не должен скрывать поведенческий тест.
+
+В итоговом отчёте automated Mobile Web, mocked TMA, migrated real browser/API stack, real Telegram
+и physical-device evidence перечисляются раздельно. Browser/mock результат никогда не выдаётся за
+доказательство реального Telegram client или физического устройства.
+
 ## Что фиксирует continuous smoke
 
 `tma-smoke.spec.ts` проверяет без дублирования больших feature suites:

--- a/frontend/src/features/workouts/ProgressExperience.tsx
+++ b/frontend/src/features/workouts/ProgressExperience.tsx
@@ -191,7 +191,6 @@ function SummaryOverview({ summary }: { summary: ProgressSummary }) {
       className="progress-summary progress-bento semantic-card semantic-card--summary semantic-card--progress"
       data-card-variant="summary"
       data-semantic-family="progress"
-      data-testid="progress-bento-overview"
       aria-labelledby="progress-overview-title"
     >
       <div className="progress-bento__context">

--- a/frontend/tests/e2e/app.spec.ts
+++ b/frontend/tests/e2e/app.spec.ts
@@ -1,15 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
+import { nutritionDaySummary, openDetailsByHeading as openCard } from './fixtures/locators';
 import { emptyHydrationDay } from './fixtures/platform-api';
-
-async function openCard(page: Page, title: string) {
-  const card = page
-    .getByRole('heading', { name: title, exact: true })
-    .locator('xpath=ancestor::details[1]');
-  if ((await card.getAttribute('open')) === null) {
-    await card.locator(':scope > summary').click();
-  }
-  await expect(card).toHaveAttribute('open');
-}
 
 type AppDestination = 'Сегодня' | 'Программа' | 'Прогресс' | 'Питание' | 'Упражнения' | 'Профиль';
 
@@ -152,7 +143,9 @@ test('первый экран лендинга объясняет продукт
     await page.goto('/');
 
     await expect(page.getByRole('heading', { name: /знайте, что делать сегодня/i })).toBeVisible();
-    await expect(page.getByRole('link', { name: /открыть приложение/i }).first()).toBeVisible();
+    await expect(
+      page.locator('.landing-hero__actions').getByRole('link', { name: /открыть приложение/i }),
+    ).toBeVisible();
     const heroProof = page.locator('.landing-hero-device');
     await expect(
       heroProof.getByRole('img', { name: /актуальный экран сегодня.*силовой тренировки/i }),
@@ -205,7 +198,9 @@ test('лендинг остаётся адаптивным на контроль
     }));
     expect(pageMetrics.documentWidth).toBeLessThanOrEqual(pageMetrics.viewport);
     expect(pageMetrics.bodyWidth).toBeLessThanOrEqual(pageMetrics.viewport);
-    await expect(page.getByRole('link', { name: /открыть приложение/i }).first()).toBeVisible();
+    await expect(
+      page.locator('.landing-hero__actions').getByRole('link', { name: /открыть приложение/i }),
+    ).toBeVisible();
     await expect(page.getByRole('button', { name: /Включить .* тему/ })).toBeInViewport();
     await expect(page.locator('.landing-continuity__rail')).toBeVisible();
   }
@@ -310,11 +305,12 @@ test('сценарии спортсмена и тренера ведут в ве
       'href',
       '/for-trainers',
     );
-    await expect(page.getByText(/тренера (можно )?подключи(ть|те) позже/i).first()).toBeVisible();
-    await expect(page.getByRole('link', { name: /открыть приложение/i }).last()).toHaveAttribute(
-      'href',
-      '/app',
-    );
+    await expect(
+      page.locator('.landing-core__self').getByText(/тренера (можно )?подключи(ть|те) позже/i),
+    ).toBeVisible();
+    await expect(
+      page.locator('.landing-contact__actions').getByRole('link', { name: /открыть приложение/i }),
+    ).toHaveAttribute('href', '/app');
     await expect(
       page.locator('.landing-contact').getByRole('link', { name: /попробовать демо/i }),
     ).toHaveAttribute('href', '/demo?cabinet=1&scenario=self_training&section=today');
@@ -326,12 +322,12 @@ test('сценарии спортсмена и тренера ведут в ве
     const contactButtons = page.locator('.landing-contact__actions .landing-button');
     for (const buttons of [heroButtons, contactButtons]) {
       await expect(buttons).toHaveCount(2);
-      const first = await buttons.first().boundingBox();
-      const second = await buttons.last().boundingBox();
-      expect(first).not.toBeNull();
-      expect(second).not.toBeNull();
-      expect(first!.height).toBe(second!.height);
-      if (viewport.width === 390) expect(first!.width).toBeCloseTo(second!.width, 0);
+      const boxes = await Promise.all((await buttons.all()).map((button) => button.boundingBox()));
+      expect(boxes).toHaveLength(2);
+      expect(boxes[0]).not.toBeNull();
+      expect(boxes[1]).not.toBeNull();
+      expect(boxes[0]!.height).toBe(boxes[1]!.height);
+      if (viewport.width === 390) expect(boxes[0]!.width).toBeCloseTo(boxes[1]!.width, 0);
     }
     const featureCards = page.locator('.landing-core__features article');
     await expect(featureCards).toHaveCount(3);
@@ -346,7 +342,9 @@ test('сценарии спортсмена и тренера ведут в ве
     }
     expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBe(viewport.width);
     if (viewport.width === 390) {
-      await expect(page.locator('.landing-footer p').first()).toBeVisible();
+      const footerTagline = page.locator('.landing-footer__brand > p');
+      await expect(footerTagline).toHaveCount(1);
+      await expect(footerTagline).toBeVisible();
     }
   }
 });
@@ -2544,9 +2542,8 @@ test('поля адаптируются к разным iPhone, а пример 
   );
 
   await openAppDestination(page, 'Питание');
-  await expect(
-    page.locator('.nutrition-day-summary').getByRole('heading', { name: 'КБЖУ' }),
-  ).toBeVisible();
+  await expect(nutritionDaySummary(page)).toHaveCount(1);
+  await expect(nutritionDaySummary(page)).toBeVisible();
   expect(
     await page.evaluate(() => ({
       viewport: document.documentElement.clientWidth,

--- a/frontend/tests/e2e/fixtures/locators.ts
+++ b/frontend/tests/e2e/fixtures/locators.ts
@@ -1,0 +1,37 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export function detailsByHeading(page: Page, title: string): Locator {
+  return page.locator('details').filter({
+    has: page.getByRole('heading', { name: title, exact: true }),
+  });
+}
+
+export async function openDetailsByHeading(page: Page, title: string): Promise<Locator> {
+  const card = detailsByHeading(page, title);
+  await expect(card).toHaveCount(1);
+  if ((await card.getAttribute('open')) === null) {
+    await card.locator(':scope > summary').click();
+  }
+  await expect(card).toHaveAttribute('open', '');
+  return card;
+}
+
+export function namedArticle(page: Page, title: string): Locator {
+  return page.getByRole('article').filter({
+    has: page.getByRole('heading', { name: title, exact: true }),
+  });
+}
+
+export function notificationArticle(page: Page, title: string): Locator {
+  return page.getByRole('article').filter({
+    has: page.getByText(title, { exact: true }),
+  });
+}
+
+export function nutritionDaySummary(page: Page): Locator {
+  return page.getByRole('complementary', { name: 'КБЖУ', exact: true });
+}
+
+export function progressOverview(page: Page): Locator {
+  return page.getByRole('region', { name: 'Прогресс по фактам', exact: true });
+}

--- a/frontend/tests/e2e/nutrition-diary.spec.ts
+++ b/frontend/tests/e2e/nutrition-diary.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Page, type Route } from '@playwright/test';
 import type { FoodDiaryEntry, HydrationEntry } from '../../src/shared/api/types';
+import { nutritionDaySummary } from './fixtures/locators';
 
 const zeroNutrition = {
   energy_kcal: '0.00',
@@ -211,6 +212,10 @@ async function mockNutritionApi(
   hydrationState: 'data' | 'empty' | 'error' | 'loading' = 'data',
   profileSex: 'female' | null = 'female',
 ) {
+  let releaseHydrationLoading = () => {};
+  const hydrationLoading = new Promise<void>((resolve) => {
+    releaseHydrationLoading = resolve;
+  });
   let entries: FoodDiaryEntry[] = [yogurtEntry];
   let hydrationEntries: HydrationEntry[] =
     hydrationState === 'empty'
@@ -289,9 +294,7 @@ async function mockNutritionApi(
       });
     }
     if (path === '/api/v1/nutrition/hydration' && request.method() === 'GET') {
-      if (hydrationState === 'loading') {
-        await new Promise((resolve) => setTimeout(resolve, 1500));
-      }
+      if (hydrationState === 'loading') await hydrationLoading;
       if (hydrationState === 'error') {
         return route.fulfill({ status: 503, json: { detail: 'Гидратация временно недоступна' } });
       }
@@ -577,6 +580,8 @@ async function mockNutritionApi(
     }
     return route.fulfill({ status: 404, json: { detail: `Unhandled ${path}` } });
   });
+
+  return { releaseHydrationLoading };
 }
 
 test('Task 81A groups nutrition into five cards and keeps profile choices compact', async ({
@@ -591,7 +596,7 @@ test('Task 81A groups nutrition into five cards and keeps profile choices compac
     page.locator('.nutrition-completeness > .nutrition-completeness__copy h2'),
     page.locator('.nutrition-day-balance h2'),
     page.locator('.nutrition-food-card__header h2'),
-    page.locator('.nutrition-day-summary h2'),
+    nutritionDaySummary(page).getByRole('heading', { name: 'КБЖУ', exact: true }),
     page.locator('.hydration-card h2'),
   ];
   const titlePositions: number[] = [];
@@ -604,7 +609,8 @@ test('Task 81A groups nutrition into five cards and keeps profile choices compac
   await expect(balance.getByRole('progressbar', { name: /Еда:/ })).toBeVisible();
   await expect(balance.getByRole('progressbar', { name: /Жидкость:/ })).toBeVisible();
   const foodCard = page.locator('.nutrition-food-card');
-  const firstMeal = foodCard.locator('.nutrition-meal').first();
+  const firstMeal = foodCard.getByRole('region', { name: 'Завтрак', exact: true });
+  await expect(firstMeal).toHaveCount(1);
   const [foodCardBox, firstMealBox] = await Promise.all([
     foodCard.boundingBox(),
     firstMeal.boundingBox(),
@@ -627,7 +633,7 @@ test('Task 81A groups nutrition into five cards and keeps profile choices compac
     page.locator('.nutrition-completeness'),
     page.locator('.nutrition-day-balance'),
     page.locator('.nutrition-food-card'),
-    page.locator('.nutrition-day-summary'),
+    nutritionDaySummary(page),
     page.locator('.hydration-card'),
   ];
   const mobileCardPositions: number[] = [];
@@ -736,12 +742,15 @@ for (const state of ['loading', 'error', 'empty'] as const) {
   test(`hydration visual evidence: ${state} state`, async ({ page }) => {
     await page.clock.setFixedTime(new Date('2026-08-19T13:00:00+03:00'));
     await page.setViewportSize({ width: 390, height: 844 });
-    await mockNutritionApi(page, state);
+    const hydrationApi = await mockNutritionApi(page, state);
     await page.goto('/app?section=nutrition&date=2026-08-19');
     const hydration = page.locator('.hydration-card');
     await expect(hydration).toBeVisible();
-    if (state === 'loading')
+    if (state === 'loading') {
       await expect(hydration.getByText('Загружаем гидратацию…')).toBeVisible();
+      hydrationApi.releaseHydrationLoading();
+      await expect(hydration.getByText('850 из 2200 мл', { exact: true })).toBeVisible();
+    }
     if (state === 'error')
       await expect(hydration.getByText('Гидратация временно недоступна')).toBeVisible();
     if (state === 'empty') await expect(hydration.getByText('0 мл записано')).toBeVisible();
@@ -771,7 +780,9 @@ test('hydration touch matrix has no horizontal overflow and keeps controls reach
       const box = await quickButtons.nth(index).boundingBox();
       expect(box?.height).toBeGreaterThanOrEqual(44);
     }
-    const volume = hydration.getByLabel('Объём, мл').first();
+    const customVolume = hydration.getByRole('region', { name: 'Другой объём', exact: true });
+    const volume = customVolume.getByLabel('Объём, мл');
+    await expect(volume).toHaveCount(1);
     await volume.focus();
     await expect(volume).toBeFocused();
     await expect(volume).toBeInViewport();
@@ -847,7 +858,16 @@ test('Russian preparation states and oil variants apply beyond potatoes', async 
   await expect(page.getByText('Яйцо целое жареное со сливочным маслом')).toBeVisible();
   await expect(page.getByText('155 ккал / 100 г')).toBeVisible();
   await expect(page.getByText('174 ккал / 100 г')).toBeVisible();
-  await expect(page.getByText('196 ккал / 100 г').first()).toBeVisible();
+  const friedWithOil = page.getByRole('article').filter({
+    hasText: 'Яйцо целое жареное с растительным маслом',
+  });
+  const friedWithButter = page.getByRole('article').filter({
+    hasText: 'Яйцо целое жареное со сливочным маслом',
+  });
+  await expect(friedWithOil).toHaveCount(1);
+  await expect(friedWithButter).toHaveCount(1);
+  await expect(friedWithOil).toContainText('196 ккал / 100 г');
+  await expect(friedWithButter).toContainText('196 ккал / 100 г');
   await page.getByText('Яйцо целое жареное с растительным маслом').scrollIntoViewIfNeeded();
   await page.screenshot({
     path: '../.artifacts/screenshots/task-114a/russian-food-oil-variants-mobile-390.png',
@@ -864,11 +884,9 @@ test('nutrition diary is responsive, keyboard-safe and supports local quick add'
 
   await expect(page.getByRole('heading', { name: 'Питание', exact: true })).toBeVisible();
   await expect(page.getByText('Греческий йогурт')).toBeVisible();
-  await expect(
-    page.locator('.nutrition-day-summary').getByRole('heading', { name: 'КБЖУ' }),
-  ).toBeVisible();
+  await expect(nutritionDaySummary(page)).toHaveCount(1);
+  await expect(nutritionDaySummary(page)).toBeVisible();
   await expect(page.getByText('Немного выше ориентира: 20 ккал')).toBeVisible();
-  await expect(page.locator('.nutrition-target').first()).not.toHaveClass(/is-over/);
   for (const viewport of [
     { width: 1440, height: 900 },
     { width: 768, height: 900 },
@@ -885,9 +903,7 @@ test('nutrition diary is responsive, keyboard-safe and supports local quick add'
     await expect(page.getByRole('navigation', { name: 'Дата дневника' })).not.toBeAttached();
     const selectedDay = week.locator('button[aria-pressed="true"]');
     expect((await selectedDay.boundingBox())?.height).toBeGreaterThanOrEqual(44);
-    const borderTop = await week.evaluate((element) => getComputedStyle(element).borderTopWidth);
-    expect(borderTop).toBe(viewport.width <= 640 ? '0px' : '1px');
-    const summary = page.locator('.nutrition-day-summary');
+    const summary = nutritionDaySummary(page);
     const targetBadge = summary.getByText('Цель КБЖУ настроена', { exact: true });
     const [weekBox, summaryBox, targetBadgeBox] = await Promise.all([
       week.boundingBox(),
@@ -903,7 +919,8 @@ test('nutrition diary is responsive, keyboard-safe and supports local quick add'
 
   const compactBreakfast = page.getByRole('region', { name: 'Завтрак' });
   const compactLunch = page.getByRole('region', { name: 'Обед' });
-  const entry = compactBreakfast.locator('.nutrition-entry').first();
+  const entry = compactBreakfast.getByRole('listitem');
+  await expect(entry).toHaveCount(1);
   const [entryBox, headerBox] = await Promise.all([
     entry.boundingBox(),
     compactBreakfast.locator('.nutrition-meal__header').boundingBox(),

--- a/frontend/tests/e2e/progress-experience.spec.ts
+++ b/frontend/tests/e2e/progress-experience.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
 import { emptyHydrationDay } from './fixtures/platform-api';
+import { progressOverview } from './fixtures/locators';
 
 const captureFeedbackAudit = Boolean(
   (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
@@ -924,19 +925,20 @@ test('shared data confidence keeps analytics factual, responsive and explicit wh
     path: '../.artifacts/screenshots/task-61/mobile-web-360x800-light-analytics.png',
   });
 
-  await expect(page.getByTestId('progress-bento-overview')).toBeVisible();
+  await expect(progressOverview(page)).toHaveCount(1);
+  await expect(progressOverview(page)).toBeVisible();
   await page.locator('.progress-hero').getByRole('tab', { name: '7 дней' }).click();
   await refreshStarted;
   const loadingState = page.getByRole('status').filter({ hasText: 'Обновляем динамику за период' });
   await expect(loadingState).toBeVisible();
-  await expect(page.getByTestId('progress-bento-overview')).toBeVisible();
+  await expect(progressOverview(page)).toBeVisible();
   await page.setViewportSize({ width: 390, height: 844 });
   await loadingState.scrollIntoViewIfNeeded();
   await page.screenshot({
     path: '../.artifacts/screenshots/task-61/mobile-web-390x844-light-period-loading.png',
   });
   releaseRefresh();
-  await expect(page.getByTestId('progress-bento-overview')).toBeVisible();
+  await expect(progressOverview(page)).toBeVisible();
 });
 
 test('measurements keep priority context, units, mobile order and add/edit history', async ({
@@ -1554,7 +1556,7 @@ test('progress bento keeps matching light and dark visual forms for the same dat
       await page.setViewportSize({ width: surface.width, height: surface.height });
 
       await expect(page.getByRole('heading', { name: 'Прогресс', exact: true })).toBeVisible();
-      await expect(page.getByTestId('progress-bento-overview')).toBeVisible();
+      await expect(progressOverview(page)).toBeVisible();
       await expect(page.locator('html')).toHaveAttribute('data-color-scheme', theme);
       await expect(
         page.locator('.progress-period-controls').getByRole('tab', { name: '30 дней' }),
@@ -1591,7 +1593,7 @@ test('progress period controls drive one exact URL and API range through history
   const controls = page.locator('.progress-period-controls');
   await expect(controls.getByRole('tab')).toHaveCount(4);
   await controls.getByRole('tab', { name: '30 дней' }).click();
-  await expect(page.getByTestId('progress-bento-overview')).toBeVisible();
+  await expect(progressOverview(page)).toBeVisible();
 
   for (const period of [7, 30, 90] as const) {
     const label = `${period} дней`;
@@ -1601,7 +1603,7 @@ test('progress period controls drive one exact URL and API range through history
       'aria-selected',
       'true',
     );
-    await expect(page.getByTestId('progress-bento-overview')).toBeVisible();
+    await expect(progressOverview(page)).toBeVisible();
   }
 
   await controls.getByRole('tab', { name: 'Свой период' }).click();
@@ -1618,5 +1620,5 @@ test('progress period controls drive one exact URL and API range through history
   await expect(page).toHaveURL(/progress_period=days_90/);
   await page.goForward();
   await expect(page).toHaveURL(/progress_period=custom/);
-  await expect(page.getByTestId('progress-bento-overview')).toBeVisible();
+  await expect(progressOverview(page)).toBeVisible();
 });

--- a/frontend/tests/e2e/pulse-concepts-pilot.spec.ts
+++ b/frontend/tests/e2e/pulse-concepts-pilot.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Locator, type Page } from '@playwright/test';
 import { installTelegramHarness } from './fixtures/mobile-tma';
 import { installPlatformApi } from './fixtures/platform-api';
+import { progressOverview } from './fixtures/locators';
 
 const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env;
 const captureVisualImpactFix = env?.YFC_CAPTURE_PULSE_VISUAL_IMPACT === '1';
@@ -330,7 +331,7 @@ test('weight bento trend keeps smooth truthful geometry, area fill and measureme
     workoutStatus: 'completed',
   });
   await page.goto('/app?section=progress');
-  const insight = page.getByTestId('progress-bento-overview').locator('.progress-bento__trend');
+  const insight = progressOverview(page).locator('.progress-bento__trend');
   await insight.scrollIntoViewIfNeeded();
   const chart = insight.locator('.data-viz-chart');
   await expect(chart).toBeVisible();
@@ -372,9 +373,7 @@ test('weight bento trend keeps smooth truthful geometry, area fill and measureme
 
   await page.setViewportSize({ width: 1440, height: 900 });
   await page.goto('/app?section=progress');
-  const desktopInsight = page
-    .getByTestId('progress-bento-overview')
-    .locator('.progress-bento__trend');
+  const desktopInsight = progressOverview(page).locator('.progress-bento__trend');
   await desktopInsight.scrollIntoViewIfNeeded();
   await expect(desktopInsight.locator('.data-viz-chart__area')).toHaveCount(1);
   if (capture) {
@@ -395,7 +394,7 @@ test('mocked TMA dark uses the same chart and safe-area floating dock', async ({
   await installPlatformApi(page, { measurementHistory: 'many', workoutStatus: 'completed' });
   await page.goto('/app?section=progress');
   const dock = page.locator('#appBottomNav');
-  const insight = page.getByTestId('progress-bento-overview').locator('.progress-bento__trend');
+  const insight = progressOverview(page).locator('.progress-bento__trend');
   await insight.scrollIntoViewIfNeeded();
   await expect(page.locator('html')).toHaveAttribute('data-color-scheme', 'dark');
   await expect(insight.locator('.data-viz-chart__area')).toHaveCount(1);

--- a/frontend/tests/e2e/semantic-card-visual-system.spec.ts
+++ b/frontend/tests/e2e/semantic-card-visual-system.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
+import { nutritionDaySummary } from './fixtures/locators';
 import { installPlatformApi } from './fixtures/platform-api';
 import { installTelegramHarness } from './fixtures/mobile-tma';
 
@@ -142,7 +143,8 @@ test('shared card effects preserve summary flow and viewport modals', async ({ b
   await openSurface(page, '/app?section=nutrition', 'light');
   await waitForSemanticSurface(page, '/app?section=nutrition');
 
-  await expect(page.locator('.nutrition-day-summary')).toHaveCSS('position', 'static');
+  await expect(nutritionDaySummary(page)).toHaveCount(1);
+  await expect(nutritionDaySummary(page)).toBeVisible();
 
   await page.goto('/app?section=profile');
   await expect(page.getByRole('heading', { name: 'Профиль и настройки' })).toBeVisible();

--- a/frontend/tests/e2e/tma-smoke.spec.ts
+++ b/frontend/tests/e2e/tma-smoke.spec.ts
@@ -12,6 +12,7 @@ import {
 } from './fixtures/mobile-tma';
 import { installPlatformApi } from './fixtures/platform-api';
 import { makeProgressReportFixture } from '../fixtures/progress-report';
+import { namedArticle, notificationArticle } from './fixtures/locators';
 
 const todayStates = [
   { name: 'planned', options: { workoutStatus: 'planned' as const }, action: 'Начать тренировку' },
@@ -330,7 +331,7 @@ test('cardio quick log keeps retry, editing and shared Mobile Web/TMA behavior',
   await tmaPage.setViewportSize(MOBILE_CONTEXTS.baseline);
   await tma.setViewport(MOBILE_CONTEXTS.baseline.height, MOBILE_CONTEXTS.baseline.height);
   await tma.setTheme('dark');
-  const tmaToastClose = tmaPage.getByRole('button', { name: 'Закрыть сообщение' }).last();
+  const tmaToastClose = tmaPage.getByRole('button', { name: 'Закрыть сообщение', exact: true });
   if (await tmaToastClose.isVisible()) await tmaToastClose.click();
   await finalTmaRow.scrollIntoViewIfNeeded();
   await expectNoOverlap(finalTmaRow, tmaPage.locator('#appBottomNav'));
@@ -339,7 +340,10 @@ test('cardio quick log keeps retry, editing and shared Mobile Web/TMA behavior',
   });
 
   await mobilePage.setViewportSize(MOBILE_CONTEXTS.compact);
-  const mobileToastClose = mobilePage.getByRole('button', { name: 'Закрыть сообщение' }).last();
+  const mobileToastClose = mobilePage.getByRole('button', {
+    name: 'Закрыть сообщение',
+    exact: true,
+  });
   if (await mobileToastClose.isVisible()) await mobileToastClose.click();
   await savedMobileRow.scrollIntoViewIfNeeded();
   await mobilePage.screenshot({
@@ -382,22 +386,28 @@ test('notification center keeps Mobile Web/TMA parity, unread geometry and an ex
     await expectNoHorizontalOverflow(page);
     await expectTouchTargets(page.locator('.notification-settings .switch-row'));
     await expectTouchTargets(page.locator('.notification-row button:visible'));
-    await expectLimeStartBoundary(page.locator('.notification-row--unread').first());
+    const unreadNotification = notificationArticle(page, 'Комментарий тренера к тренировке');
+    await expect(unreadNotification).toHaveCount(1);
+    await expectLimeStartBoundary(unreadNotification);
     await expect(page.getByRole('button', { name: 'Отметить всё' })).toHaveCSS(
       'border-top-style',
       'solid',
     );
-    await expect(page.getByRole('button', { name: 'Удалить' }).first()).toHaveCSS(
-      'border-top-style',
-      'solid',
-    );
-    const [lastRow, personal] = await Promise.all([
-      page.locator('.notification-row').last().boundingBox(),
+    const unreadDeleteButton = unreadNotification.getByRole('button', {
+      name: 'Удалить',
+      exact: true,
+    });
+    await expect(unreadDeleteButton).toHaveCount(1);
+    await expect(unreadDeleteButton).toHaveCSS('border-top-style', 'solid');
+    const readNotification = notificationArticle(page, 'Пора обновить замеры');
+    await expect(readNotification).toHaveCount(1);
+    const [readRow, personal] = await Promise.all([
+      readNotification.boundingBox(),
       page.locator('.notification-personal').boundingBox(),
     ]);
-    expect(lastRow).not.toBeNull();
+    expect(readRow).not.toBeNull();
     expect(personal).not.toBeNull();
-    expect(personal!.y - (lastRow!.y + lastRow!.height)).toBeLessThanOrEqual(20);
+    expect(personal!.y - (readRow!.y + readRow!.height)).toBeLessThanOrEqual(20);
   }
 
   const signature = (page: typeof tmaPage) =>
@@ -871,7 +881,8 @@ test('nutrition report keeps period analytics and diary return aligned in Mobile
     await expectNoHorizontalOverflow(tmaPage);
     await expectTouchTargets(tmaSelector.getByRole('tab'));
   }
-  const diaryLink = tmaReport.locator('.nutrition-report-days tbody a').first();
+  const diaryLink = tmaReport.getByRole('row').filter({ hasText: '· сегодня' }).getByRole('link');
+  await expect(diaryLink).toHaveCount(1);
   await diaryLink.scrollIntoViewIfNeeded();
   await expectNoOverlap(diaryLink, tmaPage.locator('#appBottomNav'));
 
@@ -977,8 +988,10 @@ test('measurement add, edit, history and insufficient trend keep Mobile Web and 
       'Одна точка сохраняет факт, но ещё не показывает направление изменений.',
     );
     await expect(singlePointHints).toHaveCount(2);
-    await expect(singlePointHints.first()).toBeVisible();
-    await expect(body.getByText('Пока без динамики').first()).toBeVisible();
+    for (const hint of await singlePointHints.all()) await expect(hint).toBeVisible();
+    const noTrendStates = body.getByText('Пока без динамики', { exact: true });
+    await expect(noTrendStates).toHaveCount(2);
+    for (const state of await noTrendStates.all()) await expect(state).toBeVisible();
     const row = body.locator('.measurement-history__row').filter({ hasText: '74.2 кг' });
     await row.getByRole('button', { name: 'Изменить' }).click();
     await body.getByLabel('Вес, кг').fill('74.6');
@@ -1030,13 +1043,16 @@ test('data confidence keeps insufficient analytics explicit in Mobile Web and da
   ]);
 
   for (const page of [tmaPage, mobilePage]) {
-    const insufficient = page.getByLabel('Достаточно ли данных: Пока мало данных');
-    await expect(insufficient.first()).toBeVisible();
-    await expect(insufficient.first()).toContainText('0 рабочих подходов');
+    const insufficient = page
+      .getByRole('region', { name: 'Достаточно ли данных: Пока мало данных', exact: true })
+      .filter({ hasText: '0 рабочих подходов' });
+    await expect(insufficient).toHaveCount(1);
+    await expect(insufficient).toBeVisible();
+    await expect(insufficient).toContainText('0 рабочих подходов');
     await expect(page.getByRole('link', { name: 'Открыть тренировку' })).toBeVisible();
-    await expectLimeStartBoundary(insufficient.first());
+    await expectLimeStartBoundary(insufficient);
     await expectNoHorizontalOverflow(page);
-    await expectTouchTargets(page.locator('.data-confidence__details > summary'));
+    await expectTouchTargets(page.locator('#progress-body details > summary:visible'));
   }
   expect(await sharedSurfaceSignature(tmaPage)).toEqual(await sharedSurfaceSignature(mobilePage));
 
@@ -1048,7 +1064,11 @@ test('data confidence keeps insufficient analytics explicit in Mobile Web and da
   }
   await tmaPage.setViewportSize(MOBILE_CONTEXTS.baseline);
   await tma.setViewport(MOBILE_CONTEXTS.baseline.height, MOBILE_CONTEXTS.baseline.height);
-  const bodyConfidence = tmaPage.locator('#progress-body .data-confidence').first();
+  const bodyConfidence = tmaPage
+    .locator('#progress-body')
+    .getByRole('region', { name: 'Достаточно ли данных: Пока мало данных', exact: true })
+    .filter({ hasText: 'Сейчас есть 0 замеров' });
+  await expect(bodyConfidence).toHaveCount(1);
   await bodyConfidence.scrollIntoViewIfNeeded();
   await expectNoOverlap(bodyConfidence, tmaPage.locator('#appBottomNav'));
   await tmaPage.screenshot({
@@ -1169,7 +1189,9 @@ test('direct Trainer activation keeps client context focused in mocked TMA', asy
     .getByRole('checkbox', { name: /Принимаю условия использования режима тренера/ })
     .check();
   await tmaPage.getByRole('button', { name: 'Включить режим тренера' }).click();
-  await expect(tmaPage.getByText('Режим тренера включён').first()).toBeVisible();
+  const trainerToast = tmaPage.getByRole('status').filter({ hasText: 'Режим тренера включён' });
+  await expect(trainerToast).toHaveCount(1);
+  await expect(trainerToast).toBeVisible();
   expect(api.trainerActivationCalls()).toBe(1);
 
   await tmaPage.getByRole('button', { name: 'Открыть профиль и настройки', exact: true }).click();
@@ -1871,7 +1893,12 @@ test('progression guidance screenshots cover outcomes, long content and responsi
 
     await page.goto('/app');
     await page.getByRole('button', { name: 'Продолжить тренировку' }).click();
-    const exercise = page.locator('.active-workout-exercise').first();
+    const exerciseTitle =
+      'longExerciseName' in current && current.longExerciseName
+        ? 'Приседания со штангой с контролируемой паузой в нижней точке'
+        : 'Приседания';
+    const exercise = namedArticle(page, exerciseTitle);
+    await expect(exercise).toHaveCount(1);
     const guidance = exercise.getByRole('region', { name: 'Рекомендация по следующей нагрузке' });
     await guidance.getByText('Почему?', { exact: true }).click();
     await expect(guidance).toBeVisible();
@@ -1935,8 +1962,6 @@ test('completion summary survives finish retry, feedback error, reload and TMA l
   expect((titleBox?.x ?? 0) + (titleBox?.width ?? 0)).toBeLessThanOrEqual(
     (await tmaPage.evaluate(() => window.innerWidth)) - 24,
   );
-  await expect(focusHeader).toHaveCSS('position', 'static');
-
   const resultsDisclosure = tmaPage.locator('.workout-completion__results');
   const resultsSummary = resultsDisclosure.locator('summary');
   const [resultsBox, resultsTextBox] = await Promise.all([
@@ -2018,7 +2043,11 @@ test('completion summary survives finish retry, feedback error, reload and TMA l
   }
 
   await mobilePage.goto('/');
-  await expect(mobilePage.locator('.landing-button').first()).toHaveCSS('border-radius', '12px');
+  const landingButtons = mobilePage.locator('.landing-button');
+  await expect(landingButtons).not.toHaveCount(0);
+  for (const button of await landingButtons.all()) {
+    await expect(button).toHaveCSS('border-radius', '12px');
+  }
 });
 
 test('nutrition quick paths recover in TMA and match Mobile Web before core navigation', async ({
@@ -2086,20 +2115,27 @@ test('nutrition quick paths recover in TMA and match Mobile Web before core navi
   const calories = tmaPage.getByRole('spinbutton', { name: 'Калории' });
   await calories.fill('510');
   await tmaPage.getByRole('textbox', { name: 'Название (необязательно)' }).fill('TMA перекус');
+  const quickAddAction = tmaPage.getByRole('button', {
+    name: 'Сохранить Quick Add',
+    exact: true,
+  });
+  const submitDock = tmaPage.locator('.nutrition-picker__submit');
+  await expect(quickAddAction).toHaveCount(1);
   for (const viewport of [MOBILE_CONTEXTS.compact, MOBILE_CONTEXTS.baseline]) {
     await tmaPage.setViewportSize(viewport);
     await tma.setViewport(560, viewport.height, false);
-    const lastAction = tmaPage.locator('.nutrition-picker__submit .ui-button').last();
-    await lastAction.scrollIntoViewIfNeeded();
-    const geometry = await tmaPage.locator('.nutrition-picker__submit').evaluate((submit) => {
-      const action = submit.querySelector('.ui-button:last-child');
-      if (!(action instanceof HTMLElement)) throw new Error('Quick Add action is missing');
-      return {
-        actionBottom: action.getBoundingClientRect().bottom,
-        paddingBottom: Number.parseFloat(getComputedStyle(submit).paddingBottom),
-        viewportHeight: window.innerHeight,
-      };
-    });
+    await quickAddAction.scrollIntoViewIfNeeded();
+    const [actionBox, paddingBottom, viewportHeight] = await Promise.all([
+      quickAddAction.boundingBox(),
+      submitDock.evaluate((submit) => Number.parseFloat(getComputedStyle(submit).paddingBottom)),
+      tmaPage.evaluate(() => window.innerHeight),
+    ]);
+    expect(actionBox).not.toBeNull();
+    const geometry = {
+      actionBottom: actionBox!.y + actionBox!.height,
+      paddingBottom,
+      viewportHeight,
+    };
     expect(geometry.paddingBottom).toBeGreaterThanOrEqual(24);
     expect(geometry.actionBottom).toBeLessThanOrEqual(geometry.viewportHeight - 23);
     await expectNoHorizontalOverflow(tmaPage);
@@ -2395,7 +2431,9 @@ test('contextual help covers workout, nutrition and Progress without a TMA libra
 
   await expect(tmaPage.getByRole('link', { name: 'База знаний' })).not.toBeAttached();
   await tmaPage.getByRole('button', { name: 'Начать тренировку' }).click();
-  await tmaPage.getByText('Дополнительно', { exact: true }).first().click();
+  const currentSet = tmaPage.locator('[aria-current="step"]');
+  await expect(currentSet).toHaveCount(1);
+  await currentSet.getByText('Дополнительно', { exact: true }).click();
   const rirDetails = tmaPage.locator('.active-workout-rir .contextual-help');
   const rirHelp = rirDetails.getByText('Что это?', { exact: true });
   await rirHelp.click();
@@ -2512,15 +2550,23 @@ test('task 72 screenshot packet keeps shared composition across core surfaces', 
       if (scenario.label === 'today') {
         await expect(page.getByRole('button', { name: 'Начать тренировку' })).toBeVisible();
       } else if (scenario.label === 'progress') {
-        await expect(page.locator('#progress-body .data-confidence').first()).toBeVisible();
+        const confidences = page
+          .locator('#progress-body')
+          .getByRole('region', { name: /^Достаточно ли данных:/ });
+        await expect(confidences).not.toHaveCount(0);
+        for (const confidence of await confidences.all()) await expect(confidence).toBeVisible();
       } else {
         await expect(page.getByRole('heading', { name: 'Питание', exact: true })).toBeVisible();
       }
 
       if (scenario.label === 'progress') {
-        const confidence = page.locator('#progress-body .data-confidence').first();
-        await confidence.scrollIntoViewIfNeeded();
-        await expectLimeStartBoundary(confidence);
+        const confidences = page
+          .locator('#progress-body')
+          .getByRole('region', { name: /^Достаточно ли данных:/ });
+        for (const confidence of await confidences.all()) {
+          await confidence.scrollIntoViewIfNeeded();
+          await expectLimeStartBoundary(confidence);
+        }
       }
       if (scenario.label === 'nutrition-barcode') {
         await page
@@ -2559,11 +2605,16 @@ test('task 72 screenshot packet keeps shared composition across core surfaces', 
     const page = await browser.newPage({ viewport });
     await installPlatformApi(page, { browserSession: true });
     await page.goto(viewport.width === 768 ? '/app?section=progress' : '/app');
-    await expect(
-      viewport.width === 768
-        ? page.locator('#progress-body .data-confidence').first()
-        : page.getByRole('button', { name: 'Начать тренировку' }),
-    ).toBeVisible();
+    const progressConfidences = page
+      .locator('#progress-body')
+      .getByRole('region', { name: /^Достаточно ли данных:/ });
+    if (viewport.width === 768) {
+      await expect(progressConfidences).not.toHaveCount(0);
+      for (const confidence of await progressConfidences.all())
+        await expect(confidence).toBeVisible();
+    } else {
+      await expect(page.getByRole('button', { name: 'Начать тренировку' })).toBeVisible();
+    }
     await expectNoHorizontalOverflow(page);
     await page.screenshot({
       path: `../.artifacts/screenshots/task-72/mobile-web-${viewport.width}x${viewport.height}-light-${viewport.width === 768 ? 'progress' : 'today'}.png`,

--- a/frontend/tests/e2e/today-dashboard.spec.ts
+++ b/frontend/tests/e2e/today-dashboard.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test';
+import { namedArticle } from './fixtures/locators';
 
 const captureLandingProductProofs =
   (
@@ -506,11 +507,13 @@ test('Today keeps hierarchy and has no horizontal overflow at required widths', 
     await page.setViewportSize(viewport);
     await expect(page.getByRole('button', { name: 'Начать тренировку' })).toBeInViewport();
     await expect(page.getByRole('heading', { name: 'Питание' })).toBeVisible();
-    const summaryCards = page.locator('.today-dashboard__facts .today-summary-card');
-    await expect(summaryCards).toHaveCount(2);
+    const nutritionCard = namedArticle(page, 'Питание');
+    const progressCard = namedArticle(page, 'Прогресс');
+    await expect(nutritionCard).toHaveCount(1);
+    await expect(progressCard).toHaveCount(1);
     const [nutritionBox, progressBox] = await Promise.all([
-      summaryCards.nth(0).boundingBox(),
-      summaryCards.nth(1).boundingBox(),
+      nutritionCard.boundingBox(),
+      progressCard.boundingBox(),
     ]);
     expect(nutritionBox).not.toBeNull();
     expect(progressBox).not.toBeNull();


### PR DESCRIPTION
## Summary
- freeze the Playwright E2E contract in the Mobile Web / mocked-TMA quality gate
- replace brittle positional, global-text, test-hook, CSS-detail, and timing assertions with named semantic helpers and current product invariants
- remove the unused progress overview test hook after migrating its consumers

## Verification
- `npm run e2e`: 231 passed, 4 explicit opt-in skips, 235 collected
- `npm test`: 94 files passed, 456 tests passed
- `npm run build`, `npm run typecheck`, `npm run lint`: passed
- changed-file Prettier check and `git diff --check`: passed
- repository-wide `npm run format:check` remains a pre-existing baseline issue (285 files), with no mass-formatting change in this task
- local migrated PostgreSQL lane was attempted but is blocked by missing Python/uvicorn/PostgreSQL in this environment; the required CI lane remains authoritative

## Governance
- explicit owner launch for Task 134
- independent review: APPROVED
- QA verdict: PASS
- real Telegram/device proof is not claimed; this task covers browser/mock-TMA evidence only