### PR TITLE
[Task 135] fix: quote legacy marker recovery command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -225,11 +225,11 @@ jobs:
              export DEPLOY_MIGRATION_MANIFEST=deployment-migration-manifest.json
              export DEPLOY_SINGLE_SLOT_CONFIRMED_SHA='$DEPLOY_SHA'
              active_marker='$PROD_PATH/.artifacts/operations/deployments/last-successful-revision'
-             if [ -f "\$active_marker" ]; then
-               test "\$(tr -d '\\r\\n' < "\$active_marker")" = '$ACTIVE_REVISION'
+             if [ -f \"\$active_marker\" ]; then
+               test \"\$(tr -d '\\r\\n' < \"\$active_marker\")\" = '$ACTIVE_REVISION'
              else
-               install -d -m 700 "\$(dirname "\$active_marker")"
-               printf '%s\\n' '$ACTIVE_REVISION' > "\$active_marker"
+               install -d -m 700 \"\$(dirname \"\$active_marker\")\"
+               printf '%s\\n' '$ACTIVE_REVISION' > \"\$active_marker\"
              fi
              registry_login_succeeded=false
              DOCKER_CONFIG_DIR=\$(mktemp -d)

--- a/tests/test_release_safeguards.py
+++ b/tests/test_release_safeguards.py
@@ -69,6 +69,8 @@ def test_deploy_recovers_legacy_revision_before_migration_and_rollout() -> None:
     assert "ACTIVE_REVISION: ${{ steps.migration.outputs.active_revision }}" in deploy
     assert "active_marker" in deploy
     assert "last-successful-revision" in deploy
+    assert 'if [ -f \\"\\$active_marker\\" ]; then' in deploy
+    assert 'install -d -m 700 \\"\\$(dirname \\"\\$active_marker\\")\\"' in deploy
 
 
 def test_delivery_contract_is_master_only_and_approval_gated() -> None:


### PR DESCRIPTION
## Summary\n- escape the nested marker-path quotes in the SSH remote command\n- keep legacy marker reconstruction valid under the runner shell\n- add a regression assertion for the escaped command shape\n\n## Verification\n- release safeguard and deployment contract tests: 11 passed\n- CI/deployment contracts: valid\n- pre-commit hooks: passed\n\nThis follows the failed Task 135 deployment; production rollout did not reach the application script.