### PR TITLE
[Task 137] Accelerate three-way CI test gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,11 +125,15 @@ jobs:
         run: python scripts/ci_contract.py run-group frontend-checks
 
   frontend-smoke:
-    name: Frontend smoke
-    needs: frontend
+    name: Frontend smoke (${{ matrix.shard }}/3)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -140,29 +144,34 @@ jobs:
       - name: Install frontend dependencies
         working-directory: frontend
         run: npm ci
+      - name: Build frontend for smoke tests
+        working-directory: frontend
+        run: npx vite build
       - name: Install Playwright Chromium
         working-directory: frontend
         run: npx playwright install --with-deps chromium
-      - name: Build frontend preview
-        working-directory: frontend
-        run: npm run build
       - name: Run shared frontend E2E group
-        run: python scripts/ci_contract.py run-group frontend-e2e
+        run: python scripts/ci_contract.py run-group frontend-e2e --shard "${{ matrix.shard }}/3"
       - name: Upload Playwright traces on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-failure-${{ github.run_id }}
+          name: playwright-failure-${{ github.run_id }}-shard-${{ matrix.shard }}
           path: .artifacts/runtime/tests/playwright
           if-no-files-found: ignore
           include-hidden-files: true
           retention-days: 7
 
   python-tests:
-    name: Python tests
+    name: Python tests (${{ matrix.shard }}/3)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+
     services:
       postgres:
         image: postgres:16-alpine
@@ -200,11 +209,10 @@ jobs:
           TELEGRAM_BOT_TOKEN: test-token
           BOT_INTERNAL_TOKEN: test-bot-internal-token
           SECRET_KEY: test-secret-key-at-least-thirty-two-characters
-        run: python scripts/ci_contract.py run-group python-tests
+        run: python scripts/ci_contract.py run-group python-tests --shard "${{ matrix.shard }}/3"
 
   migrated-stack:
     name: Migrated PostgreSQL stack
-    needs: frontend
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/scripts/ci_contract.py
+++ b/scripts/ci_contract.py
@@ -11,6 +11,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -18,7 +19,10 @@ from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
-CONTRACT_VERSION = "ci-contract-v1"
+CONTRACT_VERSION = "ci-contract-v2"
+CI_SHARD_COUNT = 3
+SHARDABLE_GROUPS = frozenset({"frontend-e2e", "python-tests"})
+SHARD_RE = re.compile(r"(?P<number>[1-9][0-9]*)/(?P<count>[1-9][0-9]*)\Z")
 
 
 class CIContractError(RuntimeError):
@@ -285,6 +289,13 @@ def contract_payload() -> dict[str, object]:
             for name, spec in sorted(COMMAND_GROUPS.items())
         },
         "profiles": {name: list(groups) for name, groups in sorted(PROFILE_GROUPS.items())},
+        "sharding": {
+            "frontend-e2e": {"count": CI_SHARD_COUNT, "strategy": "playwright"},
+            "python-tests": {
+                "count": CI_SHARD_COUNT,
+                "strategy": "pytest-node-round-robin",
+            },
+        },
     }
 
 
@@ -345,25 +356,165 @@ def missing_prerequisites(
     ]
 
 
+def parse_shard(value: str) -> tuple[int, int]:
+    """Convert a human-facing ``N/M`` shard label to a zero-based index."""
+
+    match = SHARD_RE.fullmatch(value)
+    if match is None:
+        raise CIContractError(f"Invalid shard {value!r}; expected N/M with 1 <= N <= M")
+    number = int(match.group("number"))
+    count = int(match.group("count"))
+    if number > count:
+        raise CIContractError(f"Invalid shard {value!r}; shard number cannot exceed shard count")
+    return number - 1, count
+
+
+def select_shard(items: Sequence[str], *, shard_index: int, shard_count: int) -> tuple[str, ...]:
+    """Select a deterministic round-robin subset from an ordered item list."""
+
+    if shard_count < 1 or not 0 <= shard_index < shard_count:
+        raise CIContractError(
+            f"Invalid shard coordinates: index={shard_index}, count={shard_count}"
+        )
+    return tuple(
+        item for position, item in enumerate(items) if position % shard_count == shard_index
+    )
+
+
+def _collect_python_test_nodes(root: Path, env: Mapping[str, str]) -> tuple[str, ...]:
+    argv = _resolve_argv(
+        (
+            "python",
+            "scripts/run_pytest.py",
+            "backend/tests",
+            "bot/tests",
+            "--collect-only",
+            "-q",
+        )
+    )
+    print(f"$ (cd . && {' '.join(argv)})", flush=True)
+    completed = subprocess.run(
+        argv,
+        cwd=root,
+        env=dict(env),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        details = "\n".join(
+            part.strip() for part in (completed.stdout, completed.stderr) if part.strip()
+        )
+        if len(details) > 4000:
+            details = details[-4000:]
+        suffix = f"\n{details}" if details else ""
+        raise CIContractError(
+            f"Python test collection failed with exit code {completed.returncode}{suffix}"
+        )
+
+    nodes = tuple(
+        normalized
+        for line in completed.stdout.splitlines()
+        if (normalized := line.strip().replace("\\", "/"))
+        and normalized.startswith(("backend/tests/", "bot/tests/"))
+        and "::" in normalized
+    )
+    if not nodes:
+        raise CIContractError("Python test collection returned no test node IDs")
+    return nodes
+
+
+def _sharded_python_command(
+    command: CommandSpec,
+    *,
+    root: Path,
+    env: Mapping[str, str],
+    shard_index: int,
+    shard_count: int,
+) -> CommandSpec:
+    all_nodes = _collect_python_test_nodes(root, env)
+    selected_nodes = select_shard(all_nodes, shard_index=shard_index, shard_count=shard_count)
+    if not selected_nodes:
+        raise CIContractError(f"No Python tests selected for shard {shard_index + 1}/{shard_count}")
+
+    target_paths = {"backend/tests", "bot/tests"}
+    target_positions = [
+        position for position, argument in enumerate(command.argv) if argument in target_paths
+    ]
+    if not target_positions:
+        raise CIContractError("Python test command has no test target paths to shard")
+    first_target = min(target_positions)
+    last_target = max(target_positions) + 1
+    argv = (
+        *command.argv[:first_target],
+        *selected_nodes,
+        *command.argv[last_target:],
+    )
+    print(
+        f"Selected {len(selected_nodes)} of {len(all_nodes)} Python tests "
+        f"for shard {shard_index + 1}/{shard_count}",
+        flush=True,
+    )
+    return CommandSpec(name=f"{command.name}-shard", argv=argv, cwd=command.cwd)
+
+
+def _sharded_frontend_command(
+    command: CommandSpec, *, shard_index: int, shard_count: int
+) -> CommandSpec:
+    shard_label = f"{shard_index + 1}/{shard_count}"
+    return CommandSpec(
+        name=f"{command.name}-shard",
+        argv=(*command.argv, "--", f"--shard={shard_label}"),
+        cwd=command.cwd,
+    )
+
+
 def run_group(
-    group: str, *, root: Path | None = None, env: Mapping[str, str] | None = None
+    group: str,
+    *,
+    root: Path | None = None,
+    env: Mapping[str, str] | None = None,
+    shard: str | None = None,
 ) -> None:
+    if group not in COMMAND_GROUPS:
+        raise CIContractError(f"Unknown CI command group: {group}")
     project_root = (root or Path.cwd()).resolve()
     effective_env = dict(os.environ) | dict(env or {})
+    shard_index: int | None = None
+    shard_count: int | None = None
+    if shard is not None:
+        if group not in SHARDABLE_GROUPS:
+            raise CIContractError(f"CI group {group} does not support sharding")
+        shard_index, shard_count = parse_shard(shard)
     missing = missing_prerequisites(group, root=project_root, env=effective_env)
     if missing:
         raise CIContractError(f"Required prerequisite missing for {group}: {', '.join(missing)}")
     spec = COMMAND_GROUPS[group]
     for command in spec.commands:
-        argv = _resolve_argv(command.argv)
+        effective_command = command
+        if shard_index is not None and shard_count is not None:
+            if group == "python-tests" and command.name == "python-suite":
+                effective_command = _sharded_python_command(
+                    command,
+                    root=project_root,
+                    env=effective_env,
+                    shard_index=shard_index,
+                    shard_count=shard_count,
+                )
+            elif group == "frontend-e2e":
+                effective_command = _sharded_frontend_command(
+                    command, shard_index=shard_index, shard_count=shard_count
+                )
+        argv = _resolve_argv(effective_command.argv)
         if argv[0] == "git":
             argv = ["git", "-c", f"safe.directory={project_root.as_posix()}", *argv[1:]]
-        cwd = (project_root / command.cwd).resolve()
-        print(f"$ (cd {command.cwd} && {' '.join(argv)})", flush=True)
+        cwd = (project_root / effective_command.cwd).resolve()
+        print(f"$ (cd {effective_command.cwd} && {' '.join(argv)})", flush=True)
         completed = subprocess.run(argv, cwd=cwd, env=effective_env, check=False)
         if completed.returncode != 0:
             raise CIContractError(
-                f"CI command group {group} failed at {command.name} with exit code {completed.returncode}"
+                f"CI command group {group} failed at {effective_command.name} "
+                f"with exit code {completed.returncode}"
             )
 
 
@@ -395,6 +546,7 @@ def _parser() -> argparse.ArgumentParser:
     run = subparsers.add_parser("run-group")
     run.add_argument("group", choices=sorted(COMMAND_GROUPS))
     run.add_argument("--root", type=Path, default=Path.cwd())
+    run.add_argument("--shard")
     return parser
 
 
@@ -416,7 +568,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(json.dumps(list(groups), ensure_ascii=False))
             return 0
         if args.command == "run-group":
-            run_group(args.group, root=args.root)
+            run_group(args.group, root=args.root, shard=args.shard)
             return 0
         raise AssertionError(f"Unhandled command: {args.command}")
     except (CIContractError, OSError) as error:

--- a/scripts/ci_contract.py
+++ b/scripts/ci_contract.py
@@ -381,6 +381,17 @@ def select_shard(items: Sequence[str], *, shard_index: int, shard_count: int) ->
     )
 
 
+def _normalize_python_test_node(line: str) -> str | None:
+    candidate = line.strip()
+    path, separator, test_id = candidate.partition("::")
+    if not separator:
+        return None
+    normalized_path = path.replace("\\", "/")
+    if not normalized_path.startswith(("backend/tests/", "bot/tests/")):
+        return None
+    return f"{normalized_path}::{test_id}"
+
+
 def _collect_python_test_nodes(root: Path, env: Mapping[str, str]) -> tuple[str, ...]:
     argv = _resolve_argv(
         (
@@ -415,9 +426,7 @@ def _collect_python_test_nodes(root: Path, env: Mapping[str, str]) -> tuple[str,
     nodes = tuple(
         normalized
         for line in completed.stdout.splitlines()
-        if (normalized := line.strip().replace("\\", "/"))
-        and normalized.startswith(("backend/tests/", "bot/tests/"))
-        and "::" in normalized
+        if (normalized := _normalize_python_test_node(line)) is not None
     )
     if not nodes:
         raise CIContractError("Python test collection returned no test node IDs")

--- a/tests/test_ci_contract.py
+++ b/tests/test_ci_contract.py
@@ -54,6 +54,12 @@ def test_shards_parse_and_select_deterministically() -> None:
         ci_contract.parse_shard("4/3")
 
 
+def test_python_node_normalization_preserves_escaped_parameter_ids() -> None:
+    assert ci_contract._normalize_python_test_node(
+        r"backend\tests\test_app.py::test_public_content[\u041e]"
+    ) == r"backend/tests/test_app.py::test_public_content[\u041e]"
+
+
 def test_frontend_e2e_shard_is_forwarded_to_playwright(monkeypatch, tmp_path: Path) -> None:
     calls: list[list[str]] = []
     monkeypatch.setattr(

--- a/tests/test_ci_contract.py
+++ b/tests/test_ci_contract.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
 from scripts import ci_contract
 
 
@@ -35,6 +37,81 @@ def test_contract_digest_changes_when_contract_changes(monkeypatch) -> None:
     assert ci_contract.contract_digest() != original_digest
 
 
+def test_shards_parse_and_select_deterministically() -> None:
+    assert ci_contract.parse_shard("1/3") == (0, 3)
+    assert ci_contract.parse_shard("3/3") == (2, 3)
+    nodes = tuple(f"test_{index}" for index in range(8))
+    assert ci_contract.select_shard(nodes, shard_index=0, shard_count=3) == (
+        "test_0",
+        "test_3",
+        "test_6",
+    )
+    assert ci_contract.select_shard(nodes, shard_index=2, shard_count=3) == (
+        "test_2",
+        "test_5",
+    )
+    with pytest.raises(ci_contract.CIContractError):
+        ci_contract.parse_shard("4/3")
+
+
+def test_frontend_e2e_shard_is_forwarded_to_playwright(monkeypatch, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        ci_contract,
+        "missing_prerequisites",
+        lambda group, *, root, env: [],
+    )
+
+    def fake_run(argv, **kwargs):
+        del kwargs
+        calls.append(list(argv))
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(ci_contract.subprocess, "run", fake_run)
+    ci_contract.run_group("frontend-e2e", root=tmp_path, env={}, shard="2/3")
+
+    assert calls[0][-2:] == ["--", "--shard=2/3"]
+
+
+def test_python_shard_collects_and_runs_only_its_node_ids(monkeypatch, tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        ci_contract,
+        "missing_prerequisites",
+        lambda group, *, root, env: [],
+    )
+    collected = "\n".join(
+        [
+            "backend/tests/test_a.py::test_a",
+            "backend/tests/test_b.py::test_b",
+            "bot/tests/test_c.py::test_c",
+            "bot/tests/test_d.py::test_d",
+            "backend/tests/test_e.py::test_e",
+            "bot/tests/test_f.py::test_f",
+        ]
+    )
+
+    def fake_run(argv, **kwargs):
+        calls.append(list(argv))
+        if "--collect-only" in argv:
+            return SimpleNamespace(returncode=0, stdout=collected, stderr="")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(ci_contract.subprocess, "run", fake_run)
+    ci_contract.run_group(
+        "python-tests",
+        root=tmp_path,
+        env={"TEST_DATABASE_URL": "postgresql://test"},
+        shard="2/3",
+    )
+
+    assert calls[1][-2:] == ["--collect-only", "-q"]
+    assert calls[2][2:4] == [
+        "backend/tests/test_b.py::test_b",
+        "backend/tests/test_e.py::test_e",
+    ]
+
+
 def test_windows_node_commands_use_cmd_wrappers(monkeypatch) -> None:
     monkeypatch.setattr(ci_contract.os, "name", "nt")
     assert ci_contract._resolve_argv(("npm", "run", "test"))[0] == "npm.cmd"
@@ -64,6 +141,21 @@ def test_workflow_calls_group_entrypoint_instead_of_inline_command_copy() -> Non
     assert "npm run typecheck" not in workflow
     assert "npm run e2e:ci" not in workflow
     assert "scripts/run_pytest.py backend/tests" not in workflow
+
+
+def test_workflow_keeps_three_way_smoke_and_python_shards_independent() -> None:
+    root = Path(__file__).parents[1]
+    workflow = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    assert "name: Frontend smoke (${{ matrix.shard }}/3)" in workflow
+    assert "name: Python tests (${{ matrix.shard }}/3)" in workflow
+    assert workflow.count("        shard: [1, 2, 3]") == 2
+    assert 'run-group frontend-e2e --shard "${{ matrix.shard }}/3"' in workflow
+    assert 'run-group python-tests --shard "${{ matrix.shard }}/3"' in workflow
+    assert (
+        "  frontend-smoke:\n    name: Frontend smoke (${{ matrix.shard }}/3)\n    if:" in workflow
+    )
+    assert "  migrated-stack:\n    name: Migrated PostgreSQL stack\n    if:" in workflow
 
 
 def test_cross_stack_profile_includes_delivery_policy_gates() -> None:

--- a/tests/test_ci_contract.py
+++ b/tests/test_ci_contract.py
@@ -55,9 +55,12 @@ def test_shards_parse_and_select_deterministically() -> None:
 
 
 def test_python_node_normalization_preserves_escaped_parameter_ids() -> None:
-    assert ci_contract._normalize_python_test_node(
-        r"backend\tests\test_app.py::test_public_content[\u041e]"
-    ) == r"backend/tests/test_app.py::test_public_content[\u041e]"
+    assert (
+        ci_contract._normalize_python_test_node(
+            r"backend\tests\test_app.py::test_public_content[\u041e]"
+        )
+        == r"backend/tests/test_app.py::test_public_content[\u041e]"
+    )
 
 
 def test_frontend_e2e_shard_is_forwarded_to_playwright(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_task_session.py
+++ b/tests/test_task_session.py
@@ -192,14 +192,14 @@ def _write_gate_evidence(
     base_sha: str,
     terminal_result: str = "PRE_PUSH_CI_PASS",
 ) -> Path:
-    from scripts.ci_contract import contract_digest
+    from scripts.ci_contract import CONTRACT_VERSION, contract_digest
     from scripts.pre_push_gate import _evidence_digest
 
     path = controller._gate_evidence_path(controller._canonical_root(), task_id)
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "evidence_version": 1,
-        "contract_version": "ci-contract-v1",
+        "contract_version": CONTRACT_VERSION,
         "contract_digest": contract_digest(),
         "task_id": task_id,
         "branch": branch,


### PR DESCRIPTION
## Summary
- restore three-way Python test sharding with deterministic pytest node distribution
- run frontend smoke as a three-way Playwright matrix and remove unnecessary frontend/migrated-stack serialization
- keep the shared CI contract and aggregate `checks` gate authoritative

## Verification
- local exact-head pre-push gate: PASS
- policy suite: 119 passed
- pre-commit, Ruff, Ruff format, mypy: PASS
- workflow/image/deployment contracts: PASS
- authoritative GitHub CI: required before merge