### PR TITLE
[Recovery approved] fix(auth): recover browser OAuth sessions safely

### DIFF
--- a/backend/alembic/versions/0070_browser_oauth_transactions.py
+++ b/backend/alembic/versions/0070_browser_oauth_transactions.py
@@ -1,0 +1,113 @@
+"""Add server-side browser OAuth transactions.
+
+Revision ID: 0070_browser_oauth_transactions
+Revises: 0069_daily_wellbeing_check_ins
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0070_browser_oauth_transactions"
+down_revision: str | None = "0069_daily_wellbeing_check_ins"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+online_rollout_phase = "expand"
+online_rollout_notes = "Adds a short-lived server-side OAuth transaction table; existing browser sessions remain valid."
+
+
+def upgrade() -> None:
+    op.create_table(
+        "oauth_transactions",
+        sa.Column("transaction_id", sa.String(length=64), nullable=False),
+        sa.Column("browser_marker_hash", sa.String(length=64), nullable=False),
+        sa.Column("provider", sa.String(length=32), nullable=False),
+        sa.Column("purpose", sa.String(length=16), nullable=False),
+        sa.Column("state", sa.String(length=256), nullable=False),
+        sa.Column("redirect_uri", sa.String(length=512), nullable=False),
+        sa.Column("next_path", sa.String(length=256), nullable=True),
+        sa.Column("code_verifier", sa.String(length=256), nullable=True),
+        sa.Column("nonce", sa.String(length=256), nullable=True),
+        sa.Column("link_action_token_hash", sa.String(length=64), nullable=True),
+        sa.Column("link_user_id", sa.Integer(), nullable=True),
+        sa.Column("session_family_id", sa.String(length=64), nullable=True),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="pending"),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("claimed_at", sa.DateTime(), nullable=True),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+        sa.Column("failure_reason", sa.String(length=32), nullable=True),
+        sa.CheckConstraint(
+            "purpose IN ('login', 'link')",
+            name="ck_oauth_transactions_purpose",
+        ),
+        sa.CheckConstraint(
+            "status IN ('pending', 'processing', 'completed', 'failed', 'expired')",
+            name="ck_oauth_transactions_status",
+        ),
+        sa.ForeignKeyConstraint(["link_user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("transaction_id"),
+    )
+    op.create_index(
+        "ix_oauth_transactions_browser_marker_hash",
+        "oauth_transactions",
+        ["browser_marker_hash"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_oauth_transactions_provider",
+        "oauth_transactions",
+        ["provider"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_oauth_transactions_state",
+        "oauth_transactions",
+        ["state"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_oauth_transactions_link_user_id",
+        "oauth_transactions",
+        ["link_user_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_oauth_transactions_session_family_id",
+        "oauth_transactions",
+        ["session_family_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_oauth_transactions_expires_at",
+        "oauth_transactions",
+        ["expires_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_oauth_transactions_browser_provider",
+        "oauth_transactions",
+        ["browser_marker_hash", "provider", "purpose"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_oauth_transactions_expiry_status",
+        "oauth_transactions",
+        ["expires_at", "status"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_oauth_transactions_expiry_status", table_name="oauth_transactions")
+    op.drop_index("ix_oauth_transactions_browser_provider", table_name="oauth_transactions")
+    op.drop_index("ix_oauth_transactions_expires_at", table_name="oauth_transactions")
+    op.drop_index("ix_oauth_transactions_session_family_id", table_name="oauth_transactions")
+    op.drop_index("ix_oauth_transactions_link_user_id", table_name="oauth_transactions")
+    op.drop_index("ix_oauth_transactions_state", table_name="oauth_transactions")
+    op.drop_index("ix_oauth_transactions_provider", table_name="oauth_transactions")
+    op.drop_index("ix_oauth_transactions_browser_marker_hash", table_name="oauth_transactions")
+    op.drop_table("oauth_transactions")

--- a/backend/fitminiapp_api/api/v1/auth.py
+++ b/backend/fitminiapp_api/api/v1/auth.py
@@ -1,8 +1,9 @@
 import logging
-from datetime import timedelta
+from datetime import UTC, timedelta
+from typing import Any
 from uuid import uuid4
 
-from authlib.integrations.base_client.errors import OAuthError
+from authlib.integrations.base_client.errors import MismatchingStateError, OAuthError
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import RedirectResponse
 from httpx import HTTPError
@@ -38,11 +39,7 @@ from fitminiapp_api.services.account_linking import (
 from fitminiapp_api.services.audit import record_audit_event
 from fitminiapp_api.services.auth_email import password_reset_email, verification_email
 from fitminiapp_api.services.auth_identities import ensure_auth_identity, ensure_telegram_identity
-from fitminiapp_api.services.auth_redirects import (
-    account_link_error_redirect,
-    auth_error_redirect,
-    safe_auth_next_path,
-)
+from fitminiapp_api.services.auth_redirects import auth_error_redirect, safe_auth_next_path
 from fitminiapp_api.services.jwt import (
     AuthError,
     build_access_token,
@@ -51,11 +48,26 @@ from fitminiapp_api.services.jwt import (
     extract_bearer_token,
 )
 from fitminiapp_api.services.oauth_login import (
+    VK_SESSION_KEY,
     OAuthAccountBlockedError,
     OAuthProviderResponseError,
     OAuthStateError,
     configured_oauth_client,
     get_or_create_oauth_user,
+    merge_vk_callback_payload,
+)
+from fitminiapp_api.services.oauth_transactions import (
+    OAUTH_BROWSER_MARKER_KEY,
+    authlib_state_data,
+    browser_marker_from_session,
+    claim_oauth_transaction,
+    create_oauth_transaction,
+    finish_oauth_transaction,
+    has_pending_oauth_transactions,
+    is_valid_oauth_state,
+    prepare_oauth_session,
+    scrub_legacy_oauth_session,
+    transaction_hash_prefix,
 )
 from fitminiapp_api.services.password_auth import (
     PasswordAuthError,
@@ -134,6 +146,56 @@ def _safe_next_path(value: str | None) -> str | None:
     return safe_auth_next_path(value)
 
 
+def _clear_oauth_cookie(response: Response) -> None:
+    response.delete_cookie(
+        key=settings.oauth_session_cookie_name,
+        path="/",
+        secure=settings.app_env == "prod",
+        httponly=True,
+        samesite="none" if settings.app_env == "prod" else "lax",
+    )
+
+
+def _log_oauth_event(
+    event: str,
+    request: Request,
+    *,
+    provider: str,
+    purpose: str,
+    reason: str,
+    state: str | None = None,
+) -> None:
+    extra: dict[str, str] = {
+        "provider": provider,
+        "purpose": purpose,
+        "reason": reason,
+    }
+    if state and is_valid_oauth_state(state):
+        extra["transaction_hash_prefix"] = transaction_hash_prefix(state)
+    request_id = getattr(request.state, "request_id", None)
+    if request_id:
+        extra["request_id"] = request_id
+    logger.warning(event, extra=extra)
+
+
+def _cleanup_oauth_artifact(
+    request: Request,
+    response: Response,
+    db: Session,
+    *,
+    browser_marker: str | None,
+) -> None:
+    scrub_legacy_oauth_session(request.session)
+    if has_pending_oauth_transactions(db, browser_marker):
+        return
+    request.session.pop(OAUTH_BROWSER_MARKER_KEY, None)
+
+    # SessionMiddleware turns a bad or expired signed cookie into an empty
+    # session. Explicitly remove that cookie once no OAuth attempt remains.
+    if not request.session and request.cookies.get(settings.oauth_session_cookie_name):
+        _clear_oauth_cookie(response)
+
+
 def _oauth_error_code(provider_error: str) -> str:
     return (
         "denied"
@@ -142,15 +204,6 @@ def _oauth_error_code(provider_error: str) -> str:
         if provider_error in {"invalid_state", "mismatching_state", "missing_state"}
         else "provider_failure"
     )
-
-
-async def _oauth_callback_error(request: Request) -> str | None:
-    provider_error = request.query_params.get("error")
-    if provider_error or request.method == "GET":
-        return provider_error
-    form = await request.form()
-    form_error = form.get("error")
-    return form_error if isinstance(form_error, str) else None
 
 
 def _clear_refresh_cookie(response: Response) -> None:
@@ -280,24 +333,62 @@ def telegram_init_auth(
 
 @router.get("/oauth/{provider}/start")
 @limiter.limit("20/minute")
-async def oauth_start(request: Request, provider: str, next: str | None = None):
+async def oauth_start(
+    request: Request,
+    provider: str,
+    next: str | None = None,
+    db: Session = Depends(get_db),
+):
     _require_web_auth()
-    client = configured_oauth_client(provider)
+    normalized_provider = provider.strip().lower()
+    client = configured_oauth_client(normalized_provider)
     if client is None:
         return RedirectResponse(
             url=auth_error_redirect("unavailable", next_path=next), status_code=303
         )
-    request.session["oauth_next"] = _safe_next_path(next)
+    next_path = _safe_next_path(next)
+    browser_marker = prepare_oauth_session(request.session)
     try:
-        return await client.authorize_redirect(request, _oauth_callback_url(provider))
-    except (HTTPError, OAuthError, ValueError) as exc:
-        logger.warning(
+        callback_url = _oauth_callback_url(normalized_provider)
+        authorization_data = await _create_authorization_data(
+            client,
+            normalized_provider,
+            callback_url,
+        )
+        create_oauth_transaction(
+            db=db,
+            browser_marker=browser_marker,
+            provider=normalized_provider,
+            purpose="login",
+            authorization_data=authorization_data,
+            next_path=next_path,
+        )
+    except HTTPError, OAuthError, IntegrityError, RuntimeError, ValueError:
+        db.rollback()
+        _log_oauth_event(
             "oauth_start_failed",
-            extra={"provider": provider, "reason": type(exc).__name__},
+            request,
+            provider=normalized_provider,
+            purpose="login",
+            reason="provider_failure",
         )
-        return RedirectResponse(
-            url=auth_error_redirect("unavailable", next_path=next), status_code=303
+        response = RedirectResponse(
+            auth_error_redirect(
+                "unavailable",
+                next_path=next_path,
+                provider=normalized_provider,
+            ),
+            status_code=303,
         )
+        _cleanup_oauth_artifact(
+            request,
+            response,
+            db,
+            browser_marker=browser_marker,
+        )
+        return response
+
+    return RedirectResponse(authorization_data["url"], status_code=302)
 
 
 @router.get("/oauth/{provider}/link/start")
@@ -343,17 +434,104 @@ async def oauth_link_start(
         )
         db.commit()
         raise HTTPException(status_code=403, detail="Ссылка создана в другой сессии")
-    request.session["oauth_link_token"] = token
-    request.session["oauth_link_provider"] = normalized_provider
-    request.session["oauth_link_family"] = session_family_id
+    browser_marker = prepare_oauth_session(request.session)
     try:
-        return await client.authorize_redirect(request, _oauth_callback_url(normalized_provider))
-    except (HTTPError, OAuthError, ValueError) as exc:
-        logger.warning(
-            "oauth_link_start_failed",
-            extra={"provider": normalized_provider, "reason": type(exc).__name__},
+        callback_url = _oauth_callback_url(normalized_provider)
+        authorization_data = await _create_authorization_data(
+            client,
+            normalized_provider,
+            callback_url,
         )
-        return RedirectResponse(url=account_link_error_redirect("unavailable"), status_code=303)
+        create_oauth_transaction(
+            db,
+            browser_marker=browser_marker,
+            provider=normalized_provider,
+            purpose="link",
+            authorization_data=authorization_data,
+            link_action_token_hash=action_token.token_hash,
+            link_user_id=target.id,
+            session_family_id=session_family_id,
+        )
+    except HTTPError, OAuthError, IntegrityError, RuntimeError, ValueError:
+        db.rollback()
+        _log_oauth_event(
+            "oauth_link_start_failed",
+            request,
+            provider=normalized_provider,
+            purpose="link",
+            reason="provider_failure",
+        )
+        response = RedirectResponse(
+            auth_error_redirect("unavailable", provider=normalized_provider, link=True),
+            status_code=303,
+        )
+        _cleanup_oauth_artifact(
+            request,
+            response,
+            db,
+            browser_marker=browser_marker,
+        )
+        return response
+
+    return RedirectResponse(authorization_data["url"], status_code=302)
+
+
+async def _create_authorization_data(
+    client: Any,
+    provider: str,
+    redirect_uri: str,
+) -> dict[str, Any]:
+    if provider == "vk":
+        data = client.create_authorization_data(redirect_uri)
+    else:
+        data = await client.create_authorization_url(redirect_uri)
+    if not isinstance(data, dict) or not isinstance(data.get("url"), str):
+        raise ValueError("OAuth provider returned invalid authorization data")
+    result = dict(data)
+    result["redirect_uri"] = redirect_uri
+    return result
+
+
+def _add_callback_param(params: dict[str, str], key: str, value: object) -> None:
+    normalized = str(value)
+    existing = params.get(key)
+    if existing is not None and existing != normalized:
+        raise ValueError("OAuth callback contains conflicting parameters")
+    params[key] = normalized
+
+
+async def _oauth_callback_params(request: Request, provider: str) -> dict[str, str]:
+    params: dict[str, str] = {}
+    for query_key, query_value in request.query_params.multi_items():
+        _add_callback_param(params, query_key, query_value)
+    if request.scope.get("method", "GET") != "GET":
+        async with request.form() as form:
+            for form_key, form_value in form.multi_items():
+                _add_callback_param(params, form_key, form_value)
+    if provider == "vk":
+        return merge_vk_callback_payload(params)
+    return params
+
+
+def _set_temporary_authlib_state(
+    request: Request,
+    client: Any,
+    provider: str,
+    row,
+) -> None:
+    state_payload = authlib_state_data(row)
+    if provider == "vk":
+        request.session[VK_SESSION_KEY] = {
+            "state": row.state,
+            "code_verifier": row.code_verifier,
+            "redirect_uri": row.redirect_uri,
+        }
+        return
+    client_name = getattr(client, "name", None) or provider
+    request.session[f"_state_{client_name}_{row.state}"] = {
+        "data": state_payload,
+        "exp": row.expires_at.replace(tzinfo=UTC).timestamp(),
+    }
 
 
 async def _oauth_callback_impl(
@@ -362,36 +540,107 @@ async def _oauth_callback_impl(
     db: Session,
 ) -> Response:
     _require_web_auth()
-    next_path = _safe_next_path(request.session.pop("oauth_next", None))
-    link_token = request.session.pop("oauth_link_token", None)
-    link_provider = request.session.pop("oauth_link_provider", None)
-    link_family_id = request.session.pop("oauth_link_family", None)
-
-    def error_redirect(code: str) -> str:
-        return (
-            account_link_error_redirect(code)
-            if link_token
-            else auth_error_redirect(code, next_path=next_path)
-        )
-
-    client = configured_oauth_client(provider)
+    normalized_provider = provider.strip().lower()
+    client = configured_oauth_client(normalized_provider)
     if client is None:
-        return RedirectResponse(url=error_redirect("unavailable"), status_code=303)
-    if link_token and (
-        link_provider != provider or not isinstance(link_family_id, str) or not link_family_id
-    ):
-        return RedirectResponse(url=error_redirect("invalid_state"), status_code=303)
-    provider_error = await _oauth_callback_error(request)
-    if provider_error:
-        return RedirectResponse(
-            url=error_redirect(_oauth_error_code(provider_error)),
+        raise HTTPException(status_code=404, detail="Провайдер входа не настроен")
+    browser_marker = browser_marker_from_session(request.session)
+    try:
+        params = await _oauth_callback_params(request, normalized_provider)
+    except ValueError, RuntimeError:
+        _log_oauth_event(
+            "oauth_login_failed",
+            request,
+            provider=normalized_provider,
+            purpose="login",
+            reason="malformed_session",
+        )
+        response = RedirectResponse(
+            auth_error_redirect("invalid_state", provider=normalized_provider),
             status_code=303,
         )
+        _cleanup_oauth_artifact(
+            request,
+            response,
+            db,
+            browser_marker=browser_marker,
+        )
+        return response
+
+    state = params.get("state")
+    claim = claim_oauth_transaction(
+        db,
+        browser_marker=browser_marker,
+        provider=normalized_provider,
+        state=state,
+    )
+    row = claim.transaction
+    if claim.reason is not None or row is None:
+        purpose = row.purpose if row is not None else "login"
+        is_link = purpose == "link"
+        _log_oauth_event(
+            "oauth_login_failed",
+            request,
+            provider=normalized_provider,
+            purpose=purpose,
+            reason=claim.reason or "invalid_state",
+            state=state,
+        )
+        response = RedirectResponse(
+            auth_error_redirect(
+                "invalid_state",
+                next_path=row.next_path if row is not None and not is_link else None,
+                provider=normalized_provider,
+                link=is_link,
+            ),
+            status_code=303,
+        )
+        _cleanup_oauth_artifact(
+            request,
+            response,
+            db,
+            browser_marker=browser_marker,
+        )
+        return response
+
+    is_link = row.purpose == "link"
     try:
+        provider_error = params.get("error")
+        if provider_error:
+            code = _oauth_error_code(provider_error)
+            failure_reason = "provider_denied" if code == "denied" else "provider_failure"
+            finish_oauth_transaction(db, row, failure_reason=failure_reason)
+            _log_oauth_event(
+                "oauth_link_failed" if is_link else "oauth_login_failed",
+                request,
+                provider=normalized_provider,
+                purpose=row.purpose,
+                reason=failure_reason,
+                state=state,
+            )
+            response = RedirectResponse(
+                auth_error_redirect(
+                    code,
+                    next_path=row.next_path,
+                    provider=normalized_provider,
+                    link=is_link,
+                ),
+                status_code=303,
+            )
+            _cleanup_oauth_artifact(
+                request,
+                response,
+                db,
+                browser_marker=browser_marker,
+            )
+            return response
+
+        _set_temporary_authlib_state(request, client, normalized_provider, row)
+        request.state.oauth_callback_params = params
         token = await client.authorize_access_token(request)
         if not isinstance(token, dict):
             raise ValueError("OAuth provider returned an invalid token response")
-        if provider == "yandex":
+        if normalized_provider == "yandex":
             profile_response = await client.get("info?format=json", token=token)
             profile_response.raise_for_status()
             raw_claims = profile_response.json()
@@ -402,77 +651,322 @@ async def _oauth_callback_impl(
             if not isinstance(userinfo, dict):
                 raise ValueError("OAuth provider returned invalid identity claims")
             raw_claims = dict(userinfo)
-        if link_token:
+        if is_link:
+            if not row.link_action_token_hash or not row.link_user_id or not row.session_family_id:
+                raise OAuthLinkError("Сессия привязки недействительна")
+            try:
+                session_user, session_family_id = _active_refresh_session(request, db)
+            except HTTPException as exc:
+                raise OAuthLinkError("Сессия привязки недействительна") from exc
+            if session_user.id != row.link_user_id or session_family_id != row.session_family_id:
+                raise OAuthLinkError("Сессия привязки недействительна")
             try:
                 user = link_oauth_account(
                     db,
-                    raw_token=link_token,
-                    provider=provider,
+                    action_token_hash=row.link_action_token_hash,
+                    provider=normalized_provider,
                     raw_claims=raw_claims,
-                    expected_session_family_id=link_family_id,
+                    expected_session_family_id=row.session_family_id,
                 )
-            except OAuthLinkConflictError as exc:
+            except OAuthLinkConflictError:
                 db.commit()
-                logger.warning(
-                    "oauth_link_conflict",
-                    extra={"provider": provider, "reason": type(exc).__name__},
-                )
-                return RedirectResponse(
-                    url=account_link_error_redirect("conflict"), status_code=303
-                )
-            except (OAuthLinkError, PasswordAuthError) as exc:
-                db.commit()
-                logger.warning(
+                finish_oauth_transaction(db, row, failure_reason="conflict")
+                _log_oauth_event(
                     "oauth_link_failed",
-                    extra={"provider": provider, "reason": type(exc).__name__},
+                    request,
+                    provider=normalized_provider,
+                    purpose="link",
+                    reason="conflict",
+                    state=state,
                 )
-                return RedirectResponse(
-                    url=account_link_error_redirect("invalid_state"), status_code=303
+                response = RedirectResponse(
+                    auth_error_redirect(
+                        "conflict",
+                        provider=normalized_provider,
+                        link=True,
+                    ),
+                    status_code=303,
                 )
+                _cleanup_oauth_artifact(
+                    request,
+                    response,
+                    db,
+                    browser_marker=browser_marker,
+                )
+                return response
+            except OAuthLinkError, PasswordAuthError:
+                db.commit()
+                finish_oauth_transaction(db, row, failure_reason="invalid_state")
+                _log_oauth_event(
+                    "oauth_link_failed",
+                    request,
+                    provider=normalized_provider,
+                    purpose="link",
+                    reason="invalid_state",
+                    state=state,
+                )
+                response = RedirectResponse(
+                    auth_error_redirect(
+                        "invalid_state",
+                        provider=normalized_provider,
+                        link=True,
+                    ),
+                    status_code=303,
+                )
+                _cleanup_oauth_artifact(
+                    request,
+                    response,
+                    db,
+                    browser_marker=browser_marker,
+                )
+                return response
+            finish_oauth_transaction(db, row, commit=False)
+            db.commit()
+            response = RedirectResponse(
+                url=f"/app?auth_linked={normalized_provider}",
+                status_code=303,
+            )
+            _cleanup_oauth_artifact(
+                request,
+                response,
+                db,
+                browser_marker=browser_marker,
+            )
+            return response
         else:
-            user = get_or_create_oauth_user(db, provider=provider, raw_claims=raw_claims)
-    except OAuthAccountBlockedError as exc:
-        logger.warning(
-            "oauth_login_blocked", extra={"provider": provider, "reason": type(exc).__name__}
-        )
-        return RedirectResponse(url=error_redirect("blocked"), status_code=303)
-    except OAuthStateError as exc:
-        logger.warning(
-            "oauth_login_failed", extra={"provider": provider, "reason": type(exc).__name__}
-        )
-        return RedirectResponse(url=error_redirect("invalid_state"), status_code=303)
-    except OAuthProviderResponseError as exc:
-        logger.warning(
-            "oauth_login_failed", extra={"provider": provider, "reason": type(exc).__name__}
-        )
-        return RedirectResponse(
-            url=error_redirect(_oauth_error_code(exc.error)),
+            user = get_or_create_oauth_user(
+                db,
+                provider=normalized_provider,
+                raw_claims=raw_claims,
+            )
+        response = RedirectResponse(
+            url=row.next_path or "/app",
             status_code=303,
         )
+        issue_token_pair(db, user, response, commit=False)
+        finish_oauth_transaction(db, row, commit=False)
+        db.commit()
+        _cleanup_oauth_artifact(
+            request,
+            response,
+            db,
+            browser_marker=browser_marker,
+        )
+        return response
+    except OAuthAccountBlockedError:
+        db.rollback()
+        finish_oauth_transaction(db, row, failure_reason="blocked")
+        _log_oauth_event(
+            "oauth_login_blocked",
+            request,
+            provider=normalized_provider,
+            purpose=row.purpose,
+            reason="blocked",
+            state=state,
+        )
+        response = RedirectResponse(
+            auth_error_redirect(
+                "blocked",
+                next_path=row.next_path if not is_link else None,
+                provider=normalized_provider,
+                link=is_link,
+            ),
+            status_code=303,
+        )
+        _cleanup_oauth_artifact(
+            request,
+            response,
+            db,
+            browser_marker=browser_marker,
+        )
+        return response
+    except OAuthStateError:
+        db.rollback()
+        finish_oauth_transaction(db, row, failure_reason="invalid_state")
+        _log_oauth_event(
+            "oauth_login_failed",
+            request,
+            provider=normalized_provider,
+            purpose=row.purpose,
+            reason="invalid_state",
+            state=state,
+        )
+        response = RedirectResponse(
+            auth_error_redirect(
+                "invalid_state",
+                next_path=row.next_path if not is_link else None,
+                provider=normalized_provider,
+                link=is_link,
+            ),
+            status_code=303,
+        )
+        _cleanup_oauth_artifact(
+            request,
+            response,
+            db,
+            browser_marker=browser_marker,
+        )
+        return response
+    except OAuthProviderResponseError as exc:
+        code = _oauth_error_code(exc.error)
+        db.rollback()
+        finish_oauth_transaction(
+            db,
+            row,
+            failure_reason="provider_denied" if code == "denied" else "provider_failure",
+        )
+        _log_oauth_event(
+            "oauth_login_failed",
+            request,
+            provider=normalized_provider,
+            purpose=row.purpose,
+            reason=code,
+            state=state,
+        )
+        response = RedirectResponse(
+            auth_error_redirect(
+                code,
+                next_path=row.next_path if not is_link else None,
+                provider=normalized_provider,
+                link=is_link,
+            ),
+            status_code=303,
+        )
+        _cleanup_oauth_artifact(
+            request,
+            response,
+            db,
+            browser_marker=browser_marker,
+        )
+        return response
+    except MismatchingStateError:
+        db.rollback()
+        finish_oauth_transaction(db, row, failure_reason="invalid_state")
+        _log_oauth_event(
+            "oauth_login_failed",
+            request,
+            provider=normalized_provider,
+            purpose=row.purpose,
+            reason="invalid_state",
+            state=state,
+        )
+        response = RedirectResponse(
+            auth_error_redirect(
+                "invalid_state",
+                next_path=row.next_path if not is_link else None,
+                provider=normalized_provider,
+                link=is_link,
+            ),
+            status_code=303,
+        )
+        _cleanup_oauth_artifact(
+            request,
+            response,
+            db,
+            browser_marker=browser_marker,
+        )
+        return response
     except OAuthError as exc:
         oauth_error = getattr(exc, "error", "")
-        logger.warning(
-            "oauth_login_failed", extra={"provider": provider, "reason": type(exc).__name__}
+        code = _oauth_error_code(oauth_error)
+        db.rollback()
+        finish_oauth_transaction(
+            db,
+            row,
+            failure_reason="provider_denied" if code == "denied" else "provider_failure",
         )
-        return RedirectResponse(
-            url=error_redirect(_oauth_error_code(oauth_error)),
+        _log_oauth_event(
+            "oauth_login_failed",
+            request,
+            provider=normalized_provider,
+            purpose=row.purpose,
+            reason=code,
+            state=state,
+        )
+        response = RedirectResponse(
+            auth_error_redirect(
+                code,
+                next_path=row.next_path if not is_link else None,
+                provider=normalized_provider,
+                link=is_link,
+            ),
             status_code=303,
         )
-    except (HTTPError, OAuthLinkError, PasswordAuthError, IntegrityError, ValueError) as exc:
-        logger.warning(
-            "oauth_login_failed", extra={"provider": provider, "reason": type(exc).__name__}
+        _cleanup_oauth_artifact(
+            request,
+            response,
+            db,
+            browser_marker=browser_marker,
         )
-        return RedirectResponse(url=error_redirect("provider_failure"), status_code=303)
-
-    redirect = RedirectResponse(
-        url=(f"/app?auth_linked={provider}" if link_token else next_path or "/app"),
-        status_code=303,
-    )
-    if link_token:
+        return response
+    except OAuthLinkConflictError:
         db.commit()
-    else:
-        issue_token_pair(db, user, redirect)
-    return redirect
+        finish_oauth_transaction(db, row, failure_reason="conflict")
+        response = RedirectResponse(
+            auth_error_redirect("conflict", provider=normalized_provider, link=True),
+            status_code=303,
+        )
+        _cleanup_oauth_artifact(
+            request,
+            response,
+            db,
+            browser_marker=browser_marker,
+        )
+        return response
+    except OAuthLinkError, PasswordAuthError:
+        db.commit()
+        finish_oauth_transaction(db, row, failure_reason="invalid_state")
+        _log_oauth_event(
+            "oauth_link_failed" if is_link else "oauth_login_failed",
+            request,
+            provider=normalized_provider,
+            purpose=row.purpose,
+            reason="invalid_state",
+            state=state,
+        )
+        response = RedirectResponse(
+            auth_error_redirect(
+                "invalid_state",
+                next_path=row.next_path if not is_link else None,
+                provider=normalized_provider,
+                link=is_link,
+            ),
+            status_code=303,
+        )
+        _cleanup_oauth_artifact(
+            request,
+            response,
+            db,
+            browser_marker=browser_marker,
+        )
+        return response
+    except HTTPError, IntegrityError, ValueError, RuntimeError:
+        db.rollback()
+        finish_oauth_transaction(db, row, failure_reason="provider_failure")
+        _log_oauth_event(
+            "oauth_link_failed" if is_link else "oauth_login_failed",
+            request,
+            provider=normalized_provider,
+            purpose=row.purpose,
+            reason="provider_failure",
+            state=state,
+        )
+        response = RedirectResponse(
+            auth_error_redirect(
+                "provider_failure",
+                next_path=row.next_path if not is_link else None,
+                provider=normalized_provider,
+                link=is_link,
+            ),
+            status_code=303,
+        )
+        _cleanup_oauth_artifact(
+            request,
+            response,
+            db,
+            browser_marker=browser_marker,
+        )
+        return response
 
 
 @router.get(

--- a/backend/fitminiapp_api/core/config.py
+++ b/backend/fitminiapp_api/core/config.py
@@ -31,6 +31,8 @@ class Settings(BaseSettings):
     access_token_expire_minutes: int = Field(gt=0, le=24 * 60)
     refresh_token_expire_days: int = Field(gt=0, le=365)
     refresh_cookie_name: str = "fit_refresh_token"
+    oauth_session_cookie_name: str = "fit_oauth_session"
+    oauth_transaction_ttl_seconds: int = Field(default=600, ge=60, le=3600)
 
     database_url: str
     db_pool_size: int = Field(default=10, ge=1, le=100)

--- a/backend/fitminiapp_api/main.py
+++ b/backend/fitminiapp_api/main.py
@@ -103,8 +103,8 @@ app.add_middleware(RequestContextMiddleware)
 app.add_middleware(
     SessionMiddleware,
     secret_key=settings.secret_key,
-    session_cookie="fit_oauth_session",
-    max_age=10 * 60,
+    session_cookie=settings.oauth_session_cookie_name,
+    max_age=settings.oauth_transaction_ttl_seconds,
     same_site="none" if settings.app_env == "prod" else "lax",
     https_only=settings.app_env == "prod",
 )

--- a/backend/fitminiapp_api/models/__init__.py
+++ b/backend/fitminiapp_api/models/__init__.py
@@ -36,6 +36,7 @@ from fitminiapp_api.models.news import (
 )
 from fitminiapp_api.models.notification import Notification, NotificationSetting
 from fitminiapp_api.models.nutrition import EnergyCalibration, NutritionTarget
+from fitminiapp_api.models.oauth_transaction import OAuthTransaction
 from fitminiapp_api.models.program import (
     HiddenProgramTemplate,
     ProgramRevision,
@@ -113,6 +114,7 @@ __all__ = [
     "Notification",
     "NotificationSetting",
     "NutritionTarget",
+    "OAuthTransaction",
     "Payment",
     "Plan",
     "ProgramRevision",

--- a/backend/fitminiapp_api/models/oauth_transaction.py
+++ b/backend/fitminiapp_api/models/oauth_transaction.py
@@ -1,0 +1,61 @@
+from datetime import UTC, datetime
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from fitminiapp_api.db.base import Base
+
+
+def utcnow() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+class OAuthTransaction(Base):
+    """Short-lived server-side state for one browser OAuth attempt."""
+
+    __tablename__ = "oauth_transactions"
+    __table_args__ = (
+        CheckConstraint(
+            "purpose IN ('login', 'link')",
+            name="ck_oauth_transactions_purpose",
+        ),
+        CheckConstraint(
+            "status IN ('pending', 'processing', 'completed', 'failed', 'expired')",
+            name="ck_oauth_transactions_status",
+        ),
+        Index(
+            "ix_oauth_transactions_browser_provider",
+            "browser_marker_hash",
+            "provider",
+            "purpose",
+        ),
+        Index(
+            "ix_oauth_transactions_expiry_status",
+            "expires_at",
+            "status",
+        ),
+    )
+
+    transaction_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    browser_marker_hash: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    provider: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    purpose: Mapped[str] = mapped_column(String(16), nullable=False)
+    state: Mapped[str] = mapped_column(String(256), nullable=False, unique=True, index=True)
+    redirect_uri: Mapped[str] = mapped_column(String(512), nullable=False)
+    next_path: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    code_verifier: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    nonce: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    link_action_token_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    link_user_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+    session_family_id: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="pending")
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=utcnow)
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, index=True)
+    claimed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    failure_reason: Mapped[str | None] = mapped_column(String(32), nullable=True)

--- a/backend/fitminiapp_api/services/account_export.py
+++ b/backend/fitminiapp_api/services/account_export.py
@@ -110,6 +110,7 @@ ACCOUNT_EXPORT_DATA_INVENTORY: dict[str, str] = {
 ACCOUNT_EXPORT_EXCLUDED_DATA_INVENTORY: dict[str, str] = {
     "account_data_exports": "short-lived generated archive bytes and download capability metadata",
     "auth_action_tokens": "hashed authentication actions and session-family metadata",
+    "oauth_transactions": "short-lived browser OAuth state, PKCE, nonce, and recovery metadata",
     "refresh_tokens": "hashed session credentials and revocation metadata",
     "coach_client_invites": "hashed invitations and managed-client identity data",
     "payments": "retired operational billing/provider records",

--- a/backend/fitminiapp_api/services/account_linking.py
+++ b/backend/fitminiapp_api/services/account_linking.py
@@ -12,7 +12,11 @@ from fitminiapp_api.models.user import User
 from fitminiapp_api.services.audit import record_audit_event
 from fitminiapp_api.services.auth_identities import ensure_auth_identity, ensure_telegram_identity
 from fitminiapp_api.services.oauth_login import normalize_oauth_claims
-from fitminiapp_api.services.password_auth import consume_action_token, create_action_token
+from fitminiapp_api.services.password_auth import (
+    consume_action_token,
+    consume_action_token_hash,
+    create_action_token,
+)
 from fitminiapp_api.services.root_admin import is_root_telegram_user_id
 from fitminiapp_api.services.telegram_auth import normalize_telegram_username
 from fitminiapp_api.services.token_service import is_refresh_token_family_active
@@ -86,24 +90,36 @@ def create_oauth_link_url(
 def link_oauth_account(
     db: Session,
     *,
-    raw_token: str,
+    raw_token: str | None = None,
+    action_token_hash: str | None = None,
     provider: str,
     raw_claims: dict[str, object],
-    expected_session_family_id: str,
+    expected_session_family_id: str | None = None,
 ) -> User:
     normalized_provider = provider.strip().lower()
-    token = consume_action_token(
-        db,
-        raw_token,
-        purpose=oauth_link_purpose(normalized_provider),
-    )
-    if token.session_family_id != expected_session_family_id:
-        raise OAuthLinkError("Сессия привязки недействительна")
+    if action_token_hash:
+        token = consume_action_token_hash(
+            db,
+            action_token_hash,
+            purpose=oauth_link_purpose(normalized_provider),
+        )
+    elif raw_token:
+        token = consume_action_token(
+            db,
+            raw_token,
+            purpose=oauth_link_purpose(normalized_provider),
+        )
+    else:
+        raise OAuthLinkError("Ссылка привязки недействительна")
+    if expected_session_family_id is not None:
+        family_id = expected_session_family_id
+        if token.session_family_id != family_id:
+            raise OAuthLinkError("Сессия привязки недействительна")
+        if not is_refresh_token_family_active(db, token.user_id, family_id):
+            raise OAuthLinkError("Сессия привязки недействительна")
     target = db.query(User).filter(User.id == token.user_id).with_for_update().first()
     if target is None or not target.is_active:
         raise OAuthLinkError("Аккаунт для привязки недоступен")
-    if not is_refresh_token_family_active(db, target.id, expected_session_family_id):
-        raise OAuthLinkError("Сессия привязки недействительна")
 
     claims = normalize_oauth_claims(normalized_provider, raw_claims)
     subject = claims["subject"]

--- a/backend/fitminiapp_api/services/auth_redirects.py
+++ b/backend/fitminiapp_api/services/auth_redirects.py
@@ -15,6 +15,7 @@ AUTH_ERROR_CODES = frozenset(
         "provider_failure",
     }
 )
+OAUTH_PROVIDERS = frozenset({"telegram", "google", "yandex", "vk", "apple"})
 
 
 def safe_auth_next_path(value: str | None) -> str | None:

--- a/backend/fitminiapp_api/services/auth_redirects.py
+++ b/backend/fitminiapp_api/services/auth_redirects.py
@@ -27,10 +27,36 @@ def safe_auth_next_path(value: str | None) -> str | None:
     return None
 
 
-def auth_error_redirect(code: str, *, next_path: str | None = None) -> str:
+def _link_error_code(code: str) -> str:
+    return {
+        "conflict": "oauth_link_conflict",
+        "invalid_state": "oauth_link_invalid_state",
+        "denied": "oauth_link_denied",
+        "provider_failure": "oauth_link_provider_failure",
+        "unavailable": "oauth_link_unavailable",
+        "blocked": "oauth_link_blocked",
+    }.get(code, "oauth_link_provider_failure")
+
+
+def auth_error_redirect(
+    code: str,
+    *,
+    next_path: str | None = None,
+    provider: str | None = None,
+    link: bool = False,
+) -> str:
     normalized_code = code if code in AUTH_ERROR_CODES else "provider_failure"
-    target = safe_auth_next_path(next_path) or "/app"
-    return f"/login?{urlencode({'next': target, 'auth_error': normalized_code})}"
+    params = {
+        "auth_error": _link_error_code(normalized_code) if link else normalized_code,
+    }
+    if provider in OAUTH_PROVIDERS:
+        params["oauth_provider"] = provider
+    if not link:
+        params = {
+            "next": safe_auth_next_path(next_path) or "/app",
+            **params,
+        }
+    return f"/{'app' if link else 'login'}?{urlencode(params)}"
 
 
 def account_link_error_redirect(code: str) -> str:

--- a/backend/fitminiapp_api/services/daily_wellbeing.py
+++ b/backend/fitminiapp_api/services/daily_wellbeing.py
@@ -51,7 +51,6 @@ def get_daily_wellbeing(
     user: User,
     local_date: date,
 ) -> dict:
-    validate_local_date(user, local_date)
     row = (
         db.query(DailyWellbeingCheckIn)
         .filter(
@@ -60,6 +59,8 @@ def get_daily_wellbeing(
         )
         .one_or_none()
     )
+    # Reads may inspect an empty future calendar date, especially immediately
+    # after the account timezone changes; only writes reject future dates.
     return {
         "local_date": local_date,
         "today": today_for_user(user),
@@ -74,7 +75,6 @@ def save_daily_wellbeing(
     local_date: date,
     payload: DailyWellbeingCheckInSaveRequest,
 ) -> DailyWellbeingCheckIn:
-    validate_local_date(user, local_date)
     if (
         payload.sleep_quality is None
         and payload.sleep_duration_minutes is None
@@ -91,6 +91,10 @@ def save_daily_wellbeing(
         )
         .one_or_none()
     )
+    # A timezone change must not turn an already valid check-in into a future
+    # date while the user is editing it. New rows still cannot be future-dated.
+    if row is None:
+        validate_local_date(user, local_date)
     now = now_for_user_naive(user)
     values = {
         "sleep_quality": payload.sleep_quality,
@@ -122,11 +126,18 @@ def save_daily_wellbeing(
 
 
 def delete_daily_wellbeing(db: Session, user: User, local_date: date) -> None:
-    validate_local_date(user, local_date)
-    db.query(DailyWellbeingCheckIn).filter(
-        DailyWellbeingCheckIn.user_id == user.id,
-        DailyWellbeingCheckIn.local_date == local_date,
-    ).delete(synchronize_session=False)
+    row = (
+        db.query(DailyWellbeingCheckIn)
+        .filter(
+            DailyWellbeingCheckIn.user_id == user.id,
+            DailyWellbeingCheckIn.local_date == local_date,
+        )
+        .one_or_none()
+    )
+    if row is None:
+        validate_local_date(user, local_date)
+    else:
+        db.delete(row)
     db.commit()
 
 

--- a/backend/fitminiapp_api/services/oauth_login.py
+++ b/backend/fitminiapp_api/services/oauth_login.py
@@ -167,26 +167,6 @@ _register_oidc(
 _register_yandex(settings.yandex_oauth_client_id, settings.yandex_oauth_client_secret)
 
 
-def _vk_callback_params(request) -> dict[str, str]:
-    """Accept both VK ID's flat callback and its JSON ``payload`` form."""
-
-    params = dict(request.query_params.items())
-    raw_payload = params.get("payload")
-    if raw_payload:
-        payload = json.loads(raw_payload)
-        if not isinstance(payload, dict):
-            raise ValueError("VK ID returned an invalid callback payload")
-        for key, value in payload.items():
-            if value is None:
-                continue
-            normalized_value = str(value)
-            if key in params and key != "payload" and params[key] != normalized_value:
-                raise OAuthStateError("VK ID returned conflicting callback parameters")
-            params[key] = normalized_value
-    params.pop("payload", None)
-    return params
-
-
 def _pkce_challenge(code_verifier: str) -> str:
     digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
     return base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
@@ -198,16 +178,9 @@ class VKOAuthClient:
     def __init__(self, client_id: str) -> None:
         self.client_id = client_id
 
-    async def authorize_redirect(self, request, redirect_uri: str):
-        from starlette.responses import RedirectResponse
-
+    def create_authorization_data(self, redirect_uri: str) -> dict[str, str]:
         state = secrets.token_urlsafe(32)
         code_verifier = secrets.token_urlsafe(48)
-        request.session[VK_SESSION_KEY] = {
-            "state": state,
-            "code_verifier": code_verifier,
-            "redirect_uri": redirect_uri,
-        }
         query = urlencode(
             {
                 "response_type": "code",
@@ -216,14 +189,40 @@ class VKOAuthClient:
                 "scope": VK_SCOPE,
                 "state": state,
                 "code_challenge": _pkce_challenge(code_verifier),
-                # VK ID's current Web SDK sends the method token in lowercase.
-                "code_challenge_method": "s256",
+                "code_challenge_method": "S256",
             }
         )
-        return RedirectResponse(f"{VK_AUTHORIZE_URL}?{query}", status_code=302)
+        return {
+            "url": f"{VK_AUTHORIZE_URL}?{query}",
+            "state": state,
+            "code_verifier": code_verifier,
+            "redirect_uri": redirect_uri,
+        }
+
+    async def _callback_params(self, request) -> dict[str, str]:
+        cached = getattr(request.state, "oauth_callback_params", None)
+        if isinstance(cached, dict):
+            return cached
+
+        params: dict[str, str] = {}
+        for key, value in request.query_params.multi_items():
+            normalized = str(value)
+            existing = params.get(key)
+            if existing is not None and existing != normalized:
+                raise OAuthStateError("VK ID returned conflicting callback parameters")
+            params[key] = normalized
+        if request.scope.get("method", "GET") != "GET":
+            async with request.form() as form:
+                for key, value in form.multi_items():
+                    normalized = str(value)
+                    existing = params.get(key)
+                    if existing is not None and existing != normalized:
+                        raise OAuthStateError("VK ID returned conflicting callback parameters")
+                    params[key] = normalized
+        return merge_vk_callback_payload(params)
 
     async def authorize_access_token(self, request) -> dict[str, object]:
-        params = _vk_callback_params(request)
+        params = await self._callback_params(request)
         error = params.get("error")
         if error:
             raise OAuthProviderResponseError(error)
@@ -289,6 +288,30 @@ class VKOAuthClient:
             if not isinstance(profile, dict) or not isinstance(profile.get("user"), dict):
                 raise ValueError("VK ID returned an invalid user profile")
             return {**token, "userinfo": profile["user"]}
+
+
+def merge_vk_callback_payload(params: dict[str, str]) -> dict[str, str]:
+    """Merge VK flat and JSON callback forms while rejecting conflicts."""
+
+    merged = dict(params)
+    raw_payload = merged.pop("payload", None)
+    if not raw_payload:
+        return merged
+    try:
+        payload = json.loads(raw_payload)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("VK ID returned an invalid callback payload") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("VK ID returned an invalid callback payload")
+    for key, value in payload.items():
+        if value is None:
+            continue
+        normalized = str(value)
+        existing = merged.get(key)
+        if existing is not None and existing != normalized:
+            raise OAuthStateError("VK ID returned conflicting callback parameters")
+        merged[key] = normalized
+    return merged
 
 
 def configured_oauth_client(provider: str):

--- a/backend/fitminiapp_api/services/oauth_transactions.py
+++ b/backend/fitminiapp_api/services/oauth_transactions.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import hashlib
+import re
+import secrets
+from collections.abc import Mapping, MutableMapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from fitminiapp_api.core.config import settings
+from fitminiapp_api.models.oauth_transaction import OAuthTransaction
+from fitminiapp_api.services.auth_redirects import OAUTH_PROVIDERS, safe_auth_next_path
+
+OAUTH_BROWSER_MARKER_KEY = "oauth_browser_marker"
+LEGACY_OAUTH_SESSION_KEYS = frozenset(
+    {
+        "oauth_next",
+        "oauth_link_token",
+        "oauth_link_provider",
+        "oauth_link_family",
+        "vk_oauth",
+    }
+)
+OAUTH_STATE_RE = re.compile(r"[A-Za-z0-9._~-]{8,256}")
+BROWSER_MARKER_RE = re.compile(r"[A-Za-z0-9_-]{32,128}")
+
+
+def utcnow() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+def hash_secret(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def transaction_hash_prefix(state: str) -> str:
+    return hash_secret(state)[:12]
+
+
+def new_browser_marker() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def is_valid_browser_marker(value: object) -> bool:
+    return isinstance(value, str) and BROWSER_MARKER_RE.fullmatch(value) is not None
+
+
+def is_valid_oauth_state(value: object) -> bool:
+    return isinstance(value, str) and OAUTH_STATE_RE.fullmatch(value) is not None
+
+
+def scrub_legacy_oauth_session(session: MutableMapping[str, Any]) -> bool:
+    removed = False
+    for key in list(session.keys()):
+        if key.startswith("_state_") or key in LEGACY_OAUTH_SESSION_KEYS:
+            session.pop(key, None)
+            removed = True
+    return removed
+
+
+def prepare_oauth_session(session: MutableMapping[str, Any]) -> str:
+    scrub_legacy_oauth_session(session)
+    marker: object = session.get(OAUTH_BROWSER_MARKER_KEY)
+    if isinstance(marker, str) and is_valid_browser_marker(marker):
+        return marker
+    marker = new_browser_marker()
+    session[OAUTH_BROWSER_MARKER_KEY] = marker
+    return marker
+
+
+def browser_marker_from_session(session: Mapping[str, Any]) -> str | None:
+    marker: object = session.get(OAUTH_BROWSER_MARKER_KEY)
+    return marker if isinstance(marker, str) and is_valid_browser_marker(marker) else None
+
+
+def _transaction_expired(row: OAuthTransaction, now: datetime) -> bool:
+    return row.expires_at <= now
+
+
+@dataclass(frozen=True)
+class OAuthTransactionClaim:
+    transaction: OAuthTransaction | None
+    reason: str | None
+
+
+def _prune_terminal_transactions(db: Session, now: datetime) -> None:
+    cutoff = now - timedelta(seconds=settings.oauth_transaction_ttl_seconds)
+    db.query(OAuthTransaction).filter(
+        OAuthTransaction.status == "pending",
+        OAuthTransaction.expires_at <= now,
+    ).update(
+        {
+            OAuthTransaction.status: "expired",
+            OAuthTransaction.failure_reason: "expired_state",
+            OAuthTransaction.completed_at: now,
+        },
+        synchronize_session=False,
+    )
+    db.query(OAuthTransaction).filter(
+        OAuthTransaction.status == "processing",
+        OAuthTransaction.claimed_at < cutoff,
+    ).update(
+        {
+            OAuthTransaction.status: "failed",
+            OAuthTransaction.failure_reason: "processing_timeout",
+            OAuthTransaction.completed_at: now,
+        },
+        synchronize_session=False,
+    )
+    db.query(OAuthTransaction).filter(
+        OAuthTransaction.status != "pending",
+        or_(
+            OAuthTransaction.completed_at < cutoff,
+            OAuthTransaction.expires_at < cutoff,
+        ),
+    ).delete(synchronize_session=False)
+
+
+def create_oauth_transaction(
+    db: Session,
+    *,
+    browser_marker: str,
+    provider: str,
+    purpose: str,
+    authorization_data: Mapping[str, Any],
+    next_path: str | None = None,
+    link_action_token_hash: str | None = None,
+    link_user_id: int | None = None,
+    session_family_id: str | None = None,
+    now: datetime | None = None,
+) -> OAuthTransaction:
+    current = now or utcnow()
+    state = authorization_data.get("state")
+    redirect_uri = authorization_data.get("redirect_uri")
+    if not is_valid_browser_marker(browser_marker):
+        raise ValueError("OAuth browser marker is invalid")
+    if provider not in OAUTH_PROVIDERS:
+        raise ValueError("Unsupported OAuth provider")
+    if purpose not in {"login", "link"}:
+        raise ValueError("Unsupported OAuth purpose")
+    if not is_valid_oauth_state(state) or not isinstance(redirect_uri, str) or not redirect_uri:
+        raise ValueError("OAuth authorization data is invalid")
+    safe_path = safe_auth_next_path(next_path)
+    if next_path is not None and safe_path is None:
+        raise ValueError("OAuth next path is invalid")
+
+    _prune_terminal_transactions(db, current)
+    row = OAuthTransaction(
+        transaction_id=secrets.token_urlsafe(32),
+        browser_marker_hash=hash_secret(browser_marker),
+        provider=provider,
+        purpose=purpose,
+        state=state,
+        redirect_uri=redirect_uri,
+        next_path=safe_path,
+        code_verifier=(
+            authorization_data.get("code_verifier")
+            if isinstance(authorization_data.get("code_verifier"), str)
+            else None
+        ),
+        nonce=(
+            authorization_data.get("nonce")
+            if isinstance(authorization_data.get("nonce"), str)
+            else None
+        ),
+        link_action_token_hash=link_action_token_hash,
+        link_user_id=link_user_id,
+        session_family_id=session_family_id,
+        expires_at=current + timedelta(seconds=settings.oauth_transaction_ttl_seconds),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def claim_oauth_transaction(
+    db: Session,
+    *,
+    browser_marker: str | None,
+    provider: str,
+    state: str | None,
+    now: datetime | None = None,
+) -> OAuthTransactionClaim:
+    current = now or utcnow()
+    if not browser_marker or not is_valid_browser_marker(browser_marker):
+        return OAuthTransactionClaim(None, "invalid_state")
+    if not is_valid_oauth_state(state):
+        return OAuthTransactionClaim(None, "invalid_state")
+
+    row = (
+        db.query(OAuthTransaction)
+        .filter(
+            OAuthTransaction.browser_marker_hash == hash_secret(browser_marker),
+            OAuthTransaction.provider == provider,
+            OAuthTransaction.state == state,
+        )
+        .with_for_update()
+        .first()
+    )
+    if row is None:
+        return OAuthTransactionClaim(None, "invalid_state")
+    if row.status != "pending":
+        return OAuthTransactionClaim(
+            row,
+            "expired_state" if row.status == "expired" else "repeated_state",
+        )
+    if _transaction_expired(row, current):
+        row.status = "expired"
+        row.failure_reason = "expired_state"
+        row.completed_at = current
+        db.commit()
+        return OAuthTransactionClaim(row, "expired_state")
+
+    row.status = "processing"
+    row.claimed_at = current
+    db.commit()
+    db.refresh(row)
+    return OAuthTransactionClaim(row, None)
+
+
+def has_pending_oauth_transactions(db: Session, browser_marker: str | None) -> bool:
+    if not browser_marker or not is_valid_browser_marker(browser_marker):
+        return False
+    return (
+        db.query(OAuthTransaction.transaction_id)
+        .filter(
+            OAuthTransaction.browser_marker_hash == hash_secret(browser_marker),
+            OAuthTransaction.status == "pending",
+            OAuthTransaction.expires_at > utcnow(),
+        )
+        .first()
+        is not None
+    )
+
+
+def finish_oauth_transaction(
+    db: Session,
+    row: OAuthTransaction,
+    *,
+    failure_reason: str | None = None,
+    commit: bool = True,
+) -> None:
+    if row.status != "processing":
+        return
+    row.status = "failed" if failure_reason else "completed"
+    row.failure_reason = failure_reason
+    row.completed_at = utcnow()
+    if commit:
+        db.commit()
+    else:
+        db.flush()
+
+
+def authlib_state_data(row: OAuthTransaction) -> dict[str, str]:
+    data = {"redirect_uri": row.redirect_uri}
+    if row.code_verifier:
+        data["code_verifier"] = row.code_verifier
+    if row.nonce:
+        data["nonce"] = row.nonce
+    return data

--- a/backend/fitminiapp_api/services/password_auth.py
+++ b/backend/fitminiapp_api/services/password_auth.py
@@ -102,7 +102,19 @@ def create_action_token(
 
 
 def consume_action_token(db: Session, raw_token: str, *, purpose: str) -> AuthActionToken:
-    token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
+    return consume_action_token_hash(
+        db,
+        hashlib.sha256(raw_token.encode()).hexdigest(),
+        purpose=purpose,
+    )
+
+
+def consume_action_token_hash(
+    db: Session,
+    token_hash: str,
+    *,
+    purpose: str,
+) -> AuthActionToken:
     row = (
         db.query(AuthActionToken)
         .filter(

--- a/backend/tests/test_alembic_config.py
+++ b/backend/tests/test_alembic_config.py
@@ -49,7 +49,7 @@ def test_legacy_support_revision_remains_in_the_linear_upgrade_path() -> None:
     assert auth_families is not None
     assert relocated_marker is not None
     assert auth_families.down_revision == legacy_support.revision
-    assert revisions.get_heads() == ["0069_daily_wellbeing_check_ins"]
+    assert revisions.get_heads() == ["0070_browser_oauth_transactions"]
     assert relocated_marker.revision in {
         revision.revision
         for revision in revisions.iterate_revisions("head", legacy_support.revision)

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -4138,6 +4138,15 @@ def test_oauth_callback_creates_browser_session_without_exposing_access_token(cl
     from fitminiapp_api.core.config import settings
 
     class FakeTelegramClient:
+        async def create_authorization_url(self, callback_url):
+            state = "fake-telegram-state"
+            return {
+                "url": f"https://telegram.example/authorize?state={state}",
+                "state": state,
+                "code_verifier": "fake-telegram-code-verifier",
+                "redirect_uri": callback_url,
+            }
+
         async def authorize_access_token(self, request):
             del request
             return {
@@ -4155,8 +4164,11 @@ def test_oauth_callback_creates_browser_session_without_exposing_access_token(cl
         "configured_oauth_client",
         lambda provider: FakeTelegramClient() if provider == "telegram" else None,
     )
+    started = client.get("/api/v1/auth/oauth/telegram/start", follow_redirects=False)
+    state = parse_qs(urlparse(started.headers["location"]).query)["state"][0]
     response = client.get(
         "/api/v1/auth/oauth/telegram/callback",
+        params={"code": "provider-code", "state": state},
         follow_redirects=False,
     )
 
@@ -4319,8 +4331,6 @@ def test_telegram_user_cannot_create_another_link(client):
 
 
 def test_telegram_account_explicitly_links_google_login(client, monkeypatch):
-    from fastapi.responses import RedirectResponse
-
     from fitminiapp_api.api.v1 import auth as auth_api
     from fitminiapp_api.services.oauth_login import get_or_create_oauth_user
 
@@ -4332,9 +4342,14 @@ def test_telegram_account_explicitly_links_google_login(client, monkeypatch):
     }
 
     class FakeGoogleClient:
-        async def authorize_redirect(self, request, callback_url):
-            del request, callback_url
-            return RedirectResponse("https://accounts.example/authorize")
+        async def create_authorization_url(self, callback_url):
+            state = "fake-google-link-state"
+            return {
+                "url": f"https://accounts.example/authorize?state={state}",
+                "state": state,
+                "code_verifier": "fake-google-link-code-verifier",
+                "redirect_uri": callback_url,
+            }
 
         async def authorize_access_token(self, request):
             del request
@@ -4358,9 +4373,14 @@ def test_telegram_account_explicitly_links_google_login(client, monkeypatch):
 
     started = client.get(created.json()["oauth_url"], follow_redirects=False)
     assert started.status_code in {302, 307}
-    assert started.headers["location"] == "https://accounts.example/authorize"
+    assert started.headers["location"].startswith("https://accounts.example/authorize?")
+    state = parse_qs(urlparse(started.headers["location"]).query)["state"][0]
 
-    callback = client.get("/api/v1/auth/oauth/google/callback", follow_redirects=False)
+    callback = client.get(
+        "/api/v1/auth/oauth/google/callback",
+        params={"code": "provider-code", "state": state},
+        follow_redirects=False,
+    )
     assert callback.status_code == 303
     assert callback.headers["location"] == "/app?auth_linked=google"
 
@@ -4374,8 +4394,6 @@ def test_telegram_account_explicitly_links_google_login(client, monkeypatch):
 
 
 def test_oauth_link_refuses_identity_owned_by_another_account(client, monkeypatch):
-    from fastapi.responses import RedirectResponse
-
     from fitminiapp_api.api.v1 import auth as auth_api
     from fitminiapp_api.services.oauth_login import get_or_create_oauth_user
 
@@ -4394,9 +4412,14 @@ def test_oauth_link_refuses_identity_owned_by_another_account(client, monkeypatc
         existing_google_id = existing_google.id
 
     class FakeGoogleClient:
-        async def authorize_redirect(self, request, callback_url):
-            del request, callback_url
-            return RedirectResponse("https://accounts.example/authorize")
+        async def create_authorization_url(self, callback_url):
+            state = "fake-google-link-conflict-state"
+            return {
+                "url": f"https://accounts.example/authorize?state={state}",
+                "state": state,
+                "code_verifier": "fake-google-link-conflict-code-verifier",
+                "redirect_uri": callback_url,
+            }
 
         async def authorize_access_token(self, request):
             del request
@@ -4414,11 +4437,18 @@ def test_oauth_link_refuses_identity_owned_by_another_account(client, monkeypatc
     telegram_id = client.get("/api/v1/me", headers=telegram_headers).json()["id"]
 
     created = client.post("/api/v1/me/auth/oauth-link/google", headers=telegram_headers)
-    client.get(created.json()["oauth_url"], follow_redirects=False)
-    callback = client.get("/api/v1/auth/oauth/google/callback", follow_redirects=False)
+    started = client.get(created.json()["oauth_url"], follow_redirects=False)
+    state = parse_qs(urlparse(started.headers["location"]).query)["state"][0]
+    callback = client.get(
+        "/api/v1/auth/oauth/google/callback",
+        params={"code": "provider-code", "state": state},
+        follow_redirects=False,
+    )
 
     assert callback.status_code == 303
-    assert callback.headers["location"] == "/app?auth_error=conflict"
+    assert (
+        callback.headers["location"] == "/app?auth_error=oauth_link_conflict&oauth_provider=google"
+    )
     me = client.get("/api/v1/me", headers=telegram_headers).json()
     assert me["id"] == telegram_id
     assert me["auth_providers"] == ["telegram"]

--- a/backend/tests/test_auth_hardening.py
+++ b/backend/tests/test_auth_hardening.py
@@ -7,7 +7,6 @@ from uuid import uuid4
 import jwt
 import pytest
 from fastapi import Response
-from fastapi.responses import RedirectResponse
 from starlette.testclient import TestClient
 
 from fitminiapp_api.api.v1 import auth as auth_api
@@ -21,7 +20,7 @@ from fitminiapp_api.models.token import RefreshToken
 from fitminiapp_api.models.user import User
 from fitminiapp_api.services.auth_redirects import auth_error_redirect, safe_auth_next_path
 from fitminiapp_api.services.jwt import ALGORITHM, decode_token, hash_token
-from fitminiapp_api.services.oauth_login import OAuthStateError, get_or_create_oauth_user
+from fitminiapp_api.services.oauth_login import get_or_create_oauth_user
 from fitminiapp_api.services.password_auth import utcnow
 from fitminiapp_api.services.telegram_auth import get_or_create_user_from_init_data
 
@@ -50,14 +49,17 @@ class _FakeGoogleClient:
     def __init__(self, claims: dict[str, object]) -> None:
         self.claims = claims
 
-    async def authorize_redirect(self, request, callback_url):
-        del callback_url
-        request.session["fake_oauth_state"] = "active"
-        return RedirectResponse("https://accounts.example/authorize")
+    async def create_authorization_url(self, callback_url):
+        state = f"fake-google-state-{id(self)}"
+        return {
+            "url": f"https://accounts.example/authorize?state={state}",
+            "state": state,
+            "code_verifier": "fake-google-code-verifier",
+            "redirect_uri": callback_url,
+        }
 
     async def authorize_access_token(self, request):
-        if request.session.pop("fake_oauth_state", None) != "active":
-            raise OAuthStateError("state expired")
+        del request
         return {"userinfo": self.claims}
 
 
@@ -91,14 +93,25 @@ def test_oauth_link_is_bound_to_owner_session_and_is_one_time(client, monkeypatc
 
     started = client.get(link_url, follow_redirects=False)
     assert started.status_code in {302, 307}
-    callback = client.get("/api/v1/auth/oauth/google/callback", follow_redirects=False)
+    state = parse_qs(urlparse(started.headers["location"]).query)["state"][0]
+    callback = client.get(
+        "/api/v1/auth/oauth/google/callback",
+        params={"code": "provider-code", "state": state},
+        follow_redirects=False,
+    )
     assert callback.status_code == 303
     assert callback.headers["location"] == "/app?auth_linked=google"
     assert settings.refresh_cookie_name not in callback.headers.get("set-cookie", "")
 
-    replayed = client.get("/api/v1/auth/oauth/google/callback", follow_redirects=False)
+    replayed = client.get(
+        "/api/v1/auth/oauth/google/callback",
+        params={"code": "provider-code", "state": state},
+        follow_redirects=False,
+    )
     assert replayed.status_code == 303
-    assert replayed.headers["location"] == "/login?next=%2Fapp&auth_error=invalid_state"
+    assert replayed.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=invalid_state&oauth_provider=google"
+    )
     with get_session_context() as db:
         identities = db.query(AuthIdentity).filter(AuthIdentity.user_id == owner_id).all()
         assert sorted(identity.provider for identity in identities) == ["google", "telegram"]
@@ -150,22 +163,31 @@ def test_oauth_browser_errors_are_normalized(client, monkeypatch):
         lambda provider: _FakeGoogleClient(blocked_claims) if provider == "google" else None,
     )
 
-    assert client.get("/api/v1/auth/oauth/google/start", follow_redirects=False).status_code in {
+    started = client.get("/api/v1/auth/oauth/google/start", follow_redirects=False)
+    assert started.status_code in {
         302,
         307,
     }
+    state = parse_qs(urlparse(started.headers["location"]).query)["state"][0]
     denied = client.get(
-        "/api/v1/auth/oauth/google/callback?error=access_denied",
+        "/api/v1/auth/oauth/google/callback",
+        params={"error": "access_denied", "state": state},
         follow_redirects=False,
     )
-    assert denied.headers["location"] == "/login?next=%2Fapp&auth_error=denied"
+    assert denied.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=denied&oauth_provider=google"
+    )
 
-    client.get("/api/v1/auth/oauth/google/start", follow_redirects=False)
+    started = client.get("/api/v1/auth/oauth/google/start", follow_redirects=False)
+    state = parse_qs(urlparse(started.headers["location"]).query)["state"][0]
     blocked_response = client.get(
         "/api/v1/auth/oauth/google/callback",
+        params={"code": "provider-code", "state": state},
         follow_redirects=False,
     )
-    assert blocked_response.headers["location"] == "/login?next=%2Fapp&auth_error=blocked"
+    assert blocked_response.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=blocked&oauth_provider=google"
+    )
 
 
 def test_refresh_replay_revokes_only_its_family_and_logout_revokes_access():

--- a/backend/tests/test_auth_providers.py
+++ b/backend/tests/test_auth_providers.py
@@ -2,12 +2,11 @@ import hashlib
 import hmac
 import json
 import time
-from urllib.parse import urlencode
+from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
 import pytest
 from authlib.integrations.base_client.errors import OAuthError
-from fastapi.responses import RedirectResponse
 from pydantic import ValidationError
 
 from fitminiapp_api.api.v1 import auth as auth_api
@@ -52,9 +51,14 @@ class _FakeOAuthClient:
         self.claims = claims or {}
         self.error = error
 
-    async def authorize_redirect(self, request, redirect_uri):
-        request.session["fake_redirect_uri"] = redirect_uri
-        return RedirectResponse("https://provider.example/authorize", status_code=302)
+    async def create_authorization_url(self, redirect_uri):
+        state = "provider-test-state"
+        return {
+            "url": f"https://provider.example/authorize?state={state}",
+            "state": state,
+            "code_verifier": "provider-test-code-verifier",
+            "redirect_uri": redirect_uri,
+        }
 
     async def authorize_access_token(self, request):
         del request
@@ -291,7 +295,13 @@ def test_yandex_callback_uses_stable_id_and_unverified_contact_email(client, mon
         ),
     )
 
-    response = client.get("/api/v1/auth/oauth/yandex/callback", follow_redirects=False)
+    started = client.get("/api/v1/auth/oauth/yandex/start", follow_redirects=False)
+    state = parse_qs(urlparse(started.headers["location"]).query)["state"][0]
+    response = client.get(
+        "/api/v1/auth/oauth/yandex/callback",
+        params={"code": "yandex-code", "state": state},
+        follow_redirects=False,
+    )
 
     assert response.status_code == 303
     assert response.headers["location"] == "/app"
@@ -314,32 +324,62 @@ def test_oauth_library_errors_are_normalized(client, monkeypatch, error, expecte
         lambda provider: _FakeOAuthClient(error=OAuthError(error=error)),
     )
 
-    response = client.get("/api/v1/auth/oauth/google/callback", follow_redirects=False)
+    started = client.get("/api/v1/auth/oauth/google/start", follow_redirects=False)
+    state = parse_qs(urlparse(started.headers["location"]).query)["state"][0]
+    response = client.get(
+        "/api/v1/auth/oauth/google/callback",
+        params={"code": "google-code", "state": state},
+        follow_redirects=False,
+    )
 
     assert response.status_code == 303
-    assert response.headers["location"] == f"/login?next=%2Fapp&auth_error={expected}"
+    assert response.headers["location"] == (
+        f"/login?next=%2Fapp&auth_error={expected}&oauth_provider=google"
+    )
 
 
 def test_provider_timeout_is_safe_on_start_and_callback(client, monkeypatch):
-    class TimeoutClient(_FakeOAuthClient):
-        async def authorize_redirect(self, request, redirect_uri):
-            del request, redirect_uri
+    class StartTimeoutClient(_FakeOAuthClient):
+        async def create_authorization_url(self, redirect_uri):
+            del redirect_uri
             raise httpx.ConnectTimeout("provider timeout")
+
+    class CallbackTimeoutClient(_FakeOAuthClient):
+        async def authorize_access_token(self, request):
+            del request
+            raise httpx.ReadTimeout("provider timeout")
 
     monkeypatch.setattr(settings, "enable_web_auth", True)
     monkeypatch.setattr(
         auth_api,
         "configured_oauth_client",
-        lambda provider: TimeoutClient(error=httpx.ReadTimeout("provider timeout")),
+        lambda provider: StartTimeoutClient() if provider == "google" else None,
     )
 
     started = client.get("/api/v1/auth/oauth/google/start", follow_redirects=False)
-    callback = client.get("/api/v1/auth/oauth/google/callback", follow_redirects=False)
 
     assert started.status_code == 303
-    assert started.headers["location"] == "/login?next=%2Fapp&auth_error=unavailable"
+    assert started.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=unavailable&oauth_provider=google"
+    )
+
+    monkeypatch.setattr(
+        auth_api,
+        "configured_oauth_client",
+        lambda provider: CallbackTimeoutClient() if provider == "google" else None,
+    )
+    started = client.get("/api/v1/auth/oauth/google/start", follow_redirects=False)
+    state = parse_qs(urlparse(started.headers["location"]).query)["state"][0]
+    callback = client.get(
+        "/api/v1/auth/oauth/google/callback",
+        params={"code": "google-code", "state": state},
+        follow_redirects=False,
+    )
+
     assert callback.status_code == 303
-    assert callback.headers["location"] == "/login?next=%2Fapp&auth_error=provider_failure"
+    assert callback.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=provider_failure&oauth_provider=google"
+    )
 
 
 def test_post_callback_cancel_is_normalized_without_provider_call(client, monkeypatch):
@@ -351,14 +391,18 @@ def test_post_callback_cancel_is_normalized_without_provider_call(client, monkey
     monkeypatch.setattr(settings, "enable_web_auth", True)
     monkeypatch.setattr(auth_api, "configured_oauth_client", lambda provider: UnexpectedClient())
 
+    started = client.get("/api/v1/auth/oauth/apple/start", follow_redirects=False)
+    state = parse_qs(urlparse(started.headers["location"]).query)["state"][0]
     response = client.post(
         "/api/v1/auth/oauth/apple/callback",
-        data={"error": "user_cancelled"},
+        data={"error": "user_cancelled", "state": state},
         follow_redirects=False,
     )
 
     assert response.status_code == 303
-    assert response.headers["location"] == "/login?next=%2Fapp&auth_error=denied"
+    assert response.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=denied&oauth_provider=apple"
+    )
 
 
 def test_post_callback_success_keeps_form_available_for_provider_client(client, monkeypatch):
@@ -366,7 +410,7 @@ def test_post_callback_success_keeps_form_available_for_provider_client(client, 
         async def authorize_access_token(self, request):
             async with request.form() as form:
                 assert form.get("code") == "apple-code"
-                assert form.get("state") == "apple-state"
+                assert form.get("state") == state
             return {
                 "userinfo": {
                     "sub": "apple-form-subject",
@@ -378,9 +422,11 @@ def test_post_callback_success_keeps_form_available_for_provider_client(client, 
     monkeypatch.setattr(settings, "enable_web_auth", True)
     monkeypatch.setattr(auth_api, "configured_oauth_client", lambda provider: FormReadingClient())
 
+    started = client.get("/api/v1/auth/oauth/apple/start", follow_redirects=False)
+    state = parse_qs(urlparse(started.headers["location"]).query)["state"][0]
     response = client.post(
         "/api/v1/auth/oauth/apple/callback",
-        data={"code": "apple-code", "state": "apple-state"},
+        data={"code": "apple-code", "state": state},
         follow_redirects=False,
     )
 

--- a/backend/tests/test_oauth_session_recovery.py
+++ b/backend/tests/test_oauth_session_recovery.py
@@ -1,0 +1,322 @@
+import base64
+import json
+from datetime import UTC, datetime, timedelta
+from time import time
+from urllib.parse import parse_qs, quote, urlparse
+
+from itsdangerous import TimestampSigner
+from starlette.responses import Response
+
+from fitminiapp_api.core.config import settings
+from fitminiapp_api.db.session import get_session_context
+from fitminiapp_api.models.oauth_transaction import OAuthTransaction
+from fitminiapp_api.services.jwt import decode_token
+
+
+class FakeOAuthClient:
+    name = "google"
+
+    def __init__(self) -> None:
+        self.states: list[str] = []
+        self.token_calls = 0
+
+    async def create_authorization_url(self, redirect_uri: str) -> dict[str, str]:
+        state = f"google-test-state-{len(self.states) + 1:03d}"
+        self.states.append(state)
+        return {
+            "url": f"https://accounts.example/authorize?state={state}",
+            "state": state,
+            "code_verifier": "test-code-verifier-which-is-kept-server-side",
+            "nonce": "test-nonce-which-is-kept-server-side",
+            "redirect_uri": redirect_uri,
+        }
+
+    async def authorize_access_token(self, request):
+        callback_params = getattr(request.state, "oauth_callback_params", {})
+        state = callback_params.get("state")
+        assert isinstance(state, str)
+        state_data = request.session.pop(f"_state_{self.name}_{state}", None)
+        assert isinstance(state_data, dict)
+        assert state_data["data"]["code_verifier"] == (
+            "test-code-verifier-which-is-kept-server-side"
+        )
+        assert state_data["data"]["nonce"] == "test-nonce-which-is-kept-server-side"
+        self.token_calls += 1
+        return {
+            "userinfo": {
+                "sub": "google-recovery-subject",
+                "email": "oauth-recovery@example.com",
+                "email_verified": True,
+                "name": "OAuth Recovery User",
+            }
+        }
+
+
+def _configure_fake_google(monkeypatch, fake: FakeOAuthClient) -> None:
+    from fitminiapp_api.api.v1 import auth as auth_api
+
+    monkeypatch.setattr(settings, "enable_web_auth", True)
+    monkeypatch.setattr(settings, "google_oauth_client_id", "google-client")
+    monkeypatch.setattr(settings, "google_oauth_client_secret", "google-secret")
+    monkeypatch.setattr(
+        auth_api,
+        "configured_oauth_client",
+        lambda provider: fake if provider == "google" else None,
+    )
+
+
+def _start(client, *, next_path: str | None = None) -> str:
+    path = "/api/v1/auth/oauth/google/start"
+    if next_path:
+        path += f"?next={quote(next_path, safe='')}"
+    response = client.get(path, follow_redirects=False)
+    assert response.status_code == 302
+    query = parse_qs(urlparse(response.headers["location"]).query)
+    return query["state"][0]
+
+
+def _callback(client, state: str, **params):
+    return client.get(
+        "/api/v1/auth/oauth/google/callback",
+        params={"code": "provider-code", "state": state, **params},
+        follow_redirects=False,
+    )
+
+
+def _post_callback(client, state: str, **params):
+    return client.post(
+        "/api/v1/auth/oauth/google/callback",
+        data={"code": "provider-code", "state": state, **params},
+        follow_redirects=False,
+    )
+
+
+def test_wrong_state_does_not_exchange_and_retry_completes(client, monkeypatch):
+    fake = FakeOAuthClient()
+    _configure_fake_google(monkeypatch, fake)
+
+    first_state = _start(client, next_path="/coach")
+    failed = _callback(client, "attacker-state-value")
+
+    assert failed.status_code == 303
+    assert failed.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=invalid_state&oauth_provider=google"
+    )
+    assert fake.token_calls == 0
+
+    second_state = _start(client)
+    succeeded = _callback(client, second_state)
+
+    assert succeeded.status_code == 303
+    assert succeeded.headers["location"] == "/app"
+    assert "access_token" not in succeeded.headers["location"]
+    assert "fit_refresh_token=" in succeeded.headers["set-cookie"]
+    assert fake.token_calls == 1
+
+    with get_session_context() as db:
+        rows = {
+            row.state: row.status
+            for row in db.query(OAuthTransaction)
+            .filter(OAuthTransaction.state.in_([first_state, second_state]))
+            .all()
+        }
+    assert rows[first_state] == "pending"
+    assert rows[second_state] == "completed"
+
+
+def test_sequential_tabs_and_provider_denial_are_isolated(client, monkeypatch):
+    fake = FakeOAuthClient()
+    _configure_fake_google(monkeypatch, fake)
+
+    first_state = _start(client)
+    second_state = _start(client)
+
+    assert _callback(client, first_state).headers["location"] == "/app"
+    assert _callback(client, second_state).headers["location"] == "/app"
+    assert fake.token_calls == 2
+
+    denied_state = _start(client)
+    denied = _callback(client, denied_state, error="access_denied")
+
+    assert denied.status_code == 303
+    assert denied.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=denied&oauth_provider=google"
+    )
+    assert fake.token_calls == 2
+    with get_session_context() as db:
+        row = db.query(OAuthTransaction).filter(OAuthTransaction.state == denied_state).one()
+        assert row.status == "failed"
+        assert row.failure_reason == "provider_denied"
+
+
+def test_form_post_and_repeated_callback_are_safe(client, monkeypatch):
+    fake = FakeOAuthClient()
+    _configure_fake_google(monkeypatch, fake)
+
+    state = _start(client)
+    response = _post_callback(client, state)
+    repeated = _callback(client, state)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/app"
+    assert repeated.status_code == 303
+    assert repeated.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=invalid_state&oauth_provider=google"
+    )
+    assert fake.token_calls == 1
+    assert settings.refresh_cookie_name not in repeated.headers.get("set-cookie", "")
+
+
+def test_malformed_and_legacy_oauth_cookies_are_removed(client, monkeypatch):
+    fake = FakeOAuthClient()
+    _configure_fake_google(monkeypatch, fake)
+
+    client.cookies.set(settings.oauth_session_cookie_name, "not-a-valid-signed-cookie")
+    malformed = _callback(client, "attacker-state-value")
+
+    assert malformed.status_code == 303
+    assert f'{settings.oauth_session_cookie_name}=""' in malformed.headers["set-cookie"]
+    assert "Max-Age=0" in malformed.headers["set-cookie"]
+
+    legacy = {
+        "_state_google_old-state": {
+            "data": {"redirect_uri": "https://app.example/callback"},
+            "exp": (datetime.now(UTC) + timedelta(minutes=5)).timestamp(),
+        },
+        "oauth_next": "/evil",
+        "oauth_link_token": "raw-token-that-must-not-return",
+    }
+    encoded = base64.b64encode(json.dumps(legacy).encode("utf-8"))
+    signed = TimestampSigner(settings.secret_key).sign(encoded).decode("utf-8")
+    client.cookies.set(settings.oauth_session_cookie_name, signed)
+
+    stale = _callback(client, "attacker-state-value")
+
+    assert stale.status_code == 303
+    assert f"{settings.oauth_session_cookie_name}=null" in stale.headers["set-cookie"]
+    assert "raw-token-that-must-not-return" not in stale.headers.get("set-cookie", "")
+    assert fake.token_calls == 0
+
+
+def test_expired_and_rotated_oauth_cookies_are_removed(client, monkeypatch):
+    _configure_fake_google(monkeypatch, FakeOAuthClient())
+
+    for secret, timestamp in (
+        (
+            settings.secret_key,
+            int(time()) - settings.oauth_transaction_ttl_seconds - 1,
+        ),
+        ("previous-secret-key-that-is-not-current", None),
+    ):
+        client.cookies.clear()
+        signer = TimestampSigner(secret)
+        if timestamp is not None:
+            signer.get_timestamp = lambda timestamp=timestamp: timestamp
+        client.cookies.set(
+            settings.oauth_session_cookie_name,
+            signer.sign(base64.b64encode(b"{}")).decode("utf-8"),
+        )
+
+        response = _callback(client, "attacker-state-value")
+
+        assert response.status_code == 303
+        assert f'{settings.oauth_session_cookie_name}=""' in response.headers["set-cookie"]
+        assert "Max-Age=0" in response.headers["set-cookie"]
+
+
+def test_oauth_cookie_deletion_keeps_prod_attributes_and_refresh_cookie(monkeypatch):
+    from fitminiapp_api.api.v1 import auth as auth_api
+
+    monkeypatch.setattr(settings, "app_env", "prod")
+    response = Response()
+
+    auth_api._clear_oauth_cookie(response)
+
+    header = response.headers["set-cookie"].lower()
+    assert f'{settings.oauth_session_cookie_name}=""' in header
+    assert "max-age=0" in header
+    assert "path=/" in header
+    assert "httponly" in header
+    assert "samesite=none" in header
+    assert "secure" in header
+    assert settings.refresh_cookie_name not in header
+
+
+def test_expired_transaction_is_not_exchanged(client, monkeypatch):
+    fake = FakeOAuthClient()
+    _configure_fake_google(monkeypatch, fake)
+    state = _start(client)
+
+    with get_session_context() as db:
+        row = db.query(OAuthTransaction).filter(OAuthTransaction.state == state).one()
+        row.expires_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(seconds=1)
+        db.commit()
+
+    response = _callback(client, state)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=invalid_state&oauth_provider=google"
+    )
+    assert fake.token_calls == 0
+    with get_session_context() as db:
+        row = db.query(OAuthTransaction).filter(OAuthTransaction.state == state).one()
+        assert row.status == "expired"
+
+
+def test_new_start_prunes_old_terminal_transactions(client, monkeypatch):
+    fake = FakeOAuthClient()
+    _configure_fake_google(monkeypatch, fake)
+    state = _start(client)
+
+    with get_session_context() as db:
+        row = db.query(OAuthTransaction).filter(OAuthTransaction.state == state).one()
+        row.expires_at = datetime.now(UTC).replace(tzinfo=None) - timedelta(
+            seconds=settings.oauth_transaction_ttl_seconds + 1
+        )
+        db.commit()
+
+    replacement_state = _start(client)
+
+    with get_session_context() as db:
+        assert (
+            db.query(OAuthTransaction).filter(OAuthTransaction.state == state).one_or_none() is None
+        )
+        assert db.query(OAuthTransaction).filter(OAuthTransaction.state == replacement_state).one()
+
+
+def test_link_transaction_keeps_refresh_family_and_stores_only_hash(client, monkeypatch):
+    fake = FakeOAuthClient()
+    _configure_fake_google(monkeypatch, fake)
+
+    login = client.post(
+        "/api/v1/auth/dev-login",
+        json={"telegram_user_id": 8_840_101},
+    )
+    assert login.status_code == 200
+    headers = {"Authorization": f"Bearer {login.json()['access_token']}"}
+    before_cookie = client.cookies.get(settings.refresh_cookie_name)
+
+    created = client.post("/api/v1/me/auth/oauth-link/google", headers=headers)
+    assert created.status_code == 200
+    raw_token = parse_qs(urlparse(created.json()["oauth_url"]).query)["token"][0]
+    started = client.get(created.json()["oauth_url"], follow_redirects=False)
+    assert started.status_code == 302
+    state = parse_qs(urlparse(started.headers["location"]).query)["state"][0]
+
+    with get_session_context() as db:
+        row = db.query(OAuthTransaction).filter(OAuthTransaction.state == state).one()
+        assert row.purpose == "link"
+        assert row.link_action_token_hash
+        assert raw_token not in row.link_action_token_hash
+        assert (
+            row.session_family_id
+            == decode_token(login.json()["access_token"], expected_type="access")["sid"]
+        )
+
+    linked = _callback(client, state)
+
+    assert linked.status_code == 303
+    assert linked.headers["location"] == "/app?auth_linked=google"
+    assert "fit_refresh_token=" not in linked.headers.get("set-cookie", "")
+    assert client.cookies.get(settings.refresh_cookie_name) == before_cookie

--- a/backend/tests/test_telegram_oauth_proxy.py
+++ b/backend/tests/test_telegram_oauth_proxy.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from urllib.parse import parse_qs, urlparse
 
 import httpx
 import pytest
@@ -102,15 +103,38 @@ def test_telegram_tunnel_failure_is_controlled_and_retryable(client, monkeypatch
     leaked_proxy = "socks5://proxy-user:proxy-password@telegram-proxy.test:1081"
 
     class UnavailableTunnelClient:
-        async def authorize_redirect(self, request, redirect_uri):
-            del request, redirect_uri
+        async def create_authorization_url(self, redirect_uri):
+            del redirect_uri
             raise httpx.ConnectError(f"tunnel unavailable: {leaked_proxy}")
 
         async def authorize_access_token(self, request):
             del request
             raise httpx.ProxyError(f"tunnel unavailable: {leaked_proxy}")
 
+    class CallbackFailureClient:
+        async def create_authorization_url(self, redirect_uri):
+            state = "telegram-callback-failure-state"
+            return {
+                "url": f"https://telegram.example/authorize?state={state}",
+                "state": state,
+                "code_verifier": "telegram-callback-failure-verifier",
+                "redirect_uri": redirect_uri,
+            }
+
+        async def authorize_access_token(self, request):
+            del request
+            raise httpx.ProxyError(f"tunnel unavailable: {leaked_proxy}")
+
     class RecoveredTunnelClient:
+        async def create_authorization_url(self, redirect_uri):
+            state = "telegram-recovered-state"
+            return {
+                "url": f"https://telegram.example/authorize?state={state}",
+                "state": state,
+                "code_verifier": "telegram-recovered-verifier",
+                "redirect_uri": redirect_uri,
+            }
+
         async def authorize_access_token(self, request):
             del request
             return {
@@ -138,9 +162,13 @@ def test_telegram_tunnel_failure_is_controlled_and_retryable(client, monkeypatch
     failed = client.get("/api/v1/auth/oauth/telegram/callback", follow_redirects=False)
 
     assert started.status_code == 303
-    assert started.headers["location"] == "/login?next=%2Fapp&auth_error=unavailable"
+    assert started.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=unavailable&oauth_provider=telegram"
+    )
     assert failed.status_code == 303
-    assert failed.headers["location"] == "/login?next=%2Fapp&auth_error=provider_failure"
+    assert failed.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=invalid_state&oauth_provider=telegram"
+    )
     assert settings.refresh_cookie_name not in failed.headers.get("set-cookie", "")
     assert leaked_proxy not in caplog.text
     assert "proxy-password" not in caplog.text
@@ -154,9 +182,37 @@ def test_telegram_tunnel_failure_is_controlled_and_retryable(client, monkeypatch
     monkeypatch.setattr(
         auth_api,
         "configured_oauth_client",
+        lambda provider: CallbackFailureClient() if provider == "telegram" else None,
+    )
+    started = client.get("/api/v1/auth/oauth/telegram/start", follow_redirects=False)
+    state = parse_qs(urlparse(started.headers["location"]).query)["state"][0]
+    failed = client.get(
+        "/api/v1/auth/oauth/telegram/callback",
+        params={"code": "telegram-code", "state": state},
+        follow_redirects=False,
+    )
+
+    assert started.status_code == 302
+    assert failed.status_code == 303
+    assert failed.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=provider_failure&oauth_provider=telegram"
+    )
+    assert settings.refresh_cookie_name not in failed.headers.get("set-cookie", "")
+    assert leaked_proxy not in caplog.text
+    assert "proxy-password" not in caplog.text
+
+    monkeypatch.setattr(
+        auth_api,
+        "configured_oauth_client",
         lambda provider: RecoveredTunnelClient() if provider == "telegram" else None,
     )
-    recovered = client.get("/api/v1/auth/oauth/telegram/callback", follow_redirects=False)
+    started = client.get("/api/v1/auth/oauth/telegram/start", follow_redirects=False)
+    state = parse_qs(urlparse(started.headers["location"]).query)["state"][0]
+    recovered = client.get(
+        "/api/v1/auth/oauth/telegram/callback",
+        params={"code": "telegram-code", "state": state},
+        follow_redirects=False,
+    )
 
     assert recovered.status_code == 303
     assert recovered.headers["location"] == "/app"

--- a/backend/tests/test_vk_oauth.py
+++ b/backend/tests/test_vk_oauth.py
@@ -78,7 +78,7 @@ def _start_vk(client, path: str = "/api/v1/auth/oauth/vk/start") -> str:
     query = parse_qs(authorization_url.query)
     assert query["client_id"] == ["vk-client"]
     assert query["scope"] == ["email"]
-    assert query["code_challenge_method"] == ["s256"]
+    assert query["code_challenge_method"] == ["S256"]
     assert len(query["code_challenge"][0]) == 43
     return query["state"][0]
 
@@ -168,7 +168,9 @@ def test_vk_oauth_rejects_callback_with_wrong_state_without_network_call(client,
     callback = _finish_vk(client, "attacker-state")
 
     assert callback.status_code == 303
-    assert callback.headers["location"] == "/login?next=%2Fapp&auth_error=invalid_state"
+    assert callback.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=invalid_state&oauth_provider=vk"
+    )
     assert requests == []
 
 
@@ -223,7 +225,9 @@ def test_vk_oauth_rejects_missing_device_without_network_call(client, monkeypatc
     )
 
     assert callback.status_code == 303
-    assert callback.headers["location"] == "/login?next=%2Fapp&auth_error=provider_failure"
+    assert callback.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=provider_failure&oauth_provider=vk"
+    )
     assert requests == []
 
 
@@ -249,7 +253,9 @@ def test_vk_oauth_rejects_conflicting_flat_and_payload_state(client, monkeypatch
     )
 
     assert callback.status_code == 303
-    assert callback.headers["location"] == "/login?next=%2Fapp&auth_error=invalid_state"
+    assert callback.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=invalid_state&oauth_provider=vk"
+    )
     assert requests == []
 
 
@@ -262,7 +268,9 @@ def test_vk_oauth_rejects_mismatched_token_state(client, monkeypatch):
     callback = _finish_vk(client, state)
 
     assert callback.status_code == 303
-    assert callback.headers["location"] == "/login?next=%2Fapp&auth_error=invalid_state"
+    assert callback.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=invalid_state&oauth_provider=vk"
+    )
     assert [request.url.path for request in requests] == ["/oauth2/auth"]
 
 
@@ -270,14 +278,16 @@ def test_vk_oauth_json_payload_cancel_is_normalized(client, monkeypatch):
     monkeypatch.setattr(settings, "enable_web_auth", True)
     monkeypatch.setattr(settings, "vk_oauth_client_id", "vk-client")
     requests = _vk_transport(monkeypatch)
-    _start_vk(client)
+    state = _start_vk(client)
 
     callback = client.get(
         "/api/v1/auth/oauth/vk/callback",
-        params={"payload": json.dumps({"error": "access_denied"})},
+        params={"payload": json.dumps({"error": "access_denied", "state": state})},
         follow_redirects=False,
     )
 
     assert callback.status_code == 303
-    assert callback.headers["location"] == "/login?next=%2Fapp&auth_error=denied"
+    assert callback.headers["location"] == (
+        "/login?next=%2Fapp&auth_error=denied&oauth_provider=vk"
+    )
     assert requests == []

--- a/docs/auth/browser-oauth-session-recovery-adr.md
+++ b/docs/auth/browser-oauth-session-recovery-adr.md
@@ -1,0 +1,72 @@
+# ADR: server-side browser OAuth transactions
+
+Статус: accepted for Task 136
+
+## Контекст
+
+Authlib и Starlette `SessionMiddleware` раньше хранили state, redirect URI,
+PKCE verifier, OIDC nonce и общий login/link-контекст в подписанной cookie
+`fit_oauth_session`. Повреждённая или устаревшая cookie могла остаться в
+браузере после `invalid_state`, а кнопка «Повторить» только перезагружала
+страницу с тем же артефактом.
+
+## Решение
+
+Вводится таблица `oauth_transactions` с bounded TTL по умолчанию 600 секунд.
+Запись содержит:
+
+- opaque transaction id, hash browser marker, provider, purpose (`login` или
+  `link`), state, redirect URI, safe `next`, timestamps и one-time status;
+- server-side PKCE verifier и OIDC nonce при наличии;
+- для link flow — hash action token, target user и исходную refresh session
+  family.
+
+`fit_oauth_session` остаётся подписанной HttpOnly-cookie с тем же именем,
+`Path=/`, production `Secure; SameSite=None` и тем же bounded TTL. В её payload
+остаётся только opaque browser marker. State, verifier, nonce, raw action token
+и link metadata в cookie не записываются.
+
+На start создаётся новая независимая transaction. Второй tab не supersede-ит
+первую запись: каждый callback должен предъявить exact state, provider и marker.
+На callback transaction сначала переводится из `pending` в `processing`; только
+после этого Authlib или VK выполняет code exchange, PKCE и проверки OIDC/VK.
+Повторный, неизвестный, просроченный или mismatching state не запускает обмен и
+не выполняет identity write.
+
+Успешный login помечает transaction `completed` и выдаёт refresh-cookie только
+после identity flow. Link использует текущую refresh session family, action
+token остаётся one-time, а новая refresh-cookie не выдаётся.
+
+## Recovery и failure modes
+
+- `invalid_state`, denial, provider failure и expired state завершают только
+  свою transaction; terminal rows удаляются при последующих bounded cleanup.
+- Если SessionMiddleware не может прочитать signed cookie (bad signature,
+  старый secret или timestamp), callback отправляет явное удаление cookie с
+  тем же именем, `Path`, `Secure`, `HttpOnly` и `SameSite`. Refresh-cookie не
+  затрагивается.
+- Legacy `_state_*`, `oauth_next` и link-keys scrub-ятся из валидной cookie.
+  Marker сохраняется, пока существует другой pending flow, поэтому callback
+  одной вкладки не стирает независимый flow другой.
+- Frontend показывает безопасный reason class и ведёт retry-ссылкой на новый
+  provider start. Она сохраняет только allowlisted `next`, не рендерит raw
+  query и не запускается автоматически в цикле.
+- Backend restart не теряет pending rows до истечения TTL. После ротации
+  `SECRET_KEY` старый marker становится unreadable и удаляется; старый state
+  всё равно не принимается.
+
+## Отклонённые альтернативы
+
+1. Оставить полный transaction payload в signed cookie — rejected: malformed
+   cookie не даёт надёжного cleanup, а shared namespace создаёт stale state и
+   race между вкладками.
+2. Отдельная cookie на provider/attempt — rejected: secrets и link context
+   остаются на клиенте, усложняя rotation и deletion.
+3. Redis/external TTL store — rejected: SQLAlchemy database уже является общей
+   частью deployment topology, новый operational dependency не нужен.
+
+## Security invariant
+
+Recovery только удаляет OAuth artifact. Он не ослабляет state/CSRF, PKCE,
+OIDC nonce, redirect URI, VK payload или identity-conflict checks и не удаляет,
+не ротирует и не инвалидирует `fit_refresh_token`.

--- a/frontend/src/app/AuthProvider.tsx
+++ b/frontend/src/app/AuthProvider.tsx
@@ -123,8 +123,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
       }
       if (reason instanceof ApiError && [401, 403].includes(reason.status)) {
+        clearAccessToken();
         clearCurrentUserData();
         setUser(null);
+        setError(null);
+        return null;
       }
       setError(reason instanceof Error ? reason.message : 'Не удалось загрузить профиль');
       return null;

--- a/frontend/src/features/auth/OAuthButtons.tsx
+++ b/frontend/src/features/auth/OAuthButtons.tsx
@@ -1,6 +1,6 @@
 import { useState, type MouseEventHandler, type ReactNode } from 'react';
-import { safeAuthNextPath } from '../../shared/auth/redirects';
 import { markProductLoginStarted } from '../../shared/analytics/productEvents';
+import { oauthStartHref } from '../../shared/auth/oauthRecovery';
 import { Icon } from '../../shared/ui/Icon';
 
 const PROVIDER_LABELS: Record<string, string> = {
@@ -124,31 +124,33 @@ export function OAuthButtons({
   const configuredProviders = configuredOAuthProviders(providers);
   if (!configuredProviders.length) return null;
 
-  const safeNext = nextPath ? safeAuthNextPath(nextPath) : null;
-
   return (
     <section className="oauth-auth" aria-label="Вход через другой сервис">
       <p className="muted">Войти с помощью</p>
       <div className="oauth-auth__grid">
-        {configuredProviders.map((provider) => (
-          <OAuthProviderButton
-            key={provider}
-            provider={provider}
-            href={`/api/v1/auth/oauth/${provider}/start${safeNext ? `?next=${encodeURIComponent(safeNext)}` : ''}`}
-            disabled={redirectingProvider !== null}
-            busy={redirectingProvider === provider}
-            onClick={(event) => {
-              if (redirectingProvider !== null) {
-                event.preventDefault();
-                return;
-              }
-              setRedirectingProvider(provider);
-              markProductLoginStarted();
-            }}
-          >
-            {redirectingProvider === provider ? 'Переходим…' : PROVIDER_LABELS[provider]}
-          </OAuthProviderButton>
-        ))}
+        {configuredProviders.map((provider) => {
+          const href = oauthStartHref(provider, nextPath);
+          if (!href) return null;
+          return (
+            <OAuthProviderButton
+              key={provider}
+              provider={provider}
+              href={href}
+              disabled={redirectingProvider !== null}
+              busy={redirectingProvider === provider}
+              onClick={(event) => {
+                if (redirectingProvider !== null) {
+                  event.preventDefault();
+                  return;
+                }
+                setRedirectingProvider(provider);
+                markProductLoginStarted();
+              }}
+            >
+              {redirectingProvider === provider ? 'Переходим…' : PROVIDER_LABELS[provider]}
+            </OAuthProviderButton>
+          );
+        })}
       </div>
     </section>
   );

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useAuth } from '../../app/AuthProvider';
 import { EmailAuthPanel } from '../../features/auth/EmailAuthPanel';
 import { configuredOAuthProviders, OAuthButtons } from '../../features/auth/OAuthButtons';
+import { oauthStartHref, providerLabel, safeOAuthProvider } from '../../shared/auth/oauthRecovery';
 import { safeAuthNextPath } from '../../shared/auth/redirects';
 import { AppLink, demoReturnPathFromLogin, useNavigation } from '../../shared/navigation/router';
 import { ErrorState, LoadingState } from '../../shared/ui/common';
@@ -124,6 +125,16 @@ export default function LoginPage() {
   const demoReturnPath = demoReturnPathFromLogin(window.location.search);
   const authErrorCode = params.get('auth_error');
   const providers = configuredOAuthProviders(config?.enable_web_auth ? config.oauth_providers : []);
+  const requestedOAuthProvider = safeOAuthProvider(params.get('oauth_provider'));
+  const retryProvider =
+    requestedOAuthProvider && providers.includes(requestedOAuthProvider)
+      ? requestedOAuthProvider
+      : (providers[0] ?? null);
+  const retryHref = retryProvider ? oauthStartHref(retryProvider, nextPath) : null;
+  const retryLabel =
+    retryProvider && retryProvider === requestedOAuthProvider
+      ? `Повторить вход через ${providerLabel(retryProvider)}`
+      : 'Повторить';
   const telegramAppUrl = config?.telegram_bot_username
     ? telegramMiniAppUrl(config.telegram_bot_username)
     : null;
@@ -215,14 +226,14 @@ export default function LoginPage() {
               )}
               {config?.enable_email_auth && <EmailAuthPanel nextPath={nextPath} />}
               {config?.enable_dev_auth && <DevLoginControls nextPath={nextPath} />}
-              {(error || authErrorCode) && (
-                <button
-                  type="button"
+              {(error || authErrorCode) && retryHref && (
+                <a
                   className="login-retry"
-                  onClick={() => window.location.reload()}
+                  href={retryHref}
+                  onClick={() => markProductLoginStarted()}
                 >
-                  Повторить
-                </button>
+                  {retryLabel}
+                </a>
               )}
             </div>
           )}

--- a/frontend/src/pages/miniapp/MiniAppPage.tsx
+++ b/frontend/src/pages/miniapp/MiniAppPage.tsx
@@ -1,6 +1,11 @@
 import { lazy, Suspense, useEffect, useState } from 'react';
 import { AppShell, type AppSection } from '../../app/AppShell';
 import { useAuth } from '../../app/AuthProvider';
+import {
+  authRecoveryMessage,
+  providerLabel,
+  safeOAuthProvider,
+} from '../../shared/auth/oauthRecovery';
 import { TelegramLinkPrompt } from '../../features/account/TelegramLinkPrompt';
 import { TodayDashboard } from '../../features/dashboard/TodayDashboard';
 import type { WorkoutNavigationTarget } from '../../features/workouts/WorkoutHistory';
@@ -216,34 +221,27 @@ export default function MiniAppPage() {
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const linkedProvider = params.get('auth_linked');
+    const rawLinkedProvider = params.get('auth_linked');
+    const linkedProvider = safeOAuthProvider(rawLinkedProvider);
     const authError = params.get('auth_error');
-    if (!linkedProvider && !authError) return;
+    const oauthProvider = safeOAuthProvider(params.get('oauth_provider'));
+    if (!rawLinkedProvider && !authError) return;
 
-    const labels: Record<string, string> = {
-      google: 'Google',
-      yandex: 'Яндекс',
-      vk: 'VK ID',
-      apple: 'Apple',
-    };
     if (linkedProvider) {
-      toast(`${labels[linkedProvider] ?? linkedProvider} привязан к аккаунту`);
-    } else if (authError === 'conflict') {
-      toast('Этот способ входа уже привязан к другому аккаунту', 'error');
-    } else if (authError === 'denied') {
-      toast('Авторизация отменена или не разрешена', 'error');
-    } else if (authError === 'invalid_state') {
-      toast('Ссылка авторизации недействительна или устарела', 'error');
-    } else if (authError === 'blocked') {
-      toast('Аккаунт заблокирован', 'error');
-    } else if (authError === 'unavailable') {
-      toast('Этот способ входа временно недоступен', 'error');
+      toast(`${providerLabel(linkedProvider)} привязан к аккаунту`);
     } else {
-      toast('Не удалось связаться с сервисом авторизации', 'error');
+      const linkError = authError === 'conflict' ? 'oauth_link_conflict' : authError;
+      toast(
+        authRecoveryMessage(linkError, oauthProvider) ??
+          'Не удалось связаться с сервисом авторизации',
+        'error',
+      );
     }
 
     params.delete('auth_linked');
     params.delete('auth_error');
+    params.delete('oauth_provider');
+    params.delete('next');
     const query = params.toString();
     window.history.replaceState(
       null,

--- a/frontend/src/shared/auth/oauthRecovery.ts
+++ b/frontend/src/shared/auth/oauthRecovery.ts
@@ -1,0 +1,70 @@
+const SAFE_AUTH_PATHS = new Set(['/app', '/coach', '/admin']);
+const SAFE_INVITE_PATH = /^\/join\/[A-Za-z0-9_-]{20,128}$/;
+const OAUTH_PROVIDERS = new Set(['telegram', 'google', 'yandex', 'vk', 'apple']);
+
+const PROVIDER_LABELS: Record<string, string> = {
+  telegram: 'Telegram',
+  google: 'Google',
+  yandex: 'Яндекс',
+  vk: 'VK ID',
+  apple: 'Apple',
+};
+
+const LOGIN_ERROR_MESSAGES: Record<string, string> = {
+  unavailable: 'Этот способ входа сейчас недоступен. Выберите другой способ.',
+  denied: 'Вход отменён. Выберите способ входа ещё раз.',
+  invalid_state: 'Не удалось подтвердить попытку входа. Начните вход заново.',
+  provider_failure: 'Сервис входа временно недоступен. Попробуйте ещё раз.',
+  conflict: 'Этот аккаунт уже связан с другим пользователем.',
+  blocked: 'Вход в этот аккаунт недоступен. Обратитесь в поддержку.',
+};
+
+const LINK_ERROR_MESSAGES: Record<string, string> = {
+  oauth_link_unavailable: 'Этот способ входа сейчас недоступен для привязки.',
+  oauth_link_denied: 'Привязка отменена. Можно попробовать ещё раз.',
+  oauth_link_invalid_state: 'Не удалось подтвердить привязку. Создайте новую ссылку.',
+  oauth_link_provider_failure: 'Сервис входа временно недоступен. Попробуйте позже.',
+  oauth_link_conflict: 'Этот способ входа уже привязан к другому аккаунту.',
+  oauth_link_blocked: 'Привязка недоступна для этого аккаунта.',
+};
+
+function safeAuthNextPath(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const normalized = value.trim();
+  if (SAFE_AUTH_PATHS.has(normalized) || SAFE_INVITE_PATH.test(normalized)) return normalized;
+  return null;
+}
+
+export function safeOAuthProvider(value: string | null | undefined): string | null {
+  const normalized = value?.trim().toLowerCase();
+  return normalized && OAUTH_PROVIDERS.has(normalized) ? normalized : null;
+}
+
+export function currentAuthNextPath(): string | null {
+  return typeof window === 'undefined' ? null : safeAuthNextPath(window.location.pathname);
+}
+
+export function oauthStartHref(provider: string, nextPath?: string | null): string | null {
+  const normalizedProvider = safeOAuthProvider(provider);
+  if (!normalizedProvider) return null;
+  const safeNextPath = safeAuthNextPath(nextPath) ?? currentAuthNextPath();
+  const query = safeNextPath ? `?next=${encodeURIComponent(safeNextPath)}` : '';
+  return `/api/v1/auth/oauth/${normalizedProvider}/start${query}`;
+}
+
+export function providerLabel(provider: string | null | undefined): string {
+  return (provider && PROVIDER_LABELS[provider]) || 'внешний сервис';
+}
+
+export function authRecoveryMessage(
+  error: string | null | undefined,
+  provider?: string | null,
+): string | null {
+  if (!error) return null;
+  const message = LINK_ERROR_MESSAGES[error] ?? LOGIN_ERROR_MESSAGES[error];
+  if (!message) return null;
+  if (error === 'denied' && provider) {
+    return `Вход через ${providerLabel(provider)} отменён. Выберите способ входа ещё раз.`;
+  }
+  return message;
+}

--- a/frontend/tests/e2e/auth.spec.ts
+++ b/frontend/tests/e2e/auth.spec.ts
@@ -14,6 +14,7 @@ type MockAuthCalls = {
   refresh: number;
   telegramInit: number;
   meAuthorization: string[];
+  oauthStarts: string[];
 };
 
 function userPayload() {
@@ -44,7 +45,12 @@ async function mockAuthApi(
 ): Promise<MockAuthCalls> {
   let hasSession = authenticated;
   let activeUser = initialUser;
-  const calls: MockAuthCalls = { refresh: 0, telegramInit: 0, meAuthorization: [] };
+  const calls: MockAuthCalls = {
+    refresh: 0,
+    telegramInit: 0,
+    meAuthorization: [],
+    oauthStarts: [],
+  };
   await page.route('**/api/v1/**', async (route) => {
     const request = route.request();
     const path = new URL(request.url()).pathname;
@@ -65,6 +71,10 @@ async function mockAuthApi(
       return hasSession
         ? route.fulfill({ json: { access_token: 'refreshed-token' } })
         : route.fulfill({ status: 401, json: { detail: 'Сессия отсутствует' } });
+    }
+    if (path.includes('/auth/oauth/') && path.endsWith('/start')) {
+      calls.oauthStarts.push(request.url());
+      return route.fulfill({ status: 204 });
     }
     if (path.endsWith('/auth/telegram/init')) {
       calls.telegramInit += 1;
@@ -271,7 +281,7 @@ test('Повторить сохраняет контраст и единый hov
     await page.emulateMedia({ colorScheme: scheme, reducedMotion: 'reduce' });
     await page.goto('/login?auth_error=provider_failure');
 
-    const retry = page.getByRole('button', { name: 'Повторить' });
+    const retry = page.getByRole('link', { name: 'Повторить' });
     const provider = page.getByRole('link', { name: 'Продолжить с Google' });
     await retry.hover();
     const retryStyles = await retry.evaluate((element) => {
@@ -300,6 +310,26 @@ test('Повторить сохраняет контраст и единый hov
     );
     expect(retryStyles.color).toBe(scheme === 'light' ? 'rgb(22, 26, 23)' : 'rgb(238, 240, 234)');
   }
+});
+
+test('OAuth invalid_state retry starts a fresh provider flow without reload loop', async ({
+  page,
+}) => {
+  const calls = await mockAuthApi(page, { providers: ['google'] });
+  await page.goto(
+    '/login?next=%2Fcoach&auth_error=invalid_state&oauth_provider=google&code=secret-code',
+  );
+
+  const retry = page.getByRole('link', { name: 'Повторить вход через Google' });
+  await expect(retry).toHaveAttribute('href', '/api/v1/auth/oauth/google/start?next=%2Fcoach');
+  await retry.click();
+
+  expect(calls.oauthStarts).toHaveLength(1);
+  const oauthStart = calls.oauthStarts[0];
+  if (!oauthStart) throw new Error('OAuth start request was not captured');
+  expect(new URL(oauthStart).pathname).toBe('/api/v1/auth/oauth/google/start');
+  expect(oauthStart).toContain('next=%2Fcoach');
+  expect(oauthStart).not.toContain('secret-code');
 });
 
 test('already authenticated Login возвращает в safe destination', async ({ page }) => {

--- a/frontend/tests/unit/pages/auth/LoginPage.test.tsx
+++ b/frontend/tests/unit/pages/auth/LoginPage.test.tsx
@@ -104,6 +104,20 @@ describe('LoginPage', () => {
     );
   });
 
+  it('retries a failed provider flow through a fresh start link', () => {
+    window.history.replaceState(
+      null,
+      '',
+      '/login?next=%2Fcoach&auth_error=invalid_state&oauth_provider=google&state=secret-state',
+    );
+    renderLogin();
+
+    const retry = screen.getByRole('link', { name: 'Повторить вход через Google' });
+    expect(retry).toHaveAttribute('href', '/api/v1/auth/oauth/google/start?next=%2Fcoach');
+    expect(screen.queryByRole('button', { name: 'Повторить' })).not.toBeInTheDocument();
+    expect(document.body).not.toHaveTextContent('secret-state');
+  });
+
   it('redirects an already authenticated account to the intended destination', async () => {
     authState.user = { id: 9 };
     renderLogin();

--- a/frontend/tests/unit/shared/auth/oauthRecovery.test.ts
+++ b/frontend/tests/unit/shared/auth/oauthRecovery.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  authRecoveryMessage,
+  oauthStartHref,
+  providerLabel,
+  safeOAuthProvider,
+} from '../../../../src/shared/auth/oauthRecovery';
+
+describe('oauthRecovery', () => {
+  afterEach(() => {
+    window.history.replaceState(null, '', '/login');
+  });
+
+  it('builds a provider retry link with only an allowlisted next path', () => {
+    expect(oauthStartHref('GOOGLE', '/coach')).toBe(
+      '/api/v1/auth/oauth/google/start?next=%2Fcoach',
+    );
+    expect(oauthStartHref('google', 'https://evil.example')).toBe(
+      '/api/v1/auth/oauth/google/start',
+    );
+    expect(oauthStartHref('unknown', '/app')).toBeNull();
+  });
+
+  it('normalizes provider query data and maps link errors without raw details', () => {
+    expect(safeOAuthProvider(' VK ')).toBe('vk');
+    expect(safeOAuthProvider('provider-secret')).toBeNull();
+    expect(providerLabel('vk')).toBe('VK ID');
+    expect(authRecoveryMessage('oauth_link_conflict', 'vk')).toBe(
+      'Этот способ входа уже привязан к другому аккаунту.',
+    );
+    expect(authRecoveryMessage('provider-secret', 'google')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Move browser OAuth state into a short-lived server-side `oauth_transactions` store keyed by an opaque signed browser marker.
- Preserve state/CSRF, PKCE, OIDC nonce, VK payload checks, safe `next`, and account-linking action-token/session-family binding.
- Make malformed, expired, rotated-secret, repeated, denied, and provider-failure callbacks idempotently recoverable without touching the refresh cookie.
- Replace the Login reload loop with a provider-specific fresh-start retry link and normalize link-flow error UX.
- Add the ADR and focused backend/frontend regression coverage.

## Verification

- Backend OAuth regression: 97 passed, 1 skipped, 138 deselected.
- Frontend targeted unit tests: 11 passed.
- Frontend typecheck and ESLint: passed.
- Frontend production build: passed.
- Browser auth mock E2E: 13 passed.
- Pre-commit: passed for each implementation stage.

## Release notes

- Migration `0070_browser_oauth_transactions` is additive and creates the bounded transaction table and indexes.
- Production deployment should use the normal `master` CI/deploy workflow after merge.
