### PR TITLE
[Task 135] Restore GHCR login before publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,6 +338,13 @@ jobs:
           ignore-unfixed: true
           trivyignores: .trivyignore.yaml
           exit-code: "1"
+      - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish immutable image after merge
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:


### PR DESCRIPTION
Restore the GitHub Container Registry login step removed during the Task 135 CI simplification. Post-merge CI for PR 139 built and scanned both immutable images, then docker push failed with unauthorized because the publish job was unauthenticated. Targeted CI/deployment/release safeguard tests: 18 passed. Pre-commit YAML and whitespace hooks: passed. Scope: .github/workflows/ci.yml only. This completes the already-approved Task 135 production release.