### PR TITLE
[Task 129] Release remediation: bundle migration sources

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,7 +161,7 @@ jobs:
           set -Eeuo pipefail
           bundle_tar="yfc-deploy-$DEPLOY_SHA.tar"
           bundle_name="$bundle_tar.gz"
-          git archive --format=tar --output="$bundle_tar" "$DEPLOY_SHA" docker-compose.yml deploy scripts
+          git archive --format=tar --output="$bundle_tar" "$DEPLOY_SHA" backend/alembic/versions docker-compose.yml deploy scripts
           tar --append --file="$bundle_tar" deployment-migration-manifest.json
           gzip -n "$bundle_tar"
           echo "name=$bundle_name" >> "$GITHUB_OUTPUT"

--- a/scripts/deployment_contract.py
+++ b/scripts/deployment_contract.py
@@ -75,6 +75,8 @@ def validate_files(
         errors.append(
             "deploy workflow does not transfer an immutable commit bundle and migration manifest"
         )
+    if "backend/alembic/versions" not in deploy:
+        errors.append("deploy workflow bundle does not include migration sources")
     if "${BACKEND_IMAGE" not in compose_text or "${BOT_IMAGE" not in compose_text:
         errors.append("Compose application services do not consume BACKEND_IMAGE/BOT_IMAGE")
     if "GHCR_BACKEND_IMAGE" in deploy or "GHCR_BOT_IMAGE" in deploy:

--- a/tests/test_deployment_contract.py
+++ b/tests/test_deployment_contract.py
@@ -36,3 +36,11 @@ def test_namespace_mismatch_fixture_is_rejected(tmp_path: Path) -> None:
             compose=compose,
             deploy_script=script,
         )
+
+
+def test_deploy_bundle_includes_migration_sources() -> None:
+    root = Path(__file__).resolve().parents[1]
+    deploy = (root / ".github" / "workflows" / "deploy.yml").read_text(encoding="utf-8")
+
+    assert "git archive" in deploy
+    assert "backend/alembic/versions" in deploy


### PR DESCRIPTION
## Scope
- include backend Alembic migration sources in the immutable production bundle
- fail the deployment contract if the bundle definition omits migration sources
- add a regression test for the bundle contract

## Context
The first exact-SHA production attempt for Task 129 was fail-closed before switching the active release because the migration manifest referenced a migration file that was not present in the transferred bundle. Production remained on the prior healthy revision.

## Verification
- targeted deployment contract tests: 6 passed
- pre-commit: passed
- deployment contract check: valid
- no manual production change was made; release remains workflow-gated