### PR TITLE
[Task 129] Release remediation: online-safe Hermes migration

### DIFF
--- a/backend/alembic/versions/0071_hermes_editorial_intake_and_taxonomy.py
+++ b/backend/alembic/versions/0071_hermes_editorial_intake_and_taxonomy.py
@@ -17,46 +17,47 @@ depends_on: str | Sequence[str] | None = None
 
 online_rollout_phase = "expand"
 online_rollout_notes = (
-    "Adds nullable taxonomy compatibility through server defaults and an append-only, "
-    "replay-protected Hermes intake receipt table."
+    "Adds nullable taxonomy compatibility columns without rewrite defaults and an "
+    "append-only, replay-protected Hermes intake receipt table."
 )
 
 
 def upgrade() -> None:
-    cluster_columns = (
-        sa.Column("primary_topic", sa.String(length=64), nullable=False, server_default="unknown"),
-        sa.Column("topics", sa.JSON(), nullable=False, server_default="[]"),
-        sa.Column("content_type", sa.String(length=32), nullable=False, server_default="explainer"),
-        sa.Column("product_class", sa.String(length=32), nullable=False, server_default="unknown"),
-        sa.Column("evidence_level", sa.String(length=32), nullable=False, server_default="unknown"),
-        sa.Column("risk_level", sa.String(length=32), nullable=False, server_default="unknown"),
-        sa.Column("audience", sa.String(length=32), nullable=False, server_default="general"),
-        sa.Column("geography", sa.JSON(), nullable=False, server_default="[]"),
-        sa.Column(
-            "classification_version",
-            sa.String(length=64),
-            nullable=False,
-            server_default="news-taxonomy-v1",
-        ),
-        sa.Column("classification_reasons", sa.JSON(), nullable=False, server_default="[]"),
-        sa.Column("discovery_eligible", sa.Boolean(), nullable=False, server_default=sa.false()),
-        sa.Column("discovery_reasons", sa.JSON(), nullable=False, server_default="[]"),
-        sa.Column(
-            "publication_policy",
-            sa.String(length=32),
-            nullable=False,
-            server_default="manual_required",
-        ),
-        sa.Column("risk_reasons", sa.JSON(), nullable=False, server_default="[]"),
-        sa.Column(
-            "risk_policy_version",
-            sa.String(length=64),
-            nullable=False,
-            server_default="news-risk-v1",
-        ),
+    op.add_column(
+        "news_clusters", sa.Column("primary_topic", sa.String(length=64), nullable=True)
     )
-    for column in cluster_columns:
-        op.add_column("news_clusters", column)
+    op.add_column("news_clusters", sa.Column("topics", sa.JSON(), nullable=True))
+    op.add_column(
+        "news_clusters", sa.Column("content_type", sa.String(length=32), nullable=True)
+    )
+    op.add_column(
+        "news_clusters", sa.Column("product_class", sa.String(length=32), nullable=True)
+    )
+    op.add_column(
+        "news_clusters", sa.Column("evidence_level", sa.String(length=32), nullable=True)
+    )
+    op.add_column("news_clusters", sa.Column("risk_level", sa.String(length=32), nullable=True))
+    op.add_column("news_clusters", sa.Column("audience", sa.String(length=32), nullable=True))
+    op.add_column("news_clusters", sa.Column("geography", sa.JSON(), nullable=True))
+    op.add_column(
+        "news_clusters", sa.Column("classification_version", sa.String(length=64), nullable=True)
+    )
+    op.add_column(
+        "news_clusters", sa.Column("classification_reasons", sa.JSON(), nullable=True)
+    )
+    op.add_column(
+        "news_clusters", sa.Column("discovery_eligible", sa.Boolean(), nullable=True)
+    )
+    op.add_column(
+        "news_clusters", sa.Column("discovery_reasons", sa.JSON(), nullable=True)
+    )
+    op.add_column(
+        "news_clusters", sa.Column("publication_policy", sa.String(length=32), nullable=True)
+    )
+    op.add_column("news_clusters", sa.Column("risk_reasons", sa.JSON(), nullable=True))
+    op.add_column(
+        "news_clusters", sa.Column("risk_policy_version", sa.String(length=64), nullable=True)
+    )
 
     op.create_table(
         "hermes_editorial_submissions",

--- a/backend/fitminiapp_api/models/news.py
+++ b/backend/fitminiapp_api/models/news.py
@@ -97,26 +97,26 @@ class NewsCluster(Base):
     score_reasons: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
     risk_flags: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
     conflict_notes: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
-    primary_topic: Mapped[str] = mapped_column(String(64), nullable=False, default="unknown")
-    topics: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
-    content_type: Mapped[str] = mapped_column(String(32), nullable=False, default="explainer")
-    product_class: Mapped[str] = mapped_column(String(32), nullable=False, default="unknown")
-    evidence_level: Mapped[str] = mapped_column(String(32), nullable=False, default="unknown")
-    risk_level: Mapped[str] = mapped_column(String(32), nullable=False, default="unknown")
-    audience: Mapped[str] = mapped_column(String(32), nullable=False, default="general")
-    geography: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
-    classification_version: Mapped[str] = mapped_column(
-        String(64), nullable=False, default="news-taxonomy-v1"
+    primary_topic: Mapped[str | None] = mapped_column(String(64), nullable=True, default="unknown")
+    topics: Mapped[list | None] = mapped_column(JSON, nullable=True, default=list)
+    content_type: Mapped[str | None] = mapped_column(String(32), nullable=True, default="explainer")
+    product_class: Mapped[str | None] = mapped_column(String(32), nullable=True, default="unknown")
+    evidence_level: Mapped[str | None] = mapped_column(String(32), nullable=True, default="unknown")
+    risk_level: Mapped[str | None] = mapped_column(String(32), nullable=True, default="unknown")
+    audience: Mapped[str | None] = mapped_column(String(32), nullable=True, default="general")
+    geography: Mapped[list | None] = mapped_column(JSON, nullable=True, default=list)
+    classification_version: Mapped[str | None] = mapped_column(
+        String(64), nullable=True, default="news-taxonomy-v1"
     )
-    classification_reasons: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
-    discovery_eligible: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
-    discovery_reasons: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
-    publication_policy: Mapped[str] = mapped_column(
-        String(32), nullable=False, default="manual_required"
+    classification_reasons: Mapped[list | None] = mapped_column(JSON, nullable=True, default=list)
+    discovery_eligible: Mapped[bool | None] = mapped_column(Boolean, nullable=True, default=False)
+    discovery_reasons: Mapped[list | None] = mapped_column(JSON, nullable=True, default=list)
+    publication_policy: Mapped[str | None] = mapped_column(
+        String(32), nullable=True, default="manual_required"
     )
-    risk_reasons: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
-    risk_policy_version: Mapped[str] = mapped_column(
-        String(64), nullable=False, default="news-risk-v1"
+    risk_reasons: Mapped[list | None] = mapped_column(JSON, nullable=True, default=list)
+    risk_policy_version: Mapped[str | None] = mapped_column(
+        String(64), nullable=True, default="news-risk-v1"
     )
     merge_reason: Mapped[str] = mapped_column(String(160), nullable=False, default="new_event")
     latest_draft_revision: Mapped[int] = mapped_column(Integer, nullable=False, default=0)


### PR DESCRIPTION
Release remediation for Task 129. The prior exact-SHA deploy was intentionally fail-closed because migration 0071 used a loop plus non-null server-default add_column operations, which the production online-migration safety contract rejects. This PR makes the existing cluster-column expand additive and statically verifiable: each column is an explicit nullable=True operation with no rewrite default; the new application writers populate taxonomy values. No direct production mutation was performed. Local evidence: 29 targeted tests passed, pre-commit passed, and check_online_migrations passed for the changed revision range.