### PR TITLE
[Task 135] Read legacy active containers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -106,11 +106,8 @@ jobs:
               cat \"\$marker\"
               exit 0
             fi
-            backend_container=\$(docker compose -f '$PROD_PATH/docker-compose.yml' -p fit-mini-app ps -q backend)
-            bot_container=\$(docker compose -f '$PROD_PATH/docker-compose.yml' -p fit-mini-app ps -q bot)
-            test -n \"\$backend_container\" -a -n \"\$bot_container\"
-            backend_image=\$(docker inspect --format '{{.Config.Image}}' \"\$backend_container\")
-            bot_image=\$(docker inspect --format '{{.Config.Image}}' \"\$bot_container\")
+            backend_image=\$(docker inspect --format '{{.Config.Image}}' fit-mini-app-backend-1)
+            bot_image=\$(docker inspect --format '{{.Config.Image}}' fit-mini-app-bot-1)
             backend_revision=\"\${backend_image##*:}\"
             bot_revision=\"\${bot_image##*:}\"
             test \"\$backend_revision\" = \"\$bot_revision\"


### PR DESCRIPTION
The first marker-recovery attempt reached production but docker compose ps returned no service IDs on the legacy host and correctly stopped before transfer. Use the stable legacy production container names documented by the previous successful deploy logs to read configured immutable image tags, then require backend and bot revisions to match before generating the migration manifest. Existing marker behavior remains unchanged. Targeted CI/deployment/release safeguard tests: 18 passed. Pre-commit YAML and whitespace hooks: passed. Scope: .github/workflows/deploy.yml only.