### PR TITLE
[Task 129] Release remediation: allowlisted table timestamp

### DIFF
--- a/backend/alembic/versions/0071_hermes_editorial_intake_and_taxonomy.py
+++ b/backend/alembic/versions/0071_hermes_editorial_intake_and_taxonomy.py
@@ -79,7 +79,12 @@ def upgrade() -> None:
         sa.Column("source_count", sa.Integer(), nullable=False),
         sa.Column("response_metadata", sa.JSON(), nullable=False, server_default="{}"),
         sa.Column("rejection_reason", sa.String(length=64), nullable=True),
-        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
         sa.Column("expires_at", sa.DateTime(), nullable=False),
         sa.Column("processed_at", sa.DateTime(), nullable=True),
         sa.CheckConstraint(


### PR DESCRIPTION
Release remediation for Task 129. The prior exact-SHA deploy passed migration source bundling and the nullable expand checks, then fail-closed because the new-table timestamp used sa.func.now(), which is outside the production online migration allowlist. This PR changes only that timestamp default to sa.text(CURRENT_TIMESTAMP), which is explicitly allowlisted. Local evidence: 25 related tests passed, pre-commit passed, and check_online_migrations passed for the changed revision range. No direct production mutation was performed.