### PR TITLE
[Task 135] fix: make migration parser Python 3 compatible

### DIFF
--- a/scripts/check_online_migrations.py
+++ b/scripts/check_online_migrations.py
@@ -152,7 +152,9 @@ def _assignment(tree: ast.Module, name: str) -> object | None:
             return None
         try:
             return ast.literal_eval(value)
-        except ValueError, TypeError:
+        except ValueError:
+            return None
+        except TypeError:
             return None
     return None
 


### PR DESCRIPTION
## Summary\n- fix Python 3 exception handling in the online migration parser\n- unblock the production migration-manifest step after active-revision recovery\n\n## Verification\n- targeted deployment/migration tests: 72 passed\n- pre-commit hooks: passed\n\nThis is a release-path follow-up for Task 135; no production changes were made by the failed deploy.