### PR TITLE
[Task 130] Public Web SEO articles

### DIFF
--- a/backend/alembic/versions/0072_web_articles_editorial_lifecycle.py
+++ b/backend/alembic/versions/0072_web_articles_editorial_lifecycle.py
@@ -1,7 +1,7 @@
 """Add canonical Web article candidates, content and immutable revisions.
 
-Revision ID: 0072_web_articles_editorial_lifecycle
-Revises: 0071_hermes_editorial_intake_and_taxonomy
+Revision ID: 0072_web_articles_lifecycle
+Revises: 0071_hermes_intake_taxonomy
 """
 
 from collections.abc import Sequence
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision: str = "0072_web_articles_editorial_lifecycle"
-down_revision: str | None = "0071_hermes_editorial_intake_and_taxonomy"
+revision: str = "0072_web_articles_lifecycle"
+down_revision: str | None = "0071_hermes_intake_taxonomy"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
@@ -60,8 +60,8 @@ def upgrade() -> None:
             "web_article_potential_reasons", sa.JSON(), nullable=False, server_default="[]"
         ),
         sa.Column("status", sa.String(length=16), nullable=False, server_default="candidate"),
-        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
-        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
         sa.CheckConstraint(
             "status IN ('candidate', 'approved', 'researching', 'draft', 'review', 'rejected')",
             name="ck_web_article_candidates_status",
@@ -91,7 +91,12 @@ def upgrade() -> None:
     op.create_table(
         "web_articles",
         sa.Column("id", sa.String(length=32), nullable=False),
-        sa.Column("candidate_id", sa.String(length=32), nullable=True),
+        sa.Column(
+            "candidate_id",
+            sa.String(length=32),
+            sa.ForeignKey("web_article_candidates.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
         sa.Column("slug", sa.String(length=180), nullable=False),
         sa.Column("status", sa.String(length=24), nullable=False, server_default="draft"),
         sa.Column("title", sa.String(length=180), nullable=False),
@@ -127,13 +132,13 @@ def upgrade() -> None:
         sa.Column("prompt_version", sa.String(length=64), nullable=False),
         sa.Column("skill_version", sa.String(length=64), nullable=False),
         sa.Column("schema_version", sa.String(length=64), nullable=False),
-        sa.Column("generated_with_ai", sa.Boolean(), nullable=False, server_default=sa.true()),
-        sa.Column("research_assistance", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("generated_with_ai", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("research_assistance", sa.Boolean(), nullable=False, server_default="true"),
         sa.Column("content_hash", sa.String(length=64), nullable=False),
         sa.Column("correction_reason", sa.String(length=256), nullable=True),
         sa.Column("published_at", sa.DateTime(), nullable=True),
         sa.Column("updated_at", sa.DateTime(), nullable=True),
-        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
         sa.CheckConstraint(
             "status IN ('candidate', 'researching', 'draft', 'review', 'approved', 'published', "
             "'update_required', 'archived', 'retracted')",
@@ -147,7 +152,6 @@ def upgrade() -> None:
         sa.CheckConstraint(
             "editorial_value BETWEEN 0 AND 100", name="ck_web_articles_editorial_value"
         ),
-        sa.ForeignKeyConstraint(["candidate_id"], ["web_article_candidates.id"], ondelete="SET NULL"),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("slug"),
     )
@@ -157,14 +161,18 @@ def upgrade() -> None:
     op.create_table(
         "web_article_revisions",
         sa.Column("id", sa.String(length=32), nullable=False),
-        sa.Column("article_id", sa.String(length=32), nullable=False),
+        sa.Column(
+            "article_id",
+            sa.String(length=32),
+            sa.ForeignKey("web_articles.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
         sa.Column("content_version", sa.Integer(), nullable=False),
         sa.Column("status", sa.String(length=24), nullable=False),
         sa.Column("snapshot", sa.JSON(), nullable=False),
         sa.Column("change_reason", sa.String(length=256), nullable=True),
-        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
         sa.CheckConstraint("content_version >= 1", name="ck_web_article_revision_positive"),
-        sa.ForeignKeyConstraint(["article_id"], ["web_articles.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("id"),
         sa.UniqueConstraint("article_id", "content_version", name="uq_web_article_revision_version"),
     )
@@ -177,8 +185,18 @@ def upgrade() -> None:
     op.create_table(
         "hermes_web_article_submissions",
         sa.Column("submission_id", sa.String(length=64), nullable=False),
-        sa.Column("candidate_id", sa.String(length=32), nullable=False),
-        sa.Column("article_id", sa.String(length=32), nullable=False),
+        sa.Column(
+            "candidate_id",
+            sa.String(length=32),
+            sa.ForeignKey("web_article_candidates.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "article_id",
+            sa.String(length=32),
+            sa.ForeignKey("web_articles.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
         sa.Column("idempotency_key", sa.String(length=128), nullable=False),
         sa.Column("request_nonce", sa.String(length=128), nullable=False),
         sa.Column("payload_hash", sa.String(length=64), nullable=False),
@@ -190,17 +208,13 @@ def upgrade() -> None:
         sa.Column("skill_version", sa.String(length=64), nullable=False),
         sa.Column("response_metadata", sa.JSON(), nullable=False, server_default="{}"),
         sa.Column("status", sa.String(length=16), nullable=False, server_default="accepted"),
-        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("CURRENT_TIMESTAMP")),
         sa.Column("expires_at", sa.DateTime(), nullable=False),
         sa.Column("processed_at", sa.DateTime(), nullable=True),
         sa.CheckConstraint(
             "status IN ('accepted', 'expired')",
             name="ck_hermes_web_article_submissions_status",
         ),
-        sa.ForeignKeyConstraint(
-            ["candidate_id"], ["web_article_candidates.id"], ondelete="RESTRICT"
-        ),
-        sa.ForeignKeyConstraint(["article_id"], ["web_articles.id"], ondelete="RESTRICT"),
         sa.PrimaryKeyConstraint("submission_id"),
         sa.UniqueConstraint("idempotency_key", name="uq_hermes_web_article_idempotency"),
         sa.UniqueConstraint("request_nonce", name="uq_hermes_web_article_nonce"),

--- a/backend/alembic/versions/0072_web_articles_editorial_lifecycle.py
+++ b/backend/alembic/versions/0072_web_articles_editorial_lifecycle.py
@@ -1,0 +1,238 @@
+"""Add canonical Web article candidates, content and immutable revisions.
+
+Revision ID: 0072_web_articles_editorial_lifecycle
+Revises: 0071_hermes_editorial_intake_and_taxonomy
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0072_web_articles_editorial_lifecycle"
+down_revision: str | None = "0071_hermes_editorial_intake_and_taxonomy"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+online_rollout_phase = "expand"
+online_rollout_notes = (
+    "Adds the canonical Web editorial lifecycle; only published rows are eligible for public routes."
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "web_article_candidates",
+        sa.Column("id", sa.String(length=32), nullable=False),
+        sa.Column("source_kind", sa.String(length=16), nullable=False),
+        sa.Column("source_ref", sa.String(length=128), nullable=True),
+        sa.Column("working_title", sa.String(length=240), nullable=False),
+        sa.Column("primary_topic", sa.String(length=64), nullable=False),
+        sa.Column("topics", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("article_kind", sa.String(length=32), nullable=False),
+        sa.Column("search_intent", sa.String(length=24), nullable=False),
+        sa.Column("primary_query", sa.String(length=240), nullable=False),
+        sa.Column("secondary_queries", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("audience", sa.String(length=32), nullable=False, server_default="general"),
+        sa.Column("risk_level", sa.String(length=32), nullable=False, server_default="unknown"),
+        sa.Column("evidence_level", sa.String(length=32), nullable=False, server_default="unknown"),
+        *(
+            sa.Column(name, sa.Integer(), nullable=False, server_default="0")
+            for name in (
+                "search_demand_signal",
+                "intent_clarity",
+                "topical_relevance",
+                "product_relevance",
+                "audience_usefulness",
+                "evergreen_potential",
+                "evidence_availability",
+                "existing_content_overlap",
+                "internal_link_potential",
+                "risk_review_cost",
+                "freshness_need",
+                "news_opportunity",
+            )
+        ),
+        sa.Column("priority_score", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("score_breakdown", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column(
+            "web_article_potential_reasons", sa.JSON(), nullable=False, server_default="[]"
+        ),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="candidate"),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "status IN ('candidate', 'approved', 'researching', 'draft', 'review', 'rejected')",
+            name="ck_web_article_candidates_status",
+        ),
+        sa.CheckConstraint(
+            "source_kind IN ('manual', 'seo_import', 'news_handoff')",
+            name="ck_web_article_candidates_source_kind",
+        ),
+        sa.CheckConstraint(
+            "search_demand_signal BETWEEN 0 AND 100 AND intent_clarity BETWEEN 0 AND 100 "
+            "AND topical_relevance BETWEEN 0 AND 100 AND product_relevance BETWEEN 0 AND 100 "
+            "AND audience_usefulness BETWEEN 0 AND 100 AND evergreen_potential BETWEEN 0 AND 100 "
+            "AND evidence_availability BETWEEN 0 AND 100 AND existing_content_overlap BETWEEN 0 AND 100 "
+            "AND internal_link_potential BETWEEN 0 AND 100 AND risk_review_cost BETWEEN 0 AND 100 "
+            "AND freshness_need BETWEEN 0 AND 100 AND news_opportunity BETWEEN 0 AND 100",
+            name="ck_web_article_candidate_signals",
+        ),
+        sa.CheckConstraint("priority_score BETWEEN 0 AND 100", name="ck_web_article_candidate_score"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_web_article_candidates_queue",
+        "web_article_candidates",
+        ["status", "priority_score", "updated_at"],
+    )
+
+    op.create_table(
+        "web_articles",
+        sa.Column("id", sa.String(length=32), nullable=False),
+        sa.Column("candidate_id", sa.String(length=32), nullable=True),
+        sa.Column("slug", sa.String(length=180), nullable=False),
+        sa.Column("status", sa.String(length=24), nullable=False, server_default="draft"),
+        sa.Column("title", sa.String(length=180), nullable=False),
+        sa.Column("description", sa.String(length=320), nullable=False),
+        sa.Column("lead", sa.Text(), nullable=False),
+        sa.Column("body_sections", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("topics", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("article_kind", sa.String(length=32), nullable=False),
+        sa.Column("search_intent", sa.String(length=24), nullable=False),
+        sa.Column("primary_query", sa.String(length=240), nullable=False),
+        sa.Column("secondary_queries", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("risk_level", sa.String(length=32), nullable=False),
+        sa.Column("evidence_level", sa.String(length=32), nullable=False),
+        sa.Column("claims", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("sources", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("claim_source_matrix", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("author", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column("editor", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column("domain_reviewer", sa.JSON(), nullable=True),
+        sa.Column("canonical_url", sa.String(length=512), nullable=True),
+        sa.Column("related_slugs", sa.JSON(), nullable=False, server_default="[]"),
+        sa.Column("cta", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column("evergreen_score", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("product_relevance", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("editorial_value", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column(
+            "web_article_potential_reasons", sa.JSON(), nullable=False, server_default="[]"
+        ),
+        sa.Column("content_version", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("research_version", sa.String(length=64), nullable=False),
+        sa.Column("provider", sa.String(length=64), nullable=False),
+        sa.Column("model", sa.String(length=128), nullable=False),
+        sa.Column("prompt_version", sa.String(length=64), nullable=False),
+        sa.Column("skill_version", sa.String(length=64), nullable=False),
+        sa.Column("schema_version", sa.String(length=64), nullable=False),
+        sa.Column("generated_with_ai", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("research_assistance", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("content_hash", sa.String(length=64), nullable=False),
+        sa.Column("correction_reason", sa.String(length=256), nullable=True),
+        sa.Column("published_at", sa.DateTime(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "status IN ('candidate', 'researching', 'draft', 'review', 'approved', 'published', "
+            "'update_required', 'archived', 'retracted')",
+            name="ck_web_articles_status",
+        ),
+        sa.CheckConstraint("content_version >= 1", name="ck_web_articles_content_version"),
+        sa.CheckConstraint("evergreen_score BETWEEN 0 AND 100", name="ck_web_articles_evergreen"),
+        sa.CheckConstraint(
+            "product_relevance BETWEEN 0 AND 100", name="ck_web_articles_product_relevance"
+        ),
+        sa.CheckConstraint(
+            "editorial_value BETWEEN 0 AND 100", name="ck_web_articles_editorial_value"
+        ),
+        sa.ForeignKeyConstraint(["candidate_id"], ["web_article_candidates.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("slug"),
+    )
+    op.create_index("ix_web_articles_candidate_id", "web_articles", ["candidate_id"])
+    op.create_index("ix_web_articles_public_queue", "web_articles", ["status", "updated_at"])
+
+    op.create_table(
+        "web_article_revisions",
+        sa.Column("id", sa.String(length=32), nullable=False),
+        sa.Column("article_id", sa.String(length=32), nullable=False),
+        sa.Column("content_version", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=24), nullable=False),
+        sa.Column("snapshot", sa.JSON(), nullable=False),
+        sa.Column("change_reason", sa.String(length=256), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint("content_version >= 1", name="ck_web_article_revision_positive"),
+        sa.ForeignKeyConstraint(["article_id"], ["web_articles.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("article_id", "content_version", name="uq_web_article_revision_version"),
+    )
+    op.create_index(
+        "ix_web_article_revisions_article_created",
+        "web_article_revisions",
+        ["article_id", "created_at"],
+    )
+
+    op.create_table(
+        "hermes_web_article_submissions",
+        sa.Column("submission_id", sa.String(length=64), nullable=False),
+        sa.Column("candidate_id", sa.String(length=32), nullable=False),
+        sa.Column("article_id", sa.String(length=32), nullable=False),
+        sa.Column("idempotency_key", sa.String(length=128), nullable=False),
+        sa.Column("request_nonce", sa.String(length=128), nullable=False),
+        sa.Column("payload_hash", sa.String(length=64), nullable=False),
+        sa.Column("schema_version", sa.String(length=64), nullable=False),
+        sa.Column("research_version", sa.String(length=64), nullable=False),
+        sa.Column("provider", sa.String(length=64), nullable=False),
+        sa.Column("model", sa.String(length=128), nullable=False),
+        sa.Column("prompt_version", sa.String(length=64), nullable=False),
+        sa.Column("skill_version", sa.String(length=64), nullable=False),
+        sa.Column("response_metadata", sa.JSON(), nullable=False, server_default="{}"),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="accepted"),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("processed_at", sa.DateTime(), nullable=True),
+        sa.CheckConstraint(
+            "status IN ('accepted', 'expired')",
+            name="ck_hermes_web_article_submissions_status",
+        ),
+        sa.ForeignKeyConstraint(
+            ["candidate_id"], ["web_article_candidates.id"], ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(["article_id"], ["web_articles.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("submission_id"),
+        sa.UniqueConstraint("idempotency_key", name="uq_hermes_web_article_idempotency"),
+        sa.UniqueConstraint("request_nonce", name="uq_hermes_web_article_nonce"),
+    )
+    op.create_index(
+        "ix_hermes_web_article_submissions_created",
+        "hermes_web_article_submissions",
+        ["created_at"],
+    )
+    op.create_index(
+        "ix_hermes_web_article_submissions_expires_status",
+        "hermes_web_article_submissions",
+        ["expires_at", "status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_hermes_web_article_submissions_expires_status",
+        table_name="hermes_web_article_submissions",
+    )
+    op.drop_index(
+        "ix_hermes_web_article_submissions_created",
+        table_name="hermes_web_article_submissions",
+    )
+    op.drop_table("hermes_web_article_submissions")
+    op.drop_index(
+        "ix_web_article_revisions_article_created", table_name="web_article_revisions"
+    )
+    op.drop_table("web_article_revisions")
+    op.drop_index("ix_web_articles_public_queue", table_name="web_articles")
+    op.drop_index("ix_web_articles_candidate_id", table_name="web_articles")
+    op.drop_table("web_articles")
+    op.drop_index("ix_web_article_candidates_queue", table_name="web_article_candidates")
+    op.drop_table("web_article_candidates")

--- a/backend/fitminiapp_api/api/v1/hermes_articles.py
+++ b/backend/fitminiapp_api/api/v1/hermes_articles.py
@@ -34,7 +34,9 @@ _CLIENT_ERROR_CODES = {
     "cta_contains_unallowed_fields",
     "cta_copy_invalid",
     "cta_destination_invalid",
+    "nonce_mismatch",
     "schema_version_unsupported",
+    "source_count_exceeded",
     "skill_version_unsupported",
     "slug_invalid",
 }
@@ -52,7 +54,7 @@ def _http_error(error: HermesIntakeError | WebArticleError) -> HTTPException:
     if error.code in _CONFLICT_CODES:
         return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=error.code)
     if error.code in _CLIENT_ERROR_CODES:
-        return HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=error.code)
+        return HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=error.code)
     return HTTPException(
         status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="article_intake_failed"
     )
@@ -92,6 +94,8 @@ async def receive_hermes_web_article_intake(
         payload = _REQUEST_ADAPTER.validate_json(body)
     except ValidationError as exc:
         raise HTTPException(status_code=422, detail="payload_invalid") from exc
+    if payload.request_nonce != (x_hermes_nonce or ""):
+        raise _http_error(WebArticleError("nonce_mismatch"))
     if payload.schema_version != HERMES_WEB_ARTICLE_SCHEMA_VERSION:
         raise _http_error(WebArticleError("schema_version_unsupported"))
     try:

--- a/backend/fitminiapp_api/api/v1/hermes_articles.py
+++ b/backend/fitminiapp_api/api/v1/hermes_articles.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import hashlib
+from typing import Literal, cast
+
+from fastapi import APIRouter, Header, HTTPException, Request, status
+from pydantic import TypeAdapter, ValidationError
+
+from fitminiapp_api.core.config import settings
+from fitminiapp_api.db.session import get_session_context
+from fitminiapp_api.schemas.articles import (
+    HermesWebArticleIntakeRequest,
+    HermesWebArticleIntakeResponse,
+)
+from fitminiapp_api.services.news_hermes import HermesIntakeError, verify_hermes_signature
+from fitminiapp_api.services.web_articles import (
+    HERMES_WEB_ARTICLE_SCHEMA_VERSION,
+    WebArticleError,
+    accept_hermes_article_submission,
+)
+
+router = APIRouter()
+_REQUEST_ADAPTER = TypeAdapter(HermesWebArticleIntakeRequest)
+_CONFLICT_CODES = {
+    "idempotency_conflict",
+    "idempotency_nonce_conflict",
+    "replay_detected",
+    "replay_expired",
+    "slug_conflict",
+}
+_CLIENT_ERROR_CODES = {
+    "candidate_missing",
+    "candidate_not_ready",
+    "cta_contains_unallowed_fields",
+    "cta_copy_invalid",
+    "cta_destination_invalid",
+    "schema_version_unsupported",
+    "skill_version_unsupported",
+    "slug_invalid",
+}
+
+
+def _http_error(error: HermesIntakeError | WebArticleError) -> HTTPException:
+    if error.code == "intake_disabled":
+        return HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=error.code)
+    if error.code in {"key_not_found", "signature_headers_invalid", "signature_invalid"}:
+        return HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="forbidden")
+    if error.code == "signature_expired":
+        return HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=error.code)
+    if error.code == "rate_limited":
+        return HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail=error.code)
+    if error.code in _CONFLICT_CODES:
+        return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=error.code)
+    if error.code in _CLIENT_ERROR_CODES:
+        return HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=error.code)
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="article_intake_failed"
+    )
+
+
+@router.post("/articles/intake", response_model=HermesWebArticleIntakeResponse)
+async def receive_hermes_web_article_intake(
+    request: Request,
+    x_hermes_key_id: str | None = Header(default=None, alias="X-Hermes-Key-Id"),
+    x_hermes_timestamp: str | None = Header(default=None, alias="X-Hermes-Timestamp"),
+    x_hermes_nonce: str | None = Header(default=None, alias="X-Hermes-Nonce"),
+    x_hermes_signature: str | None = Header(default=None, alias="X-Hermes-Signature"),
+) -> HermesWebArticleIntakeResponse:
+    if not settings.hermes_intake_enabled:
+        raise _http_error(HermesIntakeError("intake_disabled"))
+    content_length = request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            if int(content_length) > settings.hermes_intake_max_body_bytes:
+                raise HTTPException(status_code=413, detail="payload_too_large")
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail="content_length_invalid") from exc
+    body = await request.body()
+    if len(body) > settings.hermes_intake_max_body_bytes:
+        raise HTTPException(status_code=413, detail="payload_too_large")
+    try:
+        verify_hermes_signature(
+            key_id=x_hermes_key_id or "",
+            timestamp=x_hermes_timestamp or "",
+            nonce=x_hermes_nonce or "",
+            signature=x_hermes_signature or "",
+            body=body,
+        )
+    except HermesIntakeError as exc:
+        raise _http_error(exc) from exc
+    try:
+        payload = _REQUEST_ADAPTER.validate_json(body)
+    except ValidationError as exc:
+        raise HTTPException(status_code=422, detail="payload_invalid") from exc
+    if payload.schema_version != HERMES_WEB_ARTICLE_SCHEMA_VERSION:
+        raise _http_error(WebArticleError("schema_version_unsupported"))
+    try:
+        with get_session_context() as db:
+            result = accept_hermes_article_submission(
+                db,
+                payload,
+                payload_hash=hashlib.sha256(body).hexdigest(),
+            )
+    except WebArticleError as exc:
+        raise _http_error(exc) from exc
+    return HermesWebArticleIntakeResponse(
+        status=cast(Literal["accepted", "duplicate"], result.status),
+        submission_id=result.submission_id,
+        article_id=result.article_id,
+        article_status=cast(
+            Literal[
+                "candidate",
+                "researching",
+                "draft",
+                "review",
+                "approved",
+                "published",
+                "update_required",
+                "archived",
+                "retracted",
+            ],
+            result.article_status,
+        ),
+        content_version=result.content_version,
+        review_blockers=list(result.review_blockers),
+    )

--- a/backend/fitminiapp_api/api/v1/public.py
+++ b/backend/fitminiapp_api/api/v1/public.py
@@ -6,6 +6,7 @@ from fitminiapp_api.db.session import get_db
 from fitminiapp_api.models.news import WebArticle
 from fitminiapp_api.schemas.articles import WebArticleCard, WebArticleResponse
 from fitminiapp_api.schemas.public import PublicExerciseDetail, PublicExerciseSummary
+from fitminiapp_api.seo import NOINDEX_ROBOTS
 from fitminiapp_api.services.public_exercises import public_exercise, public_exercises
 from fitminiapp_api.services.web_articles import (
     article_card,
@@ -48,11 +49,23 @@ def get_public_articles(db: Session = Depends(get_db)) -> list[WebArticleCard]:
 
 @router.get("/public/articles/{slug}", response_model=WebArticleResponse)
 def get_public_article(slug: str, db: Session = Depends(get_db)) -> WebArticleResponse:
-    article = (
-        db.query(WebArticle)
-        .filter(WebArticle.slug == slug, WebArticle.status == "published")
-        .one_or_none()
-    )
+    article = db.query(WebArticle).filter(WebArticle.slug == slug).one_or_none()
     if article is None:
-        raise HTTPException(status_code=404, detail="Статья не опубликована")
+        raise HTTPException(
+            status_code=404,
+            detail="Статья не опубликована",
+            headers={"X-Robots-Tag": NOINDEX_ROBOTS},
+        )
+    if article.status in {"archived", "retracted"}:
+        raise HTTPException(
+            status_code=410,
+            detail="Статья снята с публикации",
+            headers={"X-Robots-Tag": NOINDEX_ROBOTS},
+        )
+    if article.status != "published":
+        raise HTTPException(
+            status_code=404,
+            detail="Статья не опубликована",
+            headers={"X-Robots-Tag": NOINDEX_ROBOTS},
+        )
     return article_public_response(article)

--- a/backend/fitminiapp_api/api/v1/public.py
+++ b/backend/fitminiapp_api/api/v1/public.py
@@ -1,8 +1,17 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
 
 from fitminiapp_api.core.config import settings
+from fitminiapp_api.db.session import get_db
+from fitminiapp_api.models.news import WebArticle
+from fitminiapp_api.schemas.articles import WebArticleCard, WebArticleResponse
 from fitminiapp_api.schemas.public import PublicExerciseDetail, PublicExerciseSummary
 from fitminiapp_api.services.public_exercises import public_exercise, public_exercises
+from fitminiapp_api.services.web_articles import (
+    article_card,
+    article_public_response,
+    published_articles,
+)
 
 router = APIRouter()
 
@@ -30,3 +39,20 @@ def get_public_exercise(slug: str) -> dict[str, object]:
     if exercise is None:
         raise HTTPException(status_code=404, detail="Упражнение не опубликовано")
     return exercise
+
+
+@router.get("/public/articles", response_model=list[WebArticleCard])
+def get_public_articles(db: Session = Depends(get_db)) -> list[WebArticleCard]:
+    return [article_card(article) for article in published_articles(db)]
+
+
+@router.get("/public/articles/{slug}", response_model=WebArticleResponse)
+def get_public_article(slug: str, db: Session = Depends(get_db)) -> WebArticleResponse:
+    article = (
+        db.query(WebArticle)
+        .filter(WebArticle.slug == slug, WebArticle.status == "published")
+        .one_or_none()
+    )
+    if article is None:
+        raise HTTPException(status_code=404, detail="Статья не опубликована")
+    return article_public_response(article)

--- a/backend/fitminiapp_api/api/v1/router.py
+++ b/backend/fitminiapp_api/api/v1/router.py
@@ -8,6 +8,7 @@ from fitminiapp_api.api.v1 import (
     coach,
     demo,
     hermes,
+    hermes_articles,
     me,
     notifications,
     nutrition,
@@ -31,3 +32,4 @@ api_router.include_router(notifications.router, prefix="/notifications", tags=["
 api_router.include_router(admin.router, prefix="/admin", tags=["admin"])
 api_router.include_router(bot.router, prefix="/bot", tags=["bot"])
 api_router.include_router(hermes.router, prefix="/hermes", tags=["hermes"])
+api_router.include_router(hermes_articles.router, prefix="/hermes", tags=["hermes"])

--- a/backend/fitminiapp_api/main.py
+++ b/backend/fitminiapp_api/main.py
@@ -17,11 +17,13 @@ from fitminiapp_api.api.router import api_router
 from fitminiapp_api.core.config import settings
 from fitminiapp_api.core.logging_config import configure_logging
 from fitminiapp_api.core.rate_limit import limiter
-from fitminiapp_api.db.session import engine
+from fitminiapp_api.db.session import SessionLocal, engine
 from fitminiapp_api.middleware.canonical_host import redirect_landing_application_requests
 from fitminiapp_api.middleware.request_body_limit import RequestBodyLimitMiddleware
 from fitminiapp_api.middleware.request_context import RequestContextMiddleware
+from fitminiapp_api.models.news import WebArticle
 from fitminiapp_api.seo import public_origin, public_page_paths, render_frontend_document
+from fitminiapp_api.services.web_articles import published_articles
 
 APP_DIR = Path(__file__).resolve().parent
 BACKEND_DIR = APP_DIR.parent
@@ -151,11 +153,18 @@ def health_ready() -> dict[str, str]:
     return health()
 
 
-def _frontend_index(path: str) -> HTMLResponse:
+def _frontend_index(
+    path: str,
+    *,
+    article: WebArticle | None = None,
+    articles: tuple[WebArticle, ...] = (),
+) -> HTMLResponse:
     index = FRONTEND_DIST_DIR / "index.html"
     if not index.exists():
         raise RuntimeError("Frontend build is missing. Run `npm run build` in frontend/.")
-    document, metadata = render_frontend_document(index.read_text(encoding="utf-8"), path)
+    document, metadata = render_frontend_document(
+        index.read_text(encoding="utf-8"), path, article=article, articles=articles
+    )
     return HTMLResponse(
         document,
         headers={
@@ -186,11 +195,22 @@ def robots_txt() -> PlainTextResponse:
 def sitemap() -> Response:
     origin = public_origin()
     urls = [f"{origin}/" if path == "/" else f"{origin}{path}" for path in public_page_paths()]
-    entries = "\n".join(f"  <url>\n    <loc>{url}</loc>\n  </url>" for url in urls)
+    with SessionLocal() as db:
+        articles = published_articles(db)
+    entries = [f"  <url>\n    <loc>{url}</loc>\n  </url>" for url in urls]
+    entries.extend(
+        "  <url>\n"
+        f"    <loc>{origin}/articles/{article.slug}</loc>\n"
+        f"    <lastmod>{article.updated_at.date().isoformat()}</lastmod>\n"
+        "  </url>"
+        for article in articles
+        if article.updated_at is not None
+    )
+    entry_text = "\n".join(entries)
     content = (
         '<?xml version="1.0" encoding="UTF-8"?>\n'
         '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
-        f"{entries}\n"
+        f"{entry_text}\n"
         "</urlset>\n"
     )
     return Response(
@@ -218,6 +238,27 @@ def demo_page() -> HTMLResponse:
 @app.get("/")
 def landing_page() -> HTMLResponse:
     return _frontend_index("/")
+
+
+@app.get("/articles")
+def articles_index_page() -> HTMLResponse:
+    with SessionLocal() as db:
+        articles = tuple(published_articles(db))
+    return _frontend_index("/articles", articles=articles)
+
+
+@app.get("/articles/{slug}")
+def article_page(slug: str) -> HTMLResponse:
+    with SessionLocal() as db:
+        article = (
+            db.query(WebArticle)
+            .filter(WebArticle.slug == slug, WebArticle.status == "published")
+            .one_or_none()
+        )
+        if article is None:
+            raise HTTPException(status_code=404, detail="Article not found")
+        articles = tuple(published_articles(db))
+    return _frontend_index(f"/articles/{slug}", article=article, articles=articles)
 
 
 def public_content_page(request: Request) -> HTMLResponse:

--- a/backend/fitminiapp_api/main.py
+++ b/backend/fitminiapp_api/main.py
@@ -22,7 +22,12 @@ from fitminiapp_api.middleware.canonical_host import redirect_landing_applicatio
 from fitminiapp_api.middleware.request_body_limit import RequestBodyLimitMiddleware
 from fitminiapp_api.middleware.request_context import RequestContextMiddleware
 from fitminiapp_api.models.news import WebArticle
-from fitminiapp_api.seo import public_origin, public_page_paths, render_frontend_document
+from fitminiapp_api.seo import (
+    NOINDEX_ROBOTS,
+    public_origin,
+    public_page_paths,
+    render_frontend_document,
+)
 from fitminiapp_api.services.web_articles import published_articles
 
 APP_DIR = Path(__file__).resolve().parent
@@ -250,13 +255,25 @@ def articles_index_page() -> HTMLResponse:
 @app.get("/articles/{slug}")
 def article_page(slug: str) -> HTMLResponse:
     with SessionLocal() as db:
-        article = (
-            db.query(WebArticle)
-            .filter(WebArticle.slug == slug, WebArticle.status == "published")
-            .one_or_none()
-        )
+        article = db.query(WebArticle).filter(WebArticle.slug == slug).one_or_none()
         if article is None:
-            raise HTTPException(status_code=404, detail="Article not found")
+            raise HTTPException(
+                status_code=404,
+                detail="Article not found",
+                headers={"X-Robots-Tag": NOINDEX_ROBOTS},
+            )
+        if article.status in {"archived", "retracted"}:
+            raise HTTPException(
+                status_code=410,
+                detail="Article removed",
+                headers={"X-Robots-Tag": NOINDEX_ROBOTS},
+            )
+        if article.status != "published":
+            raise HTTPException(
+                status_code=404,
+                detail="Article not found",
+                headers={"X-Robots-Tag": NOINDEX_ROBOTS},
+            )
         articles = tuple(published_articles(db))
     return _frontend_index(f"/articles/{slug}", article=article, articles=articles)
 

--- a/backend/fitminiapp_api/models/__init__.py
+++ b/backend/fitminiapp_api/models/__init__.py
@@ -23,6 +23,7 @@ from fitminiapp_api.models.food_diary import (
 )
 from fitminiapp_api.models.hydration import HydrationEntry, HydrationGoal, HydrationPreset
 from fitminiapp_api.models.news import (
+    HermesWebArticleSubmission,
     NewsCluster,
     NewsDraftRevision,
     NewsEditorialAction,
@@ -33,6 +34,9 @@ from fitminiapp_api.models.news import (
     NewsReviewDelivery,
     NewsSource,
     NewsStateTransition,
+    WebArticle,
+    WebArticleCandidate,
+    WebArticleRevision,
 )
 from fitminiapp_api.models.notification import Notification, NotificationSetting
 from fitminiapp_api.models.nutrition import EnergyCalibration, NutritionTarget
@@ -95,6 +99,7 @@ __all__ = [
     "FoodDiaryDayStatus",
     "FoodDiaryEntry",
     "FoodFavorite",
+    "HermesWebArticleSubmission",
     "HiddenProgramTemplate",
     "HydrationEntry",
     "HydrationGoal",
@@ -134,6 +139,9 @@ __all__ = [
     "UserWorkout",
     "UserWorkoutExercise",
     "UserWorkoutSet",
+    "WebArticle",
+    "WebArticleCandidate",
+    "WebArticleRevision",
     "WeeklyCheckIn",
     "WeeklyDigestDelivery",
     "WeeklyDigestIssue",

--- a/backend/fitminiapp_api/models/news.py
+++ b/backend/fitminiapp_api/models/news.py
@@ -595,6 +595,7 @@ class WebArticle(Base):
         CheckConstraint(
             "editorial_value BETWEEN 0 AND 100", name="ck_web_articles_editorial_value"
         ),
+        Index("ix_web_articles_candidate_id", "candidate_id"),
         Index("ix_web_articles_public_queue", "status", "updated_at"),
     )
 

--- a/backend/fitminiapp_api/models/news.py
+++ b/backend/fitminiapp_api/models/news.py
@@ -512,3 +512,198 @@ class HermesEditorialSubmission(Base):
     )
     expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
     processed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+
+class WebArticleCandidate(Base):
+    """Provider-neutral article idea and scoring receipt; never a publish instruction."""
+
+    __tablename__ = "web_article_candidates"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('candidate', 'approved', 'researching', 'draft', 'review', 'rejected')",
+            name="ck_web_article_candidates_status",
+        ),
+        CheckConstraint(
+            "source_kind IN ('manual', 'seo_import', 'news_handoff')",
+            name="ck_web_article_candidates_source_kind",
+        ),
+        CheckConstraint(
+            "search_demand_signal BETWEEN 0 AND 100 AND intent_clarity BETWEEN 0 AND 100 "
+            "AND topical_relevance BETWEEN 0 AND 100 AND product_relevance BETWEEN 0 AND 100 "
+            "AND audience_usefulness BETWEEN 0 AND 100 AND evergreen_potential BETWEEN 0 AND 100 "
+            "AND evidence_availability BETWEEN 0 AND 100 AND existing_content_overlap BETWEEN 0 AND 100 "
+            "AND internal_link_potential BETWEEN 0 AND 100 AND risk_review_cost BETWEEN 0 AND 100 "
+            "AND freshness_need BETWEEN 0 AND 100 AND news_opportunity BETWEEN 0 AND 100",
+            name="ck_web_article_candidate_signals",
+        ),
+        CheckConstraint("priority_score BETWEEN 0 AND 100", name="ck_web_article_candidate_score"),
+        Index("ix_web_article_candidates_queue", "status", "priority_score", "updated_at"),
+    )
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True)
+    source_kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    source_ref: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="candidate")
+    working_title: Mapped[str] = mapped_column(String(240), nullable=False)
+    primary_topic: Mapped[str] = mapped_column(String(64), nullable=False)
+    topics: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    article_kind: Mapped[str] = mapped_column(String(32), nullable=False)
+    search_intent: Mapped[str] = mapped_column(String(24), nullable=False)
+    primary_query: Mapped[str] = mapped_column(String(240), nullable=False)
+    secondary_queries: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    audience: Mapped[str] = mapped_column(String(32), nullable=False, default="general")
+    risk_level: Mapped[str] = mapped_column(String(32), nullable=False, default="unknown")
+    evidence_level: Mapped[str] = mapped_column(String(32), nullable=False, default="unknown")
+    search_demand_signal: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    intent_clarity: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    topical_relevance: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    product_relevance: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    audience_usefulness: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    evergreen_potential: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    evidence_availability: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    existing_content_overlap: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    internal_link_potential: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    risk_review_cost: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    freshness_need: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    news_opportunity: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    priority_score: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    score_breakdown: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    web_article_potential_reasons: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+
+class WebArticle(Base):
+    """Canonical Web article state. Public routes expose only the published status."""
+
+    __tablename__ = "web_articles"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('candidate', 'researching', 'draft', 'review', 'approved', 'published', "
+            "'update_required', 'archived', 'retracted')",
+            name="ck_web_articles_status",
+        ),
+        CheckConstraint("content_version >= 1", name="ck_web_articles_content_version"),
+        CheckConstraint("evergreen_score BETWEEN 0 AND 100", name="ck_web_articles_evergreen"),
+        CheckConstraint(
+            "product_relevance BETWEEN 0 AND 100", name="ck_web_articles_product_relevance"
+        ),
+        CheckConstraint(
+            "editorial_value BETWEEN 0 AND 100", name="ck_web_articles_editorial_value"
+        ),
+        Index("ix_web_articles_public_queue", "status", "updated_at"),
+    )
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True)
+    candidate_id: Mapped[str | None] = mapped_column(
+        ForeignKey("web_article_candidates.id", ondelete="SET NULL"), nullable=True
+    )
+    slug: Mapped[str] = mapped_column(String(180), nullable=False, unique=True)
+    status: Mapped[str] = mapped_column(String(24), nullable=False, default="draft")
+    title: Mapped[str] = mapped_column(String(180), nullable=False)
+    description: Mapped[str] = mapped_column(String(320), nullable=False)
+    lead: Mapped[str] = mapped_column(Text, nullable=False)
+    body_sections: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    topics: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    article_kind: Mapped[str] = mapped_column(String(32), nullable=False)
+    search_intent: Mapped[str] = mapped_column(String(24), nullable=False)
+    primary_query: Mapped[str] = mapped_column(String(240), nullable=False)
+    secondary_queries: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    risk_level: Mapped[str] = mapped_column(String(32), nullable=False)
+    evidence_level: Mapped[str] = mapped_column(String(32), nullable=False)
+    claims: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    sources: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    claim_source_matrix: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    author: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    editor: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    domain_reviewer: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    canonical_url: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    related_slugs: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    cta: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    evergreen_score: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    product_relevance: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    editorial_value: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    web_article_potential_reasons: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    content_version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    research_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    provider: Mapped[str] = mapped_column(String(64), nullable=False)
+    model: Mapped[str] = mapped_column(String(128), nullable=False)
+    prompt_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    skill_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    schema_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    generated_with_ai: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    research_assistance: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    correction_reason: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    published_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    updated_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+
+
+class WebArticleRevision(Base):
+    """Immutable snapshot of every submitted or published Web article version."""
+
+    __tablename__ = "web_article_revisions"
+    __table_args__ = (
+        UniqueConstraint("article_id", "content_version", name="uq_web_article_revision_version"),
+        CheckConstraint("content_version >= 1", name="ck_web_article_revision_positive"),
+        Index("ix_web_article_revisions_article_created", "article_id", "created_at"),
+    )
+
+    id: Mapped[str] = mapped_column(String(32), primary_key=True)
+    article_id: Mapped[str] = mapped_column(
+        ForeignKey("web_articles.id", ondelete="CASCADE"), nullable=False
+    )
+    content_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(String(24), nullable=False)
+    snapshot: Mapped[dict] = mapped_column(JSON, nullable=False)
+    change_reason: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+
+
+class HermesWebArticleSubmission(Base):
+    """Replay-protected receipt for the long-form Hermes boundary."""
+
+    __tablename__ = "hermes_web_article_submissions"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('accepted', 'expired')",
+            name="ck_hermes_web_article_submissions_status",
+        ),
+        UniqueConstraint("idempotency_key", name="uq_hermes_web_article_idempotency"),
+        UniqueConstraint("request_nonce", name="uq_hermes_web_article_nonce"),
+        Index("ix_hermes_web_article_submissions_created", "created_at"),
+        Index("ix_hermes_web_article_submissions_expires_status", "expires_at", "status"),
+    )
+
+    submission_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    candidate_id: Mapped[str] = mapped_column(
+        ForeignKey("web_article_candidates.id", ondelete="RESTRICT"), nullable=False
+    )
+    article_id: Mapped[str] = mapped_column(
+        ForeignKey("web_articles.id", ondelete="RESTRICT"), nullable=False
+    )
+    idempotency_key: Mapped[str] = mapped_column(String(128), nullable=False)
+    request_nonce: Mapped[str] = mapped_column(String(128), nullable=False)
+    payload_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    schema_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    research_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    provider: Mapped[str] = mapped_column(String(64), nullable=False)
+    model: Mapped[str] = mapped_column(String(128), nullable=False)
+    prompt_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    skill_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    response_metadata: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="accepted")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    processed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/backend/fitminiapp_api/schemas/articles.py
+++ b/backend/fitminiapp_api/schemas/articles.py
@@ -61,6 +61,12 @@ class ArticleSource(BaseModel):
     published_at: str | None = Field(default=None, max_length=32)
     limitations: str = Field(default="", max_length=800)
 
+    @model_validator(mode="after")
+    def require_https(self) -> ArticleSource:
+        if self.url.scheme != "https":
+            raise ValueError("article sources must use HTTPS")
+        return self
+
 
 class ArticleClaimSourceMatrixItem(BaseModel):
     model_config = ConfigDict(extra="forbid")

--- a/backend/fitminiapp_api/schemas/articles.py
+++ b/backend/fitminiapp_api/schemas/articles.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, model_validator
+
+from fitminiapp_api.schemas.bot import HermesGenerationProvenance
+
+ArticleKind = Literal[
+    "evergreen_explainer",
+    "practical_guide",
+    "evidence_review",
+    "myth_busting",
+    "research_update",
+    "comparison",
+    "product_education",
+]
+SearchIntent = Literal["informational", "how_to", "comparison", "definition", "evidence", "mixed"]
+ArticleStatus = Literal[
+    "candidate",
+    "researching",
+    "draft",
+    "review",
+    "approved",
+    "published",
+    "update_required",
+    "archived",
+    "retracted",
+]
+ArticleRiskLevel = Literal["low", "moderate", "high", "critical", "unknown"]
+ArticleEvidenceLevel = Literal[
+    "high", "moderate", "limited", "preliminary", "conflicting", "unknown"
+]
+
+
+class ArticleBodySection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    heading: str = Field(..., min_length=1, max_length=180)
+    paragraphs: list[str] = Field(..., min_length=1, max_length=8)
+    points: list[str] = Field(default_factory=list, max_length=12)
+
+
+class ArticleClaim(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    claim_id: str = Field(..., min_length=1, max_length=64, pattern=r"^[a-z][a-z0-9_-]{1,63}$")
+    claim_text: str = Field(..., min_length=1, max_length=800)
+    normalized_claim: str = Field(..., min_length=1, max_length=800)
+
+
+class ArticleSource(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source_id: str = Field(..., min_length=1, max_length=64, pattern=r"^[a-z][a-z0-9_-]{1,63}$")
+    title: str = Field(..., min_length=1, max_length=240)
+    publisher: str = Field(..., min_length=1, max_length=160)
+    url: HttpUrl
+    source_type: str = Field(..., min_length=1, max_length=48)
+    published_at: str | None = Field(default=None, max_length=32)
+    limitations: str = Field(default="", max_length=800)
+
+
+class ArticleClaimSourceMatrixItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    claim_id: str = Field(..., min_length=1, max_length=64, pattern=r"^[a-z][a-z0-9_-]{1,63}$")
+    source_ids: list[str] = Field(..., min_length=1, max_length=15)
+    support_level: Literal["supports", "partially_supports", "does_not_support", "unclear"]
+    limitations: str = Field(default="", max_length=1000)
+    review_status: Literal["pending", "verified", "blocked"] = "pending"
+
+
+class ArticlePerson(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., min_length=1, max_length=160)
+    type: Literal["Organization", "Person"]
+
+
+class HermesWebArticleProposal(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    slug: str = Field(..., min_length=3, max_length=180, pattern=r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+    title: str = Field(..., min_length=1, max_length=180)
+    description: str = Field(..., min_length=1, max_length=320)
+    lead: str = Field(..., min_length=1, max_length=1200)
+    body_sections: list[ArticleBodySection] = Field(..., min_length=2, max_length=24)
+    topics: list[str] = Field(..., min_length=1, max_length=12)
+    article_kind: ArticleKind
+    search_intent: SearchIntent
+    primary_query: str = Field(..., min_length=1, max_length=240)
+    secondary_queries: list[str] = Field(default_factory=list, max_length=20)
+    risk_level: ArticleRiskLevel
+    evidence_level: ArticleEvidenceLevel
+    claims: list[ArticleClaim] = Field(..., min_length=1, max_length=80)
+    sources: list[ArticleSource] = Field(..., min_length=1, max_length=30)
+    claim_source_matrix: list[ArticleClaimSourceMatrixItem] = Field(
+        ..., min_length=1, max_length=80
+    )
+    author: ArticlePerson
+    editor: ArticlePerson
+    domain_reviewer: ArticlePerson | None = None
+    related_slugs: list[str] = Field(default_factory=list, max_length=8)
+    cta: dict[str, str] = Field(default_factory=dict)
+    evergreen_score: int = Field(..., ge=0, le=100)
+    product_relevance: int = Field(..., ge=0, le=100)
+    editorial_value: int = Field(..., ge=0, le=100)
+    web_article_potential_reasons: list[str] = Field(default_factory=list, max_length=16)
+
+    @model_validator(mode="after")
+    def validate_matrix(self) -> HermesWebArticleProposal:
+        claim_ids = {claim.claim_id for claim in self.claims}
+        source_ids = {source.source_id for source in self.sources}
+        matrix_claim_ids = {item.claim_id for item in self.claim_source_matrix}
+        if matrix_claim_ids != claim_ids:
+            raise ValueError("claim_source_matrix must cover each claim exactly once")
+        if any(
+            source_id not in source_ids
+            for item in self.claim_source_matrix
+            for source_id in item.source_ids
+        ):
+            raise ValueError("claim_source_matrix references an unknown source")
+        if self.risk_level in {"high", "critical"} and self.domain_reviewer is None:
+            raise ValueError("domain_reviewer is required for high-risk articles")
+        if len(self.sources) < 2 and self.article_kind == "evidence_review":
+            raise ValueError("evidence_review requires multiple sources")
+        return self
+
+
+class HermesWebArticleIntakeRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["hermes-web-article-intake-v1"] = "hermes-web-article-intake-v1"
+    idempotency_key: str = Field(..., min_length=16, max_length=128, pattern=r"^[A-Za-z0-9_.:-]+$")
+    request_nonce: str = Field(..., min_length=16, max_length=128, pattern=r"^[A-Za-z0-9_.:-]+$")
+    candidate_id: str = Field(..., min_length=32, max_length=32, pattern=r"^[0-9a-f]{32}$")
+    research_version: str = Field(..., min_length=1, max_length=64, pattern=r"^[a-zA-Z0-9_.:-]+$")
+    article: HermesWebArticleProposal
+    provenance: HermesGenerationProvenance
+
+
+class WebArticleCard(BaseModel):
+    slug: str
+    title: str
+    description: str
+    lead: str
+    topics: list[str]
+    article_kind: ArticleKind
+    published_at: datetime
+    updated_at: datetime
+    canonical_url: str
+
+
+class WebArticleResponse(WebArticleCard):
+    body_sections: list[ArticleBodySection]
+    search_intent: SearchIntent
+    primary_query: str
+    secondary_queries: list[str]
+    risk_level: ArticleRiskLevel
+    evidence_level: ArticleEvidenceLevel
+    claims: list[ArticleClaim]
+    sources: list[ArticleSource]
+    claim_source_matrix: list[ArticleClaimSourceMatrixItem]
+    author: ArticlePerson
+    editor: ArticlePerson
+    domain_reviewer: ArticlePerson | None
+    related_slugs: list[str]
+    cta: dict[str, str]
+    content_version: int
+    generated_with_ai: bool
+    research_assistance: bool
+
+
+class HermesWebArticleIntakeResponse(BaseModel):
+    status: Literal["accepted", "duplicate"]
+    submission_id: str
+    article_id: str
+    article_status: ArticleStatus
+    content_version: int
+    review_blockers: list[str]

--- a/backend/fitminiapp_api/seo.py
+++ b/backend/fitminiapp_api/seo.py
@@ -11,12 +11,18 @@ from typing import cast
 from urllib.parse import urlparse
 
 from fitminiapp_api.core.config import settings
+from fitminiapp_api.models.news import WebArticle
 from fitminiapp_api.services.public_exercises import public_exercise
 
 INDEX_ROBOTS = "index, follow"
 NOINDEX_ROBOTS = "noindex, nofollow"
 SOCIAL_IMAGE_PATH = "/assets/brand/yfc-social-preview.png"
 SOCIAL_IMAGE_ALT = "Your Fitness Coach — тренировки, питание и прогресс в браузере и Telegram"
+ARTICLE_INDEX_TITLE = "Статьи о тренировках, питании и прогрессе — Your Fitness Coach"
+ARTICLE_INDEX_DESCRIPTION = (
+    "Понятные статьи о тренировках, питании, спортивном питании и прогрессе: "
+    "источники, ограничения и практический смысл без громких обещаний."
+)
 _PUBLIC_FALLBACK_PATTERN = re.compile(
     r"<!-- public-fallback-start -->.*?<!-- public-fallback-end -->",
     re.DOTALL,
@@ -278,6 +284,76 @@ def metadata_for_path(path: str) -> SeoMetadata:
     )
 
 
+def metadata_for_articles() -> SeoMetadata:
+    return SeoMetadata(
+        title=ARTICLE_INDEX_TITLE,
+        description=ARTICLE_INDEX_DESCRIPTION,
+        robots=INDEX_ROBOTS,
+        canonical_url=_absolute_public_url("/articles"),
+        og_description=ARTICLE_INDEX_DESCRIPTION,
+        structured_data=(
+            {
+                "@context": "https://schema.org",
+                "@type": "CollectionPage",
+                "name": ARTICLE_INDEX_TITLE,
+                "description": ARTICLE_INDEX_DESCRIPTION,
+                "url": _absolute_public_url("/articles"),
+                "isPartOf": {
+                    "@type": "WebSite",
+                    "name": "Your Fitness Coach",
+                    "url": _absolute_public_url("/"),
+                },
+            },
+        ),
+    )
+
+
+def metadata_for_article(article: WebArticle) -> SeoMetadata:
+    if article.status != "published" or article.published_at is None or article.updated_at is None:
+        return metadata_for_path("/articles")
+    canonical_url = article.canonical_url or _absolute_public_url(f"/articles/{article.slug}")
+    author = article.author if isinstance(article.author, dict) else {}
+    editor = article.editor if isinstance(article.editor, dict) else {}
+    reviewer = article.domain_reviewer if isinstance(article.domain_reviewer, dict) else None
+    entity: dict[str, object] = {
+        "@type": "Article",
+        "headline": article.title,
+        "description": article.description,
+        "url": canonical_url,
+        "mainEntityOfPage": canonical_url,
+        "datePublished": article.published_at.date().isoformat(),
+        "dateModified": article.updated_at.date().isoformat(),
+        "author": {
+            "@type": author.get("type", "Organization"),
+            "name": author.get("name", "Your Fitness Coach"),
+        },
+        "editor": {
+            "@type": editor.get("type", "Organization"),
+            "name": editor.get("name", "YFC Editorial Desk"),
+        },
+        "publisher": {"@type": "Organization", "name": "Your Fitness Coach"},
+    }
+    if reviewer:
+        entity["reviewedBy"] = {
+            "@type": reviewer.get("type", "Organization"),
+            "name": reviewer.get("name", "YFC Domain Review"),
+        }
+    return SeoMetadata(
+        title=article.title,
+        description=article.description,
+        robots=INDEX_ROBOTS,
+        canonical_url=canonical_url,
+        og_description=article.description,
+        og_type="article",
+        structured_data=(
+            {
+                "@context": "https://schema.org",
+                **entity,
+            },
+        ),
+    )
+
+
 def render_metadata(metadata: SeoMetadata) -> str:
     """Render only server-controlled metadata; no user content is inserted here."""
 
@@ -336,6 +412,113 @@ def _link_markup(item: dict[str, object]) -> str:
     description = item.get("description")
     detail = f"<span>{html.escape(description)}</span>" if isinstance(description, str) else ""
     return f'<li><a href="{path}">{label}</a>{detail}</li>'
+
+
+def _article_person_markup(label: str, person: object) -> str:
+    if not isinstance(person, dict):
+        return ""
+    name = person.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return ""
+    return f"<dt>{html.escape(label)}</dt><dd>{html.escape(name)}</dd>"
+
+
+def render_article_fallback(article: WebArticle, related: tuple[WebArticle, ...] = ()) -> str:
+    """Render published article meaningfully before React hydration."""
+
+    published_at = article.published_at
+    updated_at = article.updated_at
+    if article.status != "published" or published_at is None or updated_at is None:
+        return ""
+    parts = [
+        '<main class="seo-fallback seo-article-fallback">',
+        '<nav aria-label="Публичные разделы"><a href="/">Главная</a> '
+        '<a href="/articles">Статьи</a></nav>',
+        f'<p class="landing-kicker">{html.escape(article.article_kind)}</p>',
+        f"<h1>{html.escape(article.title)}</h1>",
+        f'<p class="public-hero__lead">{html.escape(article.lead)}</p>',
+        '<dl class="public-guide-meta">',
+        _article_person_markup("Автор", article.author),
+        _article_person_markup("Редактор", article.editor),
+        _article_person_markup("Проверил", article.domain_reviewer),
+        f'<dt>Опубликовано</dt><dd><time datetime="{published_at.date().isoformat()}">'
+        f"{published_at.date().isoformat()}</time></dd>",
+        f'<dt>Обновлено</dt><dd><time datetime="{updated_at.date().isoformat()}">'
+        f"{updated_at.date().isoformat()}</time></dd>",
+        "</dl>",
+    ]
+    for raw_section in article.body_sections:
+        if not isinstance(raw_section, dict):
+            continue
+        heading = raw_section.get("heading")
+        paragraphs = raw_section.get("paragraphs", [])
+        if not isinstance(heading, str) or not isinstance(paragraphs, list):
+            continue
+        parts.append(f"<section><h2>{html.escape(heading)}</h2>")
+        parts.extend(
+            f"<p>{html.escape(value)}</p>" for value in paragraphs if isinstance(value, str)
+        )
+        points = raw_section.get("points", [])
+        if isinstance(points, list):
+            items = "".join(
+                f"<li>{html.escape(value)}</li>" for value in points if isinstance(value, str)
+            )
+            if items:
+                parts.append(f"<ul>{items}</ul>")
+        parts.append("</section>")
+    sources = article.sources if isinstance(article.sources, list) else []
+    if sources:
+        parts.append("<section><h2>Источники</h2><ol>")
+        for source in sources:
+            if not isinstance(source, dict):
+                continue
+            url = source.get("url")
+            title = source.get("title")
+            publisher = source.get("publisher")
+            if not (isinstance(url, str) and isinstance(title, str) and isinstance(publisher, str)):
+                continue
+            parts.append(
+                f'<li><a href="{html.escape(url, quote=True)}">{html.escape(title)}</a>'
+                f" — {html.escape(publisher)}</li>"
+            )
+        parts.append("</ol></section>")
+    if related:
+        parts.append("<section><h2>Связанные статьи</h2><ul>")
+        for item in related:
+            parts.append(
+                f'<li><a href="/articles/{html.escape(item.slug, quote=True)}">'
+                f"{html.escape(item.title)}</a></li>"
+            )
+        parts.append("</ul></section>")
+    cta = article.cta if isinstance(article.cta, dict) else {}
+    cta_label = cta.get("label", "Открыть Your Fitness Coach")
+    cta_description = cta.get("description", "Продолжите работу с фактами в приложении.")
+    if isinstance(cta_label, str) and isinstance(cta_description, str):
+        app_url = f"{settings.frontend_base_url.rstrip('/')}/app"
+        parts.append(
+            f"<section><h2>{html.escape(cta_label)}</h2><p>{html.escape(cta_description)}</p>"
+            f'<a href="{html.escape(app_url, quote=True)}">Открыть приложение</a></section>'
+        )
+    parts.append("</main>")
+    return "".join(parts)
+
+
+def render_articles_index_fallback(articles: tuple[WebArticle, ...]) -> str:
+    parts = [
+        '<main class="seo-fallback seo-articles-index-fallback">',
+        '<nav aria-label="Публичные разделы"><a href="/">Главная</a> '
+        '<a href="/articles">Статьи</a></nav>',
+        f"<h1>{html.escape(ARTICLE_INDEX_TITLE)}</h1>",
+        f"<p>{html.escape(ARTICLE_INDEX_DESCRIPTION)}</p>",
+        "<section><h2>Опубликованные статьи</h2><ul>",
+    ]
+    for article in articles:
+        parts.append(
+            f'<li><a href="/articles/{html.escape(article.slug, quote=True)}">'
+            f"{html.escape(article.title)}</a> — {html.escape(article.description)}</li>"
+        )
+    parts.extend(("</ul></section>", "</main>"))
+    return "".join(parts)
 
 
 def render_public_fallback(path: str) -> str:
@@ -496,15 +679,30 @@ def render_public_fallback(path: str) -> str:
     return "".join(parts)
 
 
-def render_frontend_document(template: str, path: str) -> tuple[str, SeoMetadata]:
+def render_frontend_document(
+    template: str,
+    path: str,
+    *,
+    article: WebArticle | None = None,
+    articles: tuple[WebArticle, ...] = (),
+) -> tuple[str, SeoMetadata]:
     """Inject route metadata and public fallback into the Vite HTML entry."""
 
-    metadata = metadata_for_path(path)
+    if article is not None:
+        metadata = metadata_for_article(article)
+        fallback = render_article_fallback(
+            article, tuple(item for item in articles if item.slug in article.related_slugs)
+        )
+    elif path == "/articles":
+        metadata = metadata_for_articles()
+        fallback = render_articles_index_fallback(articles)
+    else:
+        metadata = metadata_for_path(path)
+        fallback = render_public_fallback(path)
     rendered = template.replace("<!-- seo-head -->", render_metadata(metadata))
     if rendered == template:
         rendered = template.replace("</head>", f"    {render_metadata(metadata)}\n  </head>")
 
-    fallback = render_public_fallback(path)
     marked_fallback = f"<!-- public-fallback-start -->{fallback}<!-- public-fallback-end -->"
     if _PUBLIC_FALLBACK_PATTERN.search(rendered):
         rendered = _PUBLIC_FALLBACK_PATTERN.sub(marked_fallback, rendered, count=1)

--- a/backend/fitminiapp_api/seo.py
+++ b/backend/fitminiapp_api/seo.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import cast
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 
 from fitminiapp_api.core.config import settings
 from fitminiapp_api.models.news import WebArticle
@@ -168,6 +168,31 @@ def _absolute_public_url(path: str) -> str:
     return f"{public_origin()}/" if path == "/" else f"{public_origin()}{path}"
 
 
+def public_article_cta_url(destination: object) -> str:
+    """Resolve the allowlisted article CTA destinations for server-rendered HTML."""
+
+    if destination == "landing":
+        return _absolute_public_url("/")
+    if destination == "tma":
+        username = settings.telegram_bot_username.strip().removeprefix("@")
+        if not username:
+            username = "your_fitness_coach_bot"
+        return f"https://t.me/{quote(username, safe='')}?startapp"
+    return f"{settings.frontend_base_url.rstrip('/')}/app"
+
+
+def _safe_https_url(value: object) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.strip()
+    if any(ord(character) < 0x20 for character in normalized):
+        return None
+    parsed = urlparse(normalized)
+    if parsed.scheme.lower() != "https" or not parsed.netloc or parsed.username or parsed.password:
+        return None
+    return normalized
+
+
 def _breadcrumbs_schema(page: dict[str, object]) -> dict[str, object] | None:
     raw_breadcrumbs = page.get("breadcrumbs")
     if not isinstance(raw_breadcrumbs, list) or len(raw_breadcrumbs) < 2:
@@ -311,7 +336,7 @@ def metadata_for_articles() -> SeoMetadata:
 def metadata_for_article(article: WebArticle) -> SeoMetadata:
     if article.status != "published" or article.published_at is None or article.updated_at is None:
         return metadata_for_path("/articles")
-    canonical_url = article.canonical_url or _absolute_public_url(f"/articles/{article.slug}")
+    canonical_url = _absolute_public_url(f"/articles/{article.slug}")
     author = article.author if isinstance(article.author, dict) else {}
     editor = article.editor if isinstance(article.editor, dict) else {}
     reviewer = article.domain_reviewer if isinstance(article.domain_reviewer, dict) else None
@@ -472,7 +497,7 @@ def render_article_fallback(article: WebArticle, related: tuple[WebArticle, ...]
         for source in sources:
             if not isinstance(source, dict):
                 continue
-            url = source.get("url")
+            url = _safe_https_url(source.get("url"))
             title = source.get("title")
             publisher = source.get("publisher")
             if not (isinstance(url, str) and isinstance(title, str) and isinstance(publisher, str)):
@@ -493,11 +518,12 @@ def render_article_fallback(article: WebArticle, related: tuple[WebArticle, ...]
     cta = article.cta if isinstance(article.cta, dict) else {}
     cta_label = cta.get("label", "Открыть Your Fitness Coach")
     cta_description = cta.get("description", "Продолжите работу с фактами в приложении.")
+    cta_destination = cta.get("destination", "web")
     if isinstance(cta_label, str) and isinstance(cta_description, str):
-        app_url = f"{settings.frontend_base_url.rstrip('/')}/app"
+        cta_href = public_article_cta_url(cta_destination)
         parts.append(
             f"<section><h2>{html.escape(cta_label)}</h2><p>{html.escape(cta_description)}</p>"
-            f'<a href="{html.escape(app_url, quote=True)}">Открыть приложение</a></section>'
+            f'<a href="{html.escape(cta_href, quote=True)}">{html.escape(cta_label)}</a></section>'
         )
     parts.append("</main>")
     return "".join(parts)

--- a/backend/fitminiapp_api/services/web_articles.py
+++ b/backend/fitminiapp_api/services/web_articles.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from sqlalchemy.orm import Session
 
+from fitminiapp_api.core.config import settings
 from fitminiapp_api.models.news import (
     HermesWebArticleSubmission,
     WebArticle,
@@ -460,6 +461,15 @@ def accept_hermes_article_submission(
         raise WebArticleError("schema_version_unsupported")
     if payload.provenance.skill_version != HERMES_WEB_ARTICLE_SKILL_VERSION:
         raise WebArticleError("skill_version_unsupported")
+    if len(payload.article.sources) > settings.hermes_intake_max_source_count:
+        raise WebArticleError("source_count_exceeded")
+    recent_count = (
+        db.query(HermesWebArticleSubmission)
+        .filter(HermesWebArticleSubmission.created_at >= current - timedelta(minutes=1))
+        .count()
+    )
+    if recent_count >= settings.hermes_intake_rate_limit_per_minute:
+        raise WebArticleError("rate_limited")
     candidate = db.get(WebArticleCandidate, payload.candidate_id)
     if candidate is None:
         raise WebArticleError("candidate_missing")
@@ -545,7 +555,7 @@ def accept_hermes_article_submission(
             "source_count": len(payload.article.sources),
             "claim_count": len(payload.article.claims),
         },
-        expires_at=current + timedelta(seconds=900),
+        expires_at=current + timedelta(seconds=settings.hermes_intake_replay_ttl_seconds),
         processed_at=current,
     )
     db.add(submission)

--- a/backend/fitminiapp_api/services/web_articles.py
+++ b/backend/fitminiapp_api/services/web_articles.py
@@ -26,7 +26,12 @@ from fitminiapp_api.schemas.articles import (
 from fitminiapp_api.services.audit import record_audit_event
 from fitminiapp_api.services.news_drafts import style_checklist_warnings
 from fitminiapp_api.services.news_ingestion import utcnow
-from fitminiapp_api.services.news_taxonomy import classify_editorial_text
+from fitminiapp_api.services.news_taxonomy import (
+    EDITORIAL_TOPICS,
+    EVIDENCE_LEVELS,
+    RISK_LEVELS,
+    classify_editorial_text,
+)
 
 ARTICLE_SCHEMA_VERSION = "yfc-web-article-v1"
 HERMES_WEB_ARTICLE_SCHEMA_VERSION = "hermes-web-article-intake-v1"
@@ -163,21 +168,51 @@ def create_article_candidate(
         raise WebArticleError("candidate_source_kind_invalid")
     if article_kind not in ARTICLE_KINDS or search_intent not in SEARCH_INTENTS:
         raise WebArticleError("candidate_contract_invalid")
-    if source_ref is not None and not SAFE_REF_PATTERN.fullmatch(source_ref):
+    normalized_title = working_title.strip()
+    normalized_primary_query = primary_query.strip()
+    normalized_audience = audience.strip()
+    normalized_topics = list(dict.fromkeys(topic.strip() for topic in topics))
+    normalized_secondary_queries = list(dict.fromkeys(query.strip() for query in secondary_queries))
+    if (
+        not normalized_title
+        or len(normalized_title) > 240
+        or not normalized_primary_query
+        or len(normalized_primary_query) > 240
+        or not normalized_audience
+        or len(normalized_audience) > 32
+        or not normalized_topics
+        or len(normalized_topics) > 12
+        or any(not topic or len(topic) > 64 for topic in normalized_topics)
+        or any(not query or len(query) > 240 for query in normalized_secondary_queries)
+        or len(normalized_secondary_queries) > 20
+    ):
+        raise WebArticleError("candidate_contract_invalid")
+    if (
+        primary_topic not in EDITORIAL_TOPICS
+        or any(topic not in EDITORIAL_TOPICS for topic in normalized_topics)
+        or primary_topic not in normalized_topics
+    ):
+        raise WebArticleError("candidate_topic_invalid")
+    if risk_level not in RISK_LEVELS or evidence_level not in EVIDENCE_LEVELS:
+        raise WebArticleError("candidate_contract_invalid")
+    normalized_source_ref = source_ref.strip() if source_ref is not None else None
+    if source_kind != "manual" and not normalized_source_ref:
+        raise WebArticleError("candidate_source_ref_invalid")
+    if normalized_source_ref is not None and not SAFE_REF_PATTERN.fullmatch(normalized_source_ref):
         raise WebArticleError("candidate_source_ref_invalid")
     scored = score_article_candidate(signals)
     candidate = WebArticleCandidate(
         id=candidate_id or secrets.token_hex(16),
         source_kind=source_kind,
-        source_ref=source_ref,
-        working_title=working_title.strip(),
+        source_ref=normalized_source_ref,
+        working_title=normalized_title,
         primary_topic=primary_topic,
-        topics=list(dict.fromkeys(topics)),
+        topics=normalized_topics,
         article_kind=article_kind,
         search_intent=search_intent,
-        primary_query=primary_query.strip(),
-        secondary_queries=list(dict.fromkeys(secondary_queries)),
-        audience=audience,
+        primary_query=normalized_primary_query,
+        secondary_queries=normalized_secondary_queries,
+        audience=normalized_audience,
         risk_level=risk_level,
         evidence_level=evidence_level,
         search_demand_signal=signals.search_demand,
@@ -428,9 +463,16 @@ def accept_hermes_article_submission(
     candidate = db.get(WebArticleCandidate, payload.candidate_id)
     if candidate is None:
         raise WebArticleError("candidate_missing")
-    if candidate.status not in {"candidate", "approved", "researching"}:
+    existing_article = (
+        db.query(WebArticle).filter(WebArticle.slug == payload.article.slug).one_or_none()
+    )
+    is_update = existing_article is not None
+    if candidate.status not in {"candidate", "approved", "researching", "draft", "review"}:
         raise WebArticleError("candidate_not_ready")
-    if db.query(WebArticle).filter(WebArticle.slug == payload.article.slug).first() is not None:
+    if is_update and (
+        existing_article.status != "update_required"
+        or existing_article.candidate_id != candidate.id
+    ):
         raise WebArticleError("slug_conflict")
     warnings = validate_article_proposal(payload.article)
     blockers = _review_blockers(payload.article, warnings)
@@ -442,12 +484,14 @@ def accept_hermes_article_submission(
         blockers = tuple(dict.fromkeys((*blockers, "sensitive_topic_manual_review")))
     if classification.risk_level in {"high", "critical"}:
         blockers = tuple(dict.fromkeys((*blockers, "taxonomy_risk_manual_review")))
-    article_id = secrets.token_hex(16)
-    article = WebArticle(id=article_id, candidate_id=candidate.id)
+    content_version = existing_article.content_version + 1 if is_update else 1
+    article = existing_article or WebArticle(id=secrets.token_hex(16), candidate_id=candidate.id)
+    if not is_update:
+        db.add(article)
     _assign_article_fields(
         article,
         payload.article,
-        content_version=1,
+        content_version=content_version,
         research_version=payload.research_version,
         provider=payload.provenance.provider,
         model=payload.provenance.model,
@@ -456,13 +500,13 @@ def accept_hermes_article_submission(
         status="draft",
         blockers=blockers,
     )
-    db.add(article)
     db.flush()
+    change_reason = "hermes_research_update" if is_update else "hermes_research_submission"
     db.add(
         WebArticleRevision(
             id=secrets.token_hex(16),
             article_id=article.id,
-            content_version=1,
+            content_version=content_version,
             status="draft",
             snapshot=_to_snapshot(
                 payload.article,
@@ -474,8 +518,10 @@ def accept_hermes_article_submission(
                 skill_version=payload.provenance.skill_version,
                 review_blockers=list(blockers),
                 style_warnings=list(warnings),
+                change_reason=change_reason,
+                correction_reason=article.correction_reason,
             ),
-            change_reason="hermes_research_submission",
+            change_reason=change_reason,
         )
     )
     candidate.status = "draft"
@@ -514,6 +560,7 @@ def accept_hermes_article_submission(
             "status": article.status,
             "content_version": article.content_version,
             "review_blocker_count": len(blockers),
+            "change_reason": change_reason,
         },
     )
     db.flush()
@@ -577,14 +624,74 @@ def published_articles(db: Session) -> list[WebArticle]:
 def mark_article_update_required(db: Session, article: WebArticle, *, reason: str) -> None:
     if article.status != "published":
         raise WebArticleError("article_not_published")
+    normalized_reason = reason.strip()
+    if not normalized_reason or len(normalized_reason) > 256:
+        raise WebArticleError("correction_reason_invalid")
     article.status = "update_required"
-    article.correction_reason = reason[:256]
+    article.correction_reason = normalized_reason
     record_audit_event(
         db,
         action="web_article.update_required",
         resource_type="web_article",
         resource_id=article.id,
-        details={"content_version": article.content_version, "reason": reason[:256]},
+        details={"content_version": article.content_version, "reason": normalized_reason},
+    )
+
+
+def _transition_removed_article(
+    db: Session,
+    article: WebArticle,
+    *,
+    target_status: str,
+    reason: str,
+    actor_ref: str,
+    allowed_statuses: set[str],
+) -> None:
+    normalized_reason = reason.strip()
+    if not normalized_reason or len(normalized_reason) > 256:
+        raise WebArticleError("correction_reason_invalid")
+    if article.status == target_status:
+        return
+    if article.status not in allowed_statuses:
+        raise WebArticleError("article_transition_invalid")
+    article.status = target_status
+    article.correction_reason = normalized_reason
+    record_audit_event(
+        db,
+        action=f"web_article.{target_status}",
+        resource_type="web_article",
+        resource_id=article.id,
+        details={
+            "content_version": article.content_version,
+            "reason": normalized_reason,
+            "actor_ref": actor_ref,
+        },
+    )
+
+
+def archive_web_article(db: Session, article: WebArticle, *, reason: str, actor_ref: str) -> None:
+    """Remove an article from the public surface while preserving its revisions and audit trail."""
+
+    _transition_removed_article(
+        db,
+        article,
+        target_status="archived",
+        reason=reason,
+        actor_ref=actor_ref,
+        allowed_statuses={"draft", "review", "approved", "published", "update_required"},
+    )
+
+
+def retract_web_article(db: Session, article: WebArticle, *, reason: str, actor_ref: str) -> None:
+    """Retract a public article explicitly; no content or revision is deleted."""
+
+    _transition_removed_article(
+        db,
+        article,
+        target_status="retracted",
+        reason=reason,
+        actor_ref=actor_ref,
+        allowed_statuses={"published", "update_required", "archived"},
     )
 
 

--- a/backend/fitminiapp_api/services/web_articles.py
+++ b/backend/fitminiapp_api/services/web_articles.py
@@ -570,7 +570,7 @@ def accept_hermes_article_submission(
 def article_card(article: WebArticle) -> WebArticleCard:
     if article.status != "published" or article.published_at is None or article.updated_at is None:
         raise WebArticleError("article_not_public")
-    canonical_url = article.canonical_url or f"{_article_origin()}/articles/{article.slug}"
+    canonical_url = f"{_article_origin()}/articles/{article.slug}"
     return WebArticleCard.model_validate(
         {
             "slug": article.slug,

--- a/backend/fitminiapp_api/services/web_articles.py
+++ b/backend/fitminiapp_api/services/web_articles.py
@@ -1,0 +1,636 @@
+"""Canonical Web editorial lifecycle and the narrow long-form Hermes handoff."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from fitminiapp_api.models.news import (
+    HermesWebArticleSubmission,
+    WebArticle,
+    WebArticleCandidate,
+    WebArticleRevision,
+)
+from fitminiapp_api.schemas.articles import (
+    HermesWebArticleProposal,
+    WebArticleCard,
+    WebArticleResponse,
+)
+from fitminiapp_api.services.audit import record_audit_event
+from fitminiapp_api.services.news_drafts import style_checklist_warnings
+from fitminiapp_api.services.news_ingestion import utcnow
+from fitminiapp_api.services.news_taxonomy import classify_editorial_text
+
+ARTICLE_SCHEMA_VERSION = "yfc-web-article-v1"
+HERMES_WEB_ARTICLE_SCHEMA_VERSION = "hermes-web-article-intake-v1"
+HERMES_WEB_ARTICLE_SKILL_VERSION = "yfc-hermes-editorial-v1"
+ARTICLE_STATUSES = (
+    "candidate",
+    "researching",
+    "draft",
+    "review",
+    "approved",
+    "published",
+    "update_required",
+    "archived",
+    "retracted",
+)
+ARTICLE_CANDIDATE_SOURCE_KINDS = ("manual", "seo_import", "news_handoff")
+ARTICLE_KINDS = (
+    "evergreen_explainer",
+    "practical_guide",
+    "evidence_review",
+    "myth_busting",
+    "research_update",
+    "comparison",
+    "product_education",
+)
+SEARCH_INTENTS = ("informational", "how_to", "comparison", "definition", "evidence", "mixed")
+ARTICLE_CTA_DESTINATIONS = ("tma", "web", "landing")
+SENSITIVE_ARTICLE_TOPICS = {
+    "medicine",
+    "peptides",
+    "sports_medicine_injuries",
+    "dietary_supplements",
+    "sports_nutrition",
+}
+SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+SAFE_REF_PATTERN = re.compile(r"^[A-Za-z0-9_.:-]{1,128}$")
+NUMBER_PATTERN = re.compile(r"(?<![\w])\d+(?:[.,]\d+)?(?:%|\s?(?:mg|g|kg|мг|г|кг))?", re.IGNORECASE)
+
+
+class WebArticleError(RuntimeError):
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class ArticleCandidateSignals:
+    search_demand: int = 0
+    intent_clarity: int = 0
+    topical_relevance: int = 0
+    product_relevance: int = 0
+    audience_usefulness: int = 0
+    evergreen_potential: int = 0
+    evidence_availability: int = 0
+    existing_content_overlap: int = 0
+    internal_link_potential: int = 0
+    risk_review_cost: int = 0
+    freshness_need: int = 0
+    news_opportunity: int = 0
+
+    def validate(self) -> None:
+        for value in self.__dict__.values():
+            if not isinstance(value, int) or not 0 <= value <= 100:
+                raise ValueError("article_candidate_signal_out_of_range")
+
+
+@dataclass(frozen=True)
+class HermesWebArticleIntakeResult:
+    status: str
+    submission_id: str
+    article_id: str
+    article_status: str
+    content_version: int
+    review_blockers: tuple[str, ...]
+
+
+def score_article_candidate(signals: ArticleCandidateSignals) -> dict[str, Any]:
+    """Score opportunity, not approval; overlap/risk/freshness remain separate dimensions."""
+
+    signals.validate()
+    weights = {
+        "search_demand": 12,
+        "intent_clarity": 10,
+        "topical_relevance": 12,
+        "product_relevance": 10,
+        "audience_usefulness": 12,
+        "evergreen_potential": 10,
+        "evidence_availability": 12,
+        "existing_content_overlap": -8,
+        "internal_link_potential": 6,
+        "risk_review_cost": -8,
+        "freshness_need": -3,
+        "news_opportunity": 5,
+    }
+    breakdown = {key: getattr(signals, key) * weight for key, weight in weights.items()}
+    denominator = sum(weight for weight in weights.values() if weight > 0)
+    raw_score = (
+        sum(getattr(signals, key) / 100 * weight for key, weight in weights.items())
+        / denominator
+        * 100
+    )
+    score = max(0, min(100, round(raw_score)))
+    reasons = [
+        key
+        for key in ("search_demand", "intent_clarity", "evidence_availability", "product_relevance")
+        if getattr(signals, key) >= 70
+    ]
+    if signals.existing_content_overlap >= 70:
+        reasons.append("existing_content_overlap_requires_merge_or_rejection")
+    if signals.risk_review_cost >= 60:
+        reasons.append("risk_review_cost_requires_manual_path")
+    return {"score": score, "breakdown": breakdown, "reasons": reasons}
+
+
+def create_article_candidate(
+    db: Session,
+    *,
+    source_kind: str,
+    working_title: str,
+    primary_topic: str,
+    topics: list[str],
+    article_kind: str,
+    search_intent: str,
+    primary_query: str,
+    secondary_queries: list[str],
+    audience: str,
+    risk_level: str,
+    evidence_level: str,
+    signals: ArticleCandidateSignals,
+    source_ref: str | None = None,
+    candidate_id: str | None = None,
+) -> WebArticleCandidate:
+    if source_kind not in ARTICLE_CANDIDATE_SOURCE_KINDS:
+        raise WebArticleError("candidate_source_kind_invalid")
+    if article_kind not in ARTICLE_KINDS or search_intent not in SEARCH_INTENTS:
+        raise WebArticleError("candidate_contract_invalid")
+    if source_ref is not None and not SAFE_REF_PATTERN.fullmatch(source_ref):
+        raise WebArticleError("candidate_source_ref_invalid")
+    scored = score_article_candidate(signals)
+    candidate = WebArticleCandidate(
+        id=candidate_id or secrets.token_hex(16),
+        source_kind=source_kind,
+        source_ref=source_ref,
+        working_title=working_title.strip(),
+        primary_topic=primary_topic,
+        topics=list(dict.fromkeys(topics)),
+        article_kind=article_kind,
+        search_intent=search_intent,
+        primary_query=primary_query.strip(),
+        secondary_queries=list(dict.fromkeys(secondary_queries)),
+        audience=audience,
+        risk_level=risk_level,
+        evidence_level=evidence_level,
+        search_demand_signal=signals.search_demand,
+        intent_clarity=signals.intent_clarity,
+        topical_relevance=signals.topical_relevance,
+        product_relevance=signals.product_relevance,
+        audience_usefulness=signals.audience_usefulness,
+        evergreen_potential=signals.evergreen_potential,
+        evidence_availability=signals.evidence_availability,
+        existing_content_overlap=signals.existing_content_overlap,
+        internal_link_potential=signals.internal_link_potential,
+        risk_review_cost=signals.risk_review_cost,
+        freshness_need=signals.freshness_need,
+        news_opportunity=signals.news_opportunity,
+        priority_score=scored["score"],
+        score_breakdown=scored["breakdown"],
+        web_article_potential_reasons=scored["reasons"],
+    )
+    db.add(candidate)
+    db.flush()
+    return candidate
+
+
+def validate_article_proposal(proposal: HermesWebArticleProposal) -> tuple[str, ...]:
+    """Return review warnings; this is intentionally not an AI-authorship detector."""
+
+    body = "\n\n".join(
+        [proposal.title, proposal.description, proposal.lead]
+        + [paragraph for section in proposal.body_sections for paragraph in section.paragraphs]
+        + [point for section in proposal.body_sections for point in section.points]
+    )
+    warnings = list(style_checklist_warnings(body))
+    if body.count("?") > 12:
+        warnings.append("mechanical_question_density")
+    if len({query.casefold() for query in proposal.secondary_queries}) != len(
+        proposal.secondary_queries
+    ):
+        warnings.append("duplicate_secondary_query")
+    source_ids = [source.source_id for source in proposal.sources]
+    if len(source_ids) != len(set(source_ids)):
+        warnings.append("duplicate_source_id")
+    matrix_claim_ids = [item.claim_id for item in proposal.claim_source_matrix]
+    if len(matrix_claim_ids) != len(set(matrix_claim_ids)):
+        warnings.append("duplicate_claim_matrix_entry")
+    if proposal.evidence_level in {"preliminary", "conflicting"}:
+        warnings.append(f"evidence_{proposal.evidence_level}")
+    if NUMBER_PATTERN.search(body) and not any(
+        item.support_level == "supports" and item.review_status == "verified"
+        for item in proposal.claim_source_matrix
+    ):
+        warnings.append("unsupported_number")
+    if proposal.risk_level in {"high", "critical"}:
+        warnings.append("sensitive_content_requires_domain_review")
+    return tuple(dict.fromkeys(warnings))
+
+
+def _review_blockers(
+    proposal: HermesWebArticleProposal, warnings: tuple[str, ...]
+) -> tuple[str, ...]:
+    blockers = list(warnings)
+    if not proposal.claim_source_matrix:
+        blockers.append("claim_source_matrix_missing")
+    if any(item.review_status != "verified" for item in proposal.claim_source_matrix):
+        blockers.append("claim_source_matrix_not_fully_verified")
+    if any(
+        item.support_level in {"does_not_support", "unclear"}
+        for item in proposal.claim_source_matrix
+    ):
+        blockers.append("claim_source_support_unclear")
+    if proposal.domain_reviewer is None and (
+        proposal.risk_level in {"high", "critical"}
+        or any(topic in SENSITIVE_ARTICLE_TOPICS for topic in proposal.topics)
+    ):
+        blockers.append("domain_reviewer_required")
+    if proposal.evidence_level in {"preliminary", "conflicting"}:
+        blockers.append("evidence_limitation_requires_manual_review")
+    return tuple(dict.fromkeys(blockers))
+
+
+def _article_content_payload(proposal: HermesWebArticleProposal) -> dict[str, Any]:
+    payload = proposal.model_dump(mode="json")
+    payload["sources"] = [dict(source) for source in payload["sources"]]
+    return payload
+
+
+def _content_hash(payload: dict[str, object]) -> str:
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def _article_origin() -> str:
+    from fitminiapp_api.seo import public_origin
+
+    return public_origin()
+
+
+def _safe_cta(raw: dict[str, str]) -> dict[str, str]:
+    allowed = {"destination", "label", "description"}
+    if set(raw) - allowed:
+        raise WebArticleError("cta_contains_unallowed_fields")
+    destination = raw.get("destination", "web")
+    if destination not in ARTICLE_CTA_DESTINATIONS:
+        raise WebArticleError("cta_destination_invalid")
+    label = raw.get("label", "Открыть Your Fitness Coach").strip()
+    description = raw.get(
+        "description", "Перейдите в Your Fitness Coach, чтобы продолжить работу с фактами."
+    ).strip()
+    if not label or len(label) > 120 or not description or len(description) > 320:
+        raise WebArticleError("cta_copy_invalid")
+    return {"destination": destination, "label": label, "description": description}
+
+
+def _find_existing_submission(
+    db: Session,
+    *,
+    idempotency_key: str,
+    request_nonce: str,
+    payload_hash: str,
+    now: datetime,
+) -> HermesWebArticleSubmission | None:
+    existing = (
+        db.query(HermesWebArticleSubmission)
+        .filter(HermesWebArticleSubmission.idempotency_key == idempotency_key)
+        .one_or_none()
+    )
+    if existing is not None:
+        if existing.payload_hash != payload_hash:
+            raise WebArticleError("idempotency_conflict")
+        if existing.expires_at <= now:
+            raise WebArticleError("replay_expired")
+        if existing.request_nonce != request_nonce:
+            raise WebArticleError("idempotency_nonce_conflict")
+        return existing
+    nonce_match = (
+        db.query(HermesWebArticleSubmission)
+        .filter(HermesWebArticleSubmission.request_nonce == request_nonce)
+        .one_or_none()
+    )
+    if nonce_match is not None:
+        raise WebArticleError("replay_detected")
+    return None
+
+
+def _to_snapshot(proposal: HermesWebArticleProposal, **metadata: object) -> dict[str, object]:
+    payload = _article_content_payload(proposal)
+    payload["metadata"] = metadata
+    return payload
+
+
+def _assign_article_fields(
+    article: WebArticle,
+    proposal: HermesWebArticleProposal,
+    *,
+    content_version: int,
+    research_version: str,
+    provider: str,
+    model: str,
+    prompt_version: str,
+    skill_version: str,
+    status: str,
+    blockers: tuple[str, ...],
+) -> None:
+    if not SLUG_PATTERN.fullmatch(proposal.slug):
+        raise WebArticleError("slug_invalid")
+    payload = _article_content_payload(proposal)
+    article.slug = proposal.slug
+    article.status = status
+    article.title = proposal.title.strip()
+    article.description = proposal.description.strip()
+    article.lead = proposal.lead.strip()
+    article.body_sections = payload["body_sections"]
+    article.topics = list(dict.fromkeys(proposal.topics))
+    article.article_kind = proposal.article_kind
+    article.search_intent = proposal.search_intent
+    article.primary_query = proposal.primary_query.strip()
+    article.secondary_queries = list(dict.fromkeys(proposal.secondary_queries))
+    article.risk_level = proposal.risk_level
+    article.evidence_level = proposal.evidence_level
+    article.claims = payload["claims"]
+    article.sources = payload["sources"]
+    article.claim_source_matrix = payload["claim_source_matrix"]
+    article.author = payload["author"]
+    article.editor = payload["editor"]
+    article.domain_reviewer = payload["domain_reviewer"]
+    article.canonical_url = f"{_article_origin()}/articles/{proposal.slug}"
+    article.related_slugs = list(dict.fromkeys(proposal.related_slugs))
+    article.cta = _safe_cta(proposal.cta)
+    article.evergreen_score = proposal.evergreen_score
+    article.product_relevance = proposal.product_relevance
+    article.editorial_value = proposal.editorial_value
+    article.web_article_potential_reasons = list(
+        dict.fromkeys([*proposal.web_article_potential_reasons, *blockers])
+    )
+    article.content_version = content_version
+    article.research_version = research_version
+    article.provider = provider
+    article.model = model
+    article.prompt_version = prompt_version
+    article.skill_version = skill_version
+    article.schema_version = ARTICLE_SCHEMA_VERSION
+    article.generated_with_ai = True
+    article.research_assistance = True
+    article.content_hash = _content_hash(payload)
+
+
+def _article_result(
+    submission: HermesWebArticleSubmission,
+    article: WebArticle,
+    *,
+    status: str,
+    blockers: tuple[str, ...],
+) -> HermesWebArticleIntakeResult:
+    return HermesWebArticleIntakeResult(
+        status=status,
+        submission_id=submission.submission_id,
+        article_id=article.id,
+        article_status=article.status,
+        content_version=article.content_version,
+        review_blockers=blockers,
+    )
+
+
+def accept_hermes_article_submission(
+    db: Session,
+    payload,
+    *,
+    payload_hash: str,
+    now: datetime | None = None,
+) -> HermesWebArticleIntakeResult:
+    current = now or utcnow()
+    existing = _find_existing_submission(
+        db,
+        idempotency_key=payload.idempotency_key,
+        request_nonce=payload.request_nonce,
+        payload_hash=payload_hash,
+        now=current,
+    )
+    if existing is not None:
+        article = db.get(WebArticle, existing.article_id)
+        if article is None:
+            raise WebArticleError("submission_result_missing")
+        blockers = tuple(existing.response_metadata.get("review_blockers", []))
+        return _article_result(existing, article, status="duplicate", blockers=blockers)
+    if payload.schema_version != HERMES_WEB_ARTICLE_SCHEMA_VERSION:
+        raise WebArticleError("schema_version_unsupported")
+    if payload.provenance.skill_version != HERMES_WEB_ARTICLE_SKILL_VERSION:
+        raise WebArticleError("skill_version_unsupported")
+    candidate = db.get(WebArticleCandidate, payload.candidate_id)
+    if candidate is None:
+        raise WebArticleError("candidate_missing")
+    if candidate.status not in {"candidate", "approved", "researching"}:
+        raise WebArticleError("candidate_not_ready")
+    if db.query(WebArticle).filter(WebArticle.slug == payload.article.slug).first() is not None:
+        raise WebArticleError("slug_conflict")
+    warnings = validate_article_proposal(payload.article)
+    blockers = _review_blockers(payload.article, warnings)
+    classification = classify_editorial_text(
+        f"{payload.article.title} {payload.article.primary_query} {' '.join(payload.article.topics)}",
+        payload.article.lead,
+    )
+    if any(topic in SENSITIVE_ARTICLE_TOPICS for topic in payload.article.topics):
+        blockers = tuple(dict.fromkeys((*blockers, "sensitive_topic_manual_review")))
+    if classification.risk_level in {"high", "critical"}:
+        blockers = tuple(dict.fromkeys((*blockers, "taxonomy_risk_manual_review")))
+    article_id = secrets.token_hex(16)
+    article = WebArticle(id=article_id, candidate_id=candidate.id)
+    _assign_article_fields(
+        article,
+        payload.article,
+        content_version=1,
+        research_version=payload.research_version,
+        provider=payload.provenance.provider,
+        model=payload.provenance.model,
+        prompt_version=payload.provenance.prompt_version,
+        skill_version=payload.provenance.skill_version,
+        status="draft",
+        blockers=blockers,
+    )
+    db.add(article)
+    db.flush()
+    db.add(
+        WebArticleRevision(
+            id=secrets.token_hex(16),
+            article_id=article.id,
+            content_version=1,
+            status="draft",
+            snapshot=_to_snapshot(
+                payload.article,
+                article_schema_version=ARTICLE_SCHEMA_VERSION,
+                research_version=payload.research_version,
+                provider=payload.provenance.provider,
+                model=payload.provenance.model,
+                prompt_version=payload.provenance.prompt_version,
+                skill_version=payload.provenance.skill_version,
+                review_blockers=list(blockers),
+                style_warnings=list(warnings),
+            ),
+            change_reason="hermes_research_submission",
+        )
+    )
+    candidate.status = "draft"
+    submission = HermesWebArticleSubmission(
+        submission_id=secrets.token_hex(24),
+        candidate_id=candidate.id,
+        article_id=article.id,
+        idempotency_key=payload.idempotency_key,
+        request_nonce=payload.request_nonce,
+        payload_hash=payload_hash,
+        schema_version=payload.schema_version,
+        research_version=payload.research_version,
+        provider=payload.provenance.provider,
+        model=payload.provenance.model,
+        prompt_version=payload.provenance.prompt_version,
+        skill_version=payload.provenance.skill_version,
+        response_metadata={
+            "article_schema_version": ARTICLE_SCHEMA_VERSION,
+            "review_blockers": list(blockers),
+            "style_warnings": list(warnings),
+            "source_count": len(payload.article.sources),
+            "claim_count": len(payload.article.claims),
+        },
+        expires_at=current + timedelta(seconds=900),
+        processed_at=current,
+    )
+    db.add(submission)
+    record_audit_event(
+        db,
+        action="web_article.hermes_intake_accepted",
+        resource_type="web_article",
+        resource_id=article.id,
+        details={
+            "candidate_id": candidate.id,
+            "submission_id": submission.submission_id,
+            "status": article.status,
+            "content_version": article.content_version,
+            "review_blocker_count": len(blockers),
+        },
+    )
+    db.flush()
+    return _article_result(submission, article, status="accepted", blockers=blockers)
+
+
+def article_card(article: WebArticle) -> WebArticleCard:
+    if article.status != "published" or article.published_at is None or article.updated_at is None:
+        raise WebArticleError("article_not_public")
+    canonical_url = article.canonical_url or f"{_article_origin()}/articles/{article.slug}"
+    return WebArticleCard.model_validate(
+        {
+            "slug": article.slug,
+            "title": article.title,
+            "description": article.description,
+            "lead": article.lead,
+            "topics": list(article.topics),
+            "article_kind": article.article_kind,
+            "published_at": article.published_at,
+            "updated_at": article.updated_at,
+            "canonical_url": canonical_url,
+        }
+    )
+
+
+def article_public_response(article: WebArticle) -> WebArticleResponse:
+    card = article_card(article)
+    return WebArticleResponse.model_validate(
+        {
+            **card.model_dump(),
+            "body_sections": article.body_sections,
+            "search_intent": article.search_intent,
+            "primary_query": article.primary_query,
+            "secondary_queries": list(article.secondary_queries),
+            "risk_level": article.risk_level,
+            "evidence_level": article.evidence_level,
+            "claims": article.claims,
+            "sources": article.sources,
+            "claim_source_matrix": article.claim_source_matrix,
+            "author": article.author,
+            "editor": article.editor,
+            "domain_reviewer": article.domain_reviewer,
+            "related_slugs": list(article.related_slugs),
+            "cta": dict(article.cta),
+            "content_version": article.content_version,
+            "generated_with_ai": article.generated_with_ai,
+            "research_assistance": article.research_assistance,
+        }
+    )
+
+
+def published_articles(db: Session) -> list[WebArticle]:
+    return (
+        db.query(WebArticle)
+        .filter(WebArticle.status == "published")
+        .order_by(WebArticle.published_at.desc(), WebArticle.slug.asc())
+        .all()
+    )
+
+
+def mark_article_update_required(db: Session, article: WebArticle, *, reason: str) -> None:
+    if article.status != "published":
+        raise WebArticleError("article_not_published")
+    article.status = "update_required"
+    article.correction_reason = reason[:256]
+    record_audit_event(
+        db,
+        action="web_article.update_required",
+        resource_type="web_article",
+        resource_id=article.id,
+        details={"content_version": article.content_version, "reason": reason[:256]},
+    )
+
+
+def publish_web_article(db: Session, article: WebArticle, *, actor_ref: str) -> None:
+    """Owner/editor gate: publishing is an explicit internal action, never Hermes intake."""
+
+    if article.status != "approved":
+        raise WebArticleError("article_not_approved")
+    revision = (
+        db.query(WebArticleRevision)
+        .filter(
+            WebArticleRevision.article_id == article.id,
+            WebArticleRevision.content_version == article.content_version,
+        )
+        .one_or_none()
+    )
+    if revision is None:
+        raise WebArticleError("article_revision_missing")
+    if any(
+        item.get("review_status") != "verified"
+        or item.get("support_level") in {"does_not_support", "unclear"}
+        for item in article.claim_source_matrix
+        if isinstance(item, dict)
+    ):
+        raise WebArticleError("claim_source_review_incomplete")
+    if not article.domain_reviewer and (
+        article.risk_level in {"high", "critical"}
+        or any(topic in SENSITIVE_ARTICLE_TOPICS for topic in article.topics)
+    ):
+        raise WebArticleError("domain_reviewer_required")
+    now = utcnow()
+    article.status = "published"
+    article.published_at = article.published_at or now
+    article.updated_at = now
+    revision.status = "published"
+    record_audit_event(
+        db,
+        action="web_article.published",
+        resource_type="web_article",
+        resource_id=article.id,
+        actor_user_id=None,
+        details={"content_version": article.content_version, "actor_ref": actor_ref},
+    )
+
+
+def public_article_path(slug: str) -> str:
+    if not SLUG_PATTERN.fullmatch(slug):
+        raise WebArticleError("slug_invalid")
+    return f"/articles/{slug}"

--- a/backend/tests/test_alembic_config.py
+++ b/backend/tests/test_alembic_config.py
@@ -49,7 +49,7 @@ def test_legacy_support_revision_remains_in_the_linear_upgrade_path() -> None:
     assert auth_families is not None
     assert relocated_marker is not None
     assert auth_families.down_revision == legacy_support.revision
-    assert revisions.get_heads() == ["0071_hermes_intake_taxonomy"]
+    assert revisions.get_heads() == ["0072_web_articles_lifecycle"]
     assert relocated_marker.revision in {
         revision.revision
         for revision in revisions.iterate_revisions("head", legacy_support.revision)

--- a/backend/tests/test_web_articles.py
+++ b/backend/tests/test_web_articles.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import hashlib
+import time
 
 import pytest
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 
+from fitminiapp_api.core.config import settings
 from fitminiapp_api.db.session import SessionLocal
 from fitminiapp_api.models.news import WebArticle, WebArticleRevision
-from fitminiapp_api.schemas.articles import HermesWebArticleIntakeRequest
+from fitminiapp_api.schemas.articles import ArticleSource, HermesWebArticleIntakeRequest
+from fitminiapp_api.services.news_hermes import hermes_signature
 from fitminiapp_api.services.web_articles import (
     ArticleCandidateSignals,
     WebArticleError,
@@ -182,6 +185,65 @@ def test_hermes_article_intake_is_idempotent_and_creates_draft(db_session) -> No
 def test_sensitive_article_requires_domain_reviewer() -> None:
     with pytest.raises(ValidationError, match="domain_reviewer"):
         _payload("a" * 32, risk_level="high")
+
+
+def test_article_sources_require_https() -> None:
+    with pytest.raises(ValidationError, match="must use HTTPS"):
+        ArticleSource.model_validate(
+            {
+                "source_id": "source-one",
+                "title": "Source",
+                "publisher": "Publisher",
+                "url": "http://example.com/source",
+                "source_type": "official_organization",
+            }
+        )
+
+
+def test_signed_hermes_article_intake_is_idempotent_and_never_publishes(
+    client, monkeypatch
+) -> None:
+    monkeypatch.setattr(settings, "hermes_intake_enabled", True)
+    monkeypatch.setattr(settings, "hermes_intake_key_id", "hermes-test")
+    monkeypatch.setattr(
+        settings,
+        "hermes_intake_shared_secret",
+        SecretStr("test-hermes-shared-secret-that-is-long-enough"),
+    )
+    with SessionLocal() as db:
+        candidate_id = _candidate(db)
+        db.commit()
+
+    payload = _payload(candidate_id)
+    body = payload.model_dump_json().encode()
+    timestamp = str(int(time.time()))
+    nonce = "article-request-nonce-001"
+    headers = {
+        "X-Hermes-Key-Id": "hermes-test",
+        "X-Hermes-Timestamp": timestamp,
+        "X-Hermes-Nonce": nonce,
+        "X-Hermes-Signature": hermes_signature(
+            "test-hermes-shared-secret-that-is-long-enough",
+            timestamp=timestamp,
+            nonce=nonce,
+            body=body,
+        ),
+    }
+
+    first = client.post("/api/v1/hermes/articles/intake", content=body, headers=headers)
+    second = client.post("/api/v1/hermes/articles/intake", content=body, headers=headers)
+
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.json()["status"] == "accepted"
+    assert second.json()["status"] == "duplicate"
+    assert first.json()["article_status"] == "draft"
+    assert first.json()["article_id"] == second.json()["article_id"]
+
+    with SessionLocal() as db:
+        article = db.get(WebArticle, first.json()["article_id"])
+        assert article is not None
+        assert article.status == "draft"
 
 
 def test_publish_requires_approval_and_update_preserves_revision(db_session) -> None:

--- a/backend/tests/test_web_articles.py
+++ b/backend/tests/test_web_articles.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+from pydantic import ValidationError
+
+from fitminiapp_api.db.session import SessionLocal
+from fitminiapp_api.models.news import WebArticle, WebArticleRevision
+from fitminiapp_api.schemas.articles import HermesWebArticleIntakeRequest
+from fitminiapp_api.services.web_articles import (
+    ArticleCandidateSignals,
+    WebArticleError,
+    accept_hermes_article_submission,
+    create_article_candidate,
+    mark_article_update_required,
+    publish_web_article,
+    score_article_candidate,
+)
+
+
+def _payload(candidate_id: str, *, risk_level: str = "low") -> HermesWebArticleIntakeRequest:
+    return HermesWebArticleIntakeRequest.model_validate(
+        {
+            "idempotency_key": "article-idempotency-001",
+            "request_nonce": "article-request-nonce-001",
+            "candidate_id": candidate_id,
+            "research_version": "research-v1",
+            "article": {
+                "slug": "kak-nachat-silovye-trenirovki",
+                "title": "Как начать силовые тренировки и не потерять контекст",
+                "description": "Понятный старт силовых тренировок: план, факты и ограничения.",
+                "lead": "Для старта силовых тренировок важнее повторяемый план и запись фактов, чем сложная программа. Начните с посильной нагрузки и меняйте её только после наблюдения за несколькими занятиями.",
+                "body_sections": [
+                    {
+                        "heading": "С чего начать",
+                        "paragraphs": [
+                            "Выберите несколько базовых движений и заранее определите дни занятий. Первые недели нужны, чтобы понять технику, восстановление и то, какие записи вы действительно ведёте.",
+                        ],
+                        "points": [
+                            "Планируйте посильную нагрузку",
+                            "Записывайте выполненные подходы",
+                        ],
+                    },
+                    {
+                        "heading": "Что отслеживать",
+                        "paragraphs": [
+                            "Смотрите на выполненные подходы, повторения и рабочий вес в контексте всей недели. Одно занятие не показывает устойчивую динамику.",
+                        ],
+                    },
+                ],
+                "topics": ["training", "strength_hypertrophy"],
+                "article_kind": "evergreen_explainer",
+                "search_intent": "informational",
+                "primary_query": "как начать силовые тренировки",
+                "secondary_queries": ["план силовых тренировок для начинающих"],
+                "risk_level": risk_level,
+                "evidence_level": "moderate",
+                "claims": [
+                    {
+                        "claim_id": "claim-plan",
+                        "claim_text": "Повторяемый план помогает сравнивать фактические записи.",
+                        "normalized_claim": "repeatable plan supports comparison of recorded facts",
+                    }
+                ],
+                "sources": [
+                    {
+                        "source_id": "source-guideline",
+                        "title": "Physical activity guidance",
+                        "publisher": "World Health Organization",
+                        "url": "https://www.who.int/news-room/fact-sheets/detail/physical-activity",
+                        "source_type": "official_organization",
+                        "limitations": "Общие рекомендации не заменяют индивидуальную оценку.",
+                    },
+                    {
+                        "source_id": "source-review",
+                        "title": "Resistance training review",
+                        "publisher": "PubMed",
+                        "url": "https://pubmed.ncbi.nlm.nih.gov/00000001/",
+                        "source_type": "systematic_review",
+                        "limitations": "Выводы зависят от популяции и протокола.",
+                    },
+                ],
+                "claim_source_matrix": [
+                    {
+                        "claim_id": "claim-plan",
+                        "source_ids": ["source-guideline", "source-review"],
+                        "support_level": "supports",
+                        "limitations": "Источники не определяют индивидуальную программу.",
+                        "review_status": "verified",
+                    }
+                ],
+                "author": {"name": "Your Fitness Coach", "type": "Organization"},
+                "editor": {"name": "YFC Editorial Desk", "type": "Organization"},
+                "related_slugs": [],
+                "cta": {
+                    "destination": "web",
+                    "label": "Открыть Your Fitness Coach",
+                    "description": "Сохраняйте план и фактические результаты в одном месте.",
+                },
+                "evergreen_score": 82,
+                "product_relevance": 75,
+                "editorial_value": 88,
+                "web_article_potential_reasons": ["evergreen_gap"],
+            },
+            "provenance": {
+                "provider": "local",
+                "model": "hermes-mock",
+                "prompt_version": "web-article-v1",
+                "skill_version": "yfc-hermes-editorial-v1",
+            },
+        }
+    )
+
+
+@pytest.fixture()
+def db_session():
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.rollback()
+        session.close()
+
+
+def _candidate(db) -> str:
+    candidate = create_article_candidate(
+        db,
+        source_kind="manual",
+        working_title="Как начать силовые тренировки",
+        primary_topic="training",
+        topics=["training", "strength_hypertrophy"],
+        article_kind="evergreen_explainer",
+        search_intent="informational",
+        primary_query="как начать силовые тренировки",
+        secondary_queries=[],
+        audience="general",
+        risk_level="low",
+        evidence_level="moderate",
+        signals=ArticleCandidateSignals(
+            search_demand=80,
+            intent_clarity=90,
+            topical_relevance=90,
+            product_relevance=70,
+            audience_usefulness=85,
+            evergreen_potential=90,
+            evidence_availability=80,
+            existing_content_overlap=10,
+            internal_link_potential=70,
+            risk_review_cost=10,
+            freshness_need=20,
+            news_opportunity=25,
+        ),
+    )
+    return candidate.id
+
+
+def test_candidate_score_keeps_opportunity_separate_from_approval() -> None:
+    result = score_article_candidate(
+        ArticleCandidateSignals(search_demand=100, risk_review_cost=100)
+    )
+    assert result["score"] < 60
+    assert "risk_review_cost_requires_manual_path" in result["reasons"]
+
+
+def test_hermes_article_intake_is_idempotent_and_creates_draft(db_session) -> None:
+    candidate_id = _candidate(db_session)
+    payload = _payload(candidate_id)
+    payload_hash = hashlib.sha256(payload.model_dump_json().encode()).hexdigest()
+
+    first = accept_hermes_article_submission(db_session, payload, payload_hash=payload_hash)
+    second = accept_hermes_article_submission(db_session, payload, payload_hash=payload_hash)
+
+    assert first.status == "accepted"
+    assert first.article_status == "draft"
+    assert second.status == "duplicate"
+    assert second.article_id == first.article_id
+    assert db_session.query(WebArticle).count() == 1
+    assert db_session.query(WebArticleRevision).count() == 1
+
+
+def test_sensitive_article_requires_domain_reviewer() -> None:
+    with pytest.raises(ValidationError, match="domain_reviewer"):
+        _payload("a" * 32, risk_level="high")
+
+
+def test_publish_requires_approval_and_update_preserves_revision(db_session) -> None:
+    candidate_id = _candidate(db_session)
+    payload = _payload(candidate_id)
+    payload_hash = hashlib.sha256(payload.model_dump_json().encode()).hexdigest()
+    result = accept_hermes_article_submission(db_session, payload, payload_hash=payload_hash)
+    article = db_session.get(WebArticle, result.article_id)
+    assert article is not None
+
+    with pytest.raises(WebArticleError, match="article_not_approved"):
+        publish_web_article(db_session, article, actor_ref="owner")
+
+    article.status = "approved"
+    publish_web_article(db_session, article, actor_ref="owner")
+    assert article.status == "published"
+    assert article.published_at is not None
+
+    revision_id = db_session.query(WebArticleRevision.id).scalar()
+    mark_article_update_required(db_session, article, reason="Источник обновился")
+    assert article.status == "update_required"
+    assert db_session.query(WebArticleRevision.id).scalar() == revision_id

--- a/backend/tests/test_web_articles.py
+++ b/backend/tests/test_web_articles.py
@@ -242,10 +242,35 @@ def test_signed_hermes_article_intake_is_idempotent_and_never_publishes(
     assert first.json()["article_status"] == "draft"
     assert first.json()["article_id"] == second.json()["article_id"]
 
+    mismatch_nonce = "article-request-nonce-other"
+    mismatch_headers = {
+        **headers,
+        "X-Hermes-Nonce": mismatch_nonce,
+        "X-Hermes-Signature": hermes_signature(
+            "test-hermes-shared-secret-that-is-long-enough",
+            timestamp=timestamp,
+            nonce=mismatch_nonce,
+            body=body,
+        ),
+    }
+    mismatch = client.post("/api/v1/hermes/articles/intake", content=body, headers=mismatch_headers)
+    assert mismatch.status_code == 422
+    assert mismatch.json()["detail"] == "nonce_mismatch"
+
     with SessionLocal() as db:
         article = db.get(WebArticle, first.json()["article_id"])
         assert article is not None
         assert article.status == "draft"
+
+
+def test_hermes_article_intake_enforces_shared_source_limit(db_session, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "hermes_intake_max_source_count", 1)
+    candidate_id = _candidate(db_session)
+    payload = _payload(candidate_id)
+    payload_hash = hashlib.sha256(payload.model_dump_json().encode()).hexdigest()
+
+    with pytest.raises(WebArticleError, match="source_count_exceeded"):
+        accept_hermes_article_submission(db_session, payload, payload_hash=payload_hash)
 
 
 def test_publish_requires_approval_and_update_preserves_revision(db_session) -> None:

--- a/backend/tests/test_web_articles.py
+++ b/backend/tests/test_web_articles.py
@@ -15,9 +15,11 @@ from fitminiapp_api.services.web_articles import (
     ArticleCandidateSignals,
     WebArticleError,
     accept_hermes_article_submission,
+    archive_web_article,
     create_article_candidate,
     mark_article_update_required,
     publish_web_article,
+    retract_web_article,
     score_article_candidate,
 )
 
@@ -261,8 +263,72 @@ def test_publish_requires_approval_and_update_preserves_revision(db_session) -> 
     publish_web_article(db_session, article, actor_ref="owner")
     assert article.status == "published"
     assert article.published_at is not None
+    published_at = article.published_at
 
     revision_id = db_session.query(WebArticleRevision.id).scalar()
     mark_article_update_required(db_session, article, reason="Источник обновился")
     assert article.status == "update_required"
     assert db_session.query(WebArticleRevision.id).scalar() == revision_id
+
+    updated_proposal = payload.article.model_copy(
+        update={
+            "title": "Как начать силовые тренировки: обновлённый разбор",
+            "lead": "Обновлённый разбор сохраняет прежний intent и canonical URL, но проходит новый review.",
+        }
+    )
+    update_payload = payload.model_copy(
+        update={
+            "idempotency_key": "article-idempotency-update-001",
+            "request_nonce": "article-request-nonce-update-001",
+            "research_version": "research-v2",
+            "article": updated_proposal,
+        }
+    )
+    update_hash = hashlib.sha256(update_payload.model_dump_json().encode()).hexdigest()
+    update_result = accept_hermes_article_submission(
+        db_session, update_payload, payload_hash=update_hash
+    )
+
+    assert update_result.status == "accepted"
+    assert update_result.article_id == article.id
+    assert update_result.content_version == 2
+    assert article.status == "draft"
+    assert article.slug == payload.article.slug
+    assert article.canonical_url == (
+        f"{settings.frontend_base_url.rstrip('/')}/articles/kak-nachat-silovye-trenirovki"
+    )
+    assert article.published_at == published_at
+    assert db_session.query(WebArticleRevision).count() == 2
+    old_revision = db_session.get(WebArticleRevision, revision_id)
+    assert old_revision is not None
+    assert old_revision.status == "published"
+    assert old_revision.snapshot["title"] == payload.article.title
+
+    article.status = "approved"
+    publish_web_article(db_session, article, actor_ref="owner")
+    assert article.status == "published"
+    assert article.content_version == 2
+    assert article.updated_at is not None
+
+
+def test_archive_and_retract_preserve_article_history(db_session) -> None:
+    candidate_id = _candidate(db_session)
+    payload = _payload(candidate_id)
+    payload_hash = hashlib.sha256(payload.model_dump_json().encode()).hexdigest()
+    result = accept_hermes_article_submission(db_session, payload, payload_hash=payload_hash)
+    article = db_session.get(WebArticle, result.article_id)
+    assert article is not None
+    article.status = "approved"
+    publish_web_article(db_session, article, actor_ref="owner")
+
+    archive_web_article(db_session, article, reason="Intent устарел", actor_ref="editor")
+    assert article.status == "archived"
+    assert article.correction_reason == "Intent устарел"
+    assert db_session.query(WebArticleRevision).count() == 1
+
+    retract_web_article(
+        db_session, article, reason="Обнаружена фактическая ошибка", actor_ref="owner"
+    )
+    assert article.status == "retracted"
+    assert article.correction_reason == "Обнаружена фактическая ошибка"
+    assert db_session.query(WebArticleRevision).count() == 1

--- a/backend/tests/test_web_public.py
+++ b/backend/tests/test_web_public.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from datetime import datetime
 from xml.etree import ElementTree
 
+import pytest
+
 from fitminiapp_api.core.config import settings
 from fitminiapp_api.db.session import get_session_context
 from fitminiapp_api.models.news import WebArticle, WebArticleRevision
@@ -152,6 +154,39 @@ def test_draft_article_is_not_public_or_in_sitemap(client, monkeypatch) -> None:
 
     assert client.get("/articles/internal-draft").status_code == 404
     assert "internal-draft" not in client.get("/sitemap.xml").text
+
+
+@pytest.mark.parametrize("status", ["archived", "retracted"])
+def test_removed_article_returns_explicit_gone_status(client, status) -> None:
+    with get_session_context() as db:
+        article = _published_article()
+        article.status = status
+        db.add(article)
+
+    page = client.get("/articles/strength-basics")
+    api = client.get("/api/v1/public/articles/strength-basics")
+    assert page.status_code == 410
+    assert api.status_code == 410
+    assert page.headers["x-robots-tag"] == "noindex, nofollow"
+    assert api.headers["x-robots-tag"] == "noindex, nofollow"
+
+
+def test_server_article_fallback_resolves_allowlisted_cta(client, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "landing_domain", "your-fitness-coach.ru")
+    monkeypatch.setattr(settings, "telegram_bot_username", "hermes_yfc_bot")
+    with get_session_context() as db:
+        article = _published_article()
+        article.cta = {
+            "destination": "tma",
+            "label": "Открыть в Telegram",
+            "description": "Продолжить в Mini App.",
+        }
+        db.add(article)
+
+    response = client.get("/articles/strength-basics", headers={"Host": "your-fitness-coach.ru"})
+    assert response.status_code == 200
+    assert 'href="https://t.me/hermes_yfc_bot?startapp"' in response.text
+    assert ">Открыть в Telegram</a>" in response.text
 
 
 def test_public_article_api_exposes_only_published_records(client) -> None:

--- a/backend/tests/test_web_public.py
+++ b/backend/tests/test_web_public.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from datetime import datetime
+from xml.etree import ElementTree
+
+from fitminiapp_api.core.config import settings
+from fitminiapp_api.db.session import get_session_context
+from fitminiapp_api.models.news import WebArticle, WebArticleRevision
+
+
+def _published_article() -> WebArticle:
+    return WebArticle(
+        id="a" * 32,
+        slug="strength-basics",
+        status="published",
+        title="Основы силовых тренировок без лишней сложности",
+        description="Как начать силовые тренировки: план, записи и честные ограничения.",
+        lead="Для старта силовых тренировок достаточно посильного плана и записи фактов. Смотрите на несколько занятий в контексте недели, а не на одну цифру.",
+        body_sections=[
+            {
+                "heading": "Начните с повторяемого плана",
+                "paragraphs": [
+                    "Выберите посильные движения и заранее определите дни занятий. Так проще заметить, что меняется на практике.",
+                ],
+                "points": [
+                    "Записывайте выполненные подходы",
+                    "Оставляйте место для восстановления",
+                ],
+            },
+            {
+                "heading": "Читайте записи в контексте",
+                "paragraphs": [
+                    "Одно занятие не показывает устойчивую динамику. Сверяйте план и факт по нескольким тренировкам.",
+                ],
+                "points": [],
+            },
+        ],
+        topics=["training", "strength_hypertrophy"],
+        article_kind="evergreen_explainer",
+        search_intent="informational",
+        primary_query="как начать силовые тренировки",
+        secondary_queries=["план силовых тренировок"],
+        risk_level="low",
+        evidence_level="moderate",
+        claims=[
+            {
+                "claim_id": "plan-context",
+                "claim_text": "Повторяемый план помогает сравнивать записи.",
+                "normalized_claim": "repeatable plan supports comparison",
+            }
+        ],
+        sources=[
+            {
+                "source_id": "who-activity",
+                "title": "Physical activity",
+                "publisher": "World Health Organization",
+                "url": "https://www.who.int/news-room/fact-sheets/detail/physical-activity",
+                "source_type": "official_organization",
+                "published_at": None,
+                "limitations": "Общие рекомендации.",
+            }
+        ],
+        claim_source_matrix=[
+            {
+                "claim_id": "plan-context",
+                "source_ids": ["who-activity"],
+                "support_level": "supports",
+                "limitations": "Источник не задаёт индивидуальную программу.",
+                "review_status": "verified",
+            }
+        ],
+        author={"name": "Your Fitness Coach", "type": "Organization"},
+        editor={"name": "YFC Editorial Desk", "type": "Organization"},
+        domain_reviewer=None,
+        canonical_url="https://your-fitness-coach.ru/articles/strength-basics",
+        related_slugs=[],
+        cta={
+            "destination": "web",
+            "label": "Открыть Your Fitness Coach",
+            "description": "Сохраняйте план и фактические результаты.",
+        },
+        evergreen_score=80,
+        product_relevance=75,
+        editorial_value=85,
+        web_article_potential_reasons=["evergreen_gap"],
+        content_version=1,
+        research_version="research-v1",
+        provider="local",
+        model="fixture",
+        prompt_version="web-article-v1",
+        skill_version="yfc-hermes-editorial-v1",
+        schema_version="yfc-web-article-v1",
+        generated_with_ai=True,
+        research_assistance=True,
+        content_hash="b" * 64,
+        published_at=datetime(2026, 9, 1, 10, 0),
+        updated_at=datetime(2026, 9, 2, 10, 0),
+    )
+
+
+def test_articles_routes_render_published_content_and_metadata(client, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "landing_domain", "your-fitness-coach.ru")
+    with get_session_context() as db:
+        article = _published_article()
+        db.add(article)
+        db.add(
+            WebArticleRevision(
+                id="c" * 32,
+                article_id=article.id,
+                content_version=1,
+                status="published",
+                snapshot={"title": article.title},
+            )
+        )
+
+    index = client.get("/articles", headers={"Host": "your-fitness-coach.ru"})
+    detail = client.get("/articles/strength-basics", headers={"Host": "your-fitness-coach.ru"})
+    assert index.status_code == 200
+    assert detail.status_code == 200
+    assert index.headers["x-robots-tag"] == "index, follow"
+    assert "strength-basics" in index.text
+    detail_html = detail.content.decode("utf-8")
+    assert "Основы силовых тренировок без лишней сложности" in detail_html
+    assert '<meta property="og:type" content="article" />' in detail_html
+    assert (
+        '<link rel="canonical" href="https://your-fitness-coach.ru/articles/strength-basics" />'
+        in detail_html
+    )
+    assert '"datePublished":"2026-09-01"' in detail_html
+    assert "Выберите посильные движения" in detail_html
+
+    sitemap = client.get("/sitemap.xml", headers={"Host": "your-fitness-coach.ru"})
+    root = ElementTree.fromstring(sitemap.content)
+    locs = [
+        element.text
+        for element in root.findall(
+            "{http://www.sitemaps.org/schemas/sitemap/0.9}url/{http://www.sitemaps.org/schemas/sitemap/0.9}loc"
+        )
+    ]
+    assert "https://your-fitness-coach.ru/articles/strength-basics" in locs
+
+
+def test_draft_article_is_not_public_or_in_sitemap(client, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "landing_domain", "your-fitness-coach.ru")
+    with get_session_context() as db:
+        draft = _published_article()
+        draft.id = "d" * 32
+        draft.slug = "internal-draft"
+        draft.status = "review"
+        draft.canonical_url = "https://your-fitness-coach.ru/articles/internal-draft"
+        db.add(draft)
+
+    assert client.get("/articles/internal-draft").status_code == 404
+    assert "internal-draft" not in client.get("/sitemap.xml").text
+
+
+def test_public_article_api_exposes_only_published_records(client) -> None:
+    with get_session_context() as db:
+        article = _published_article()
+        db.add(article)
+
+    response = client.get("/api/v1/public/articles")
+    detail = client.get("/api/v1/public/articles/strength-basics")
+    assert response.status_code == 200
+    assert response.json()[0]["slug"] == "strength-basics"
+    assert detail.status_code == 200
+    assert detail.json()["content_version"] == 1

--- a/docs/web-articles-editorial.md
+++ b/docs/web-articles-editorial.md
@@ -1,0 +1,152 @@
+# Публичные Web-статьи и SEO-контур
+
+Статус документа: Task 130, локальный/mock-контур. Документ описывает канонический
+жизненный цикл статьи, границу Hermes → YFC и правила публикации. Наличие кода и
+локальных тестов не означает, что production-индексация, Search Console или живой
+Hermes/provider уже подключены.
+
+## Граница продукта
+
+Публичная статья — отдельный индексируемый раздел, а не продолжение продающего
+лендинга. Лендинг может показывать не более трёх опубликованных curated-карточек;
+полный каталог живёт на `/articles`.
+
+| Путь | Назначение | Публичный статус |
+| --- | --- | --- |
+| `/articles` | индекс статей | 200 даже при пустом каталоге |
+| `/articles/<slug>` | каноническая статья | только `published`, иначе 404 |
+| `/api/v1/public/articles` | карточки для Web/лендинга | только `published` |
+| `/api/v1/public/articles/<slug>` | полный read model | только `published` |
+| `/sitemap.xml` | discovery поисковыми роботами | только `published` |
+| `/api/v1/hermes/articles/intake` | узкий вход исследовательского draft | не публикует |
+
+Источник истины — `WebArticle` и неизменяемые `WebArticleRevision` в базе. Backend
+рендерит содержательный HTML-fallback для crawler/readability, а React после загрузки
+гидратирует тот же контракт через public API. Frontend не создаёт статью и не может
+обойти backend-статус.
+
+## Жизненный цикл и ручные ворота
+
+Допустимые статусы: `candidate → researching → draft → review → approved → published`.
+Отдельные состояния: `update_required`, `archived`, `retracted`.
+
+- `candidate` — возможность для редакции, не обещание публикации.
+- `draft` — Hermes или другой исследователь подготовил материал; он не индексируется.
+- `review` — редактор проверяет русский текст, intent, источники и внутренние ссылки.
+- `approved` — редактор явно одобрил конкретную версию.
+- `published` — отдельное owner/editor-действие `publish_web_article`; только эта
+  операция открывает URL, API, sitemap и landing-card.
+- `update_required` — опубликованная версия временно закрыта после изменения источника
+  или обнаружения проблемы. Предыдущий revision сохраняется; новая версия проходит
+  тот же review → approval → publish путь.
+- `archived`/`retracted` — материал снят с публичного контура. Ретракция не удаляет
+  аудит и причину исправления.
+
+Hermes intake всегда создаёт только `draft`. В endpoint нет операции publish, deploy,
+Telegram-send или произвольного shell/provider tool call.
+
+## Кандидаты и приоритизация
+
+Кандидат может прийти из трёх allowlisted-контуров: `manual`, `seo_import` или
+`news_handoff` (из Task 129). Для `news_handoff` сохраняется ссылка на исходный
+news-cluster/revision, но Web-статья получает отдельное решение о публикации.
+
+`score_article_candidate` оценивает opportunity, а не качество и не approval. В расчёт
+входят независимые сигналы: поисковый спрос, ясность intent, тематическая и продуктовая
+релевантность, польза аудитории, evergreen-потенциал, наличие evidence, overlap с
+текущим контентом, потенциал внутренних ссылок, стоимость risk-review, потребность в
+свежести и news opportunity. Overlap, risk и freshness не сворачиваются в ложное
+«разрешение на публикацию».
+
+`sports_nutrition` и `dietary_supplements` — разные topic-классы. Оба относятся к
+чувствительному контуру и требуют более строгой проверки; нельзя маскировать обзор
+добавок под обычную evergreen-статью.
+
+## Hermes → YFC
+
+Hermes рассматривается как недоверенный внешний worker. На вход принимается ограниченный
+research packet и Russian draft proposal со следующими обязательными частями:
+
+- `candidate_id`, `research_version`, `schema_version`, `provenance`;
+- slug, title, description, lead, секции тела и search intent;
+- claims, sources и полная `claim_source_matrix`;
+- author/editor, при необходимости domain reviewer;
+- allowlisted CTA без произвольного URL и SEO-полей;
+- source URL только по HTTPS.
+
+Аутентификация и эксплуатационные ограничения переиспользуют Task 129:
+`X-Hermes-Key-Id`, `X-Hermes-Timestamp`, `X-Hermes-Nonce`, `X-Hermes-Signature`;
+подпись — HMAC-SHA256 от `timestamp + "\n" + nonce + "\n" + raw_body`. Проверяются
+key id, clock skew, размер тела, nonce replay, idempotency key и rate limit. Ошибки
+наружу нормализуются; секреты, raw body, Telegram IDs и персональные данные не попадают
+в аналитику или audit details.
+
+Hermes может использовать CLI/gateway и messaging/scheduled-job интеграции согласно
+[официальному репозиторию Hermes](https://github.com/NousResearch/hermes-agent) и
+[официальной документации Hermes](https://hermes-agent.nousresearch.com/docs/), но
+конкретный provider, outbound account, live Telegram и расписание не являются частью
+этой задачи. В YFC флаги intake по умолчанию выключены. Включение требует отдельного
+owner gate на выбранную версию Hermes, изоляцию, retention, outbound domains, ротацию
+ключа и rollback.
+
+## Evidence и редакционная проверка
+
+Каждое существенное утверждение получает стабильный `claim_id`, одну или несколько
+ссылок на source и статус матрицы `pending | verified | blocked`. `evidence_review`
+требует несколько источников. Для `high`/`critical` risk и для sensitive topics нужен
+`domain_reviewer`. Не используется AI-detector как автоматический gate: проверяется
+смысл, происхождение, источники, ограничения, русский язык и польза читателю.
+
+Верификация не превращает исследовательский результат в медицинскую рекомендацию.
+Ограничения источника хранятся рядом с ним и с claim; числа без проверенной поддержки
+блокируются для следующего ручного шага.
+
+## SEO и публичный read model
+
+Для опубликованной статьи backend формирует:
+
+- уникальный slug и canonical на `public_origin()/articles/<slug>`;
+- title, description, Open Graph metadata и `og:type=article`;
+- JSON-LD `Article` с author/editor/reviewer, `datePublished` и `dateModified`;
+- server-readable H1, lead, секции, источники, related links и CTA;
+- запись в sitemap с `lastmod`.
+
+Draft, review, approved, update_required, archived и retracted не появляются в sitemap,
+public API или indexable HTML. Публичный маршрут не использует framework rewrite как
+единственный источник SEO-содержимого: первоначальный ответ backend уже содержит
+заголовок и текст статьи.
+
+При изменении источника сначала ставится `update_required`, затем создаётся новый
+immutable revision. Публикация новой версии меняет `content_version` и `dateModified`,
+а прошлый snapshot и audit reason остаются доступными для проверки и rollback-решения.
+
+## Аналитика и воронка
+
+Контракт добавляет только privacy-safe события:
+
+- `article_viewed` с allowlisted slug в `content_key`;
+- `article_cta_clicked` с allowlisted slug и destination `tma | web | landing`.
+
+Событие CTA — это intent, а не lead. В отчётах отдельно различаются view, CTA intent,
+qualified lead, server-confirmed conversion и activation. Не передаются raw query,
+поисковый текст, тело статьи, URL с токенами, user ID, Telegram ID, health data или
+контент формы. Недоступный analytics provider не блокирует чтение статьи или редакционный
+pipeline.
+
+## Локальная проверка и release gates
+
+Минимальная проверка Task 130 выполняется в worktree:
+
+```powershell
+D:\Pet-projects\your-fitness-coach\.venv\Scripts\python.exe -m pytest backend/tests/test_web_articles.py backend/tests/test_web_public.py -q
+Set-Location frontend
+npm run typecheck
+npm run lint -- --quiet
+npm run test -- --run tests/unit/shared/analytics/productEvents.test.ts
+npm run build
+```
+
+Перед owner approval нельзя считать локальный/mock HTML доказательством live search
+indexing, реального Telegram Mini App, физического устройства, live Hermes/provider,
+внешней SEO-учётной записи или production публикации. Эти проверки выполняются только
+отдельным явно разрешённым release-процессом.

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -32,6 +32,10 @@ const publicContentRoots = new Set([
   '/exercises',
 ]);
 
+function isArticleRoute(path: string): boolean {
+  return path === '/articles' || path.startsWith('/articles/');
+}
+
 function isPublicContentRoute(path: string): boolean {
   return (
     publicContentRoots.has(path) || path.startsWith('/knowledge/') || path.startsWith('/exercises/')
@@ -45,6 +49,7 @@ const AdminPage = lazy(() => import('./pages/admin/AdminPage'));
 const LandingPage = lazy(() => import('./pages/landing/LandingPage'));
 const DemoPage = lazy(() => import('./pages/demo/DemoPage'));
 const PublicContentPage = lazy(() => import('./pages/public/PublicContentPage'));
+const ArticlesPage = lazy(() => import('./pages/public/ArticlesPage'));
 const KnowledgeHandoffPage = lazy(() => import('./pages/public/KnowledgeHandoffPage'));
 const VerifyEmailPage = lazy(() => import('./pages/auth/VerifyEmailPage'));
 const ResetPasswordPage = lazy(() => import('./pages/auth/ResetPasswordPage'));
@@ -87,9 +92,12 @@ function AppRoutes() {
     Boolean(window.Telegram?.WebApp?.initData?.trim()) || isTelegramLaunch(window.location);
   const legacyKnowledgePath = publicKnowledgePathFromLegacyRoute(path);
   useEffect(() => {
-    if (path !== '/' && !isPublicContentRoute(path)) applyRouteMetadata(path);
+    if (path !== '/' && !isPublicContentRoute(path) && !isArticleRoute(path)) {
+      applyRouteMetadata(path);
+    }
   }, [path]);
   if (path === '/') return <LandingPage />;
+  if (isArticleRoute(path)) return <ArticlesPage />;
   if (path === '/demo') {
     if (isTelegramLaunch(window.location)) return <Redirect to="/app" />;
     return <DemoPage />;

--- a/frontend/src/pages/landing/LandingPage.tsx
+++ b/frontend/src/pages/landing/LandingPage.tsx
@@ -1,4 +1,7 @@
 import { useEffect, useRef, useState, type ImgHTMLAttributes } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { WebArticleCard } from '../../shared/api/types';
+import { api } from '../../shared/api/client';
 import {
   productEventSurface,
   trackProductEvent,
@@ -224,6 +227,10 @@ export default function LandingPage() {
   const { colorScheme } = useWebTheme();
   const menuButtonRef = useRef<HTMLButtonElement>(null);
   const navigationRef = useRef<HTMLElement>(null);
+  const publishedArticles = useQuery({
+    queryKey: ['public', 'articles'],
+    queryFn: () => api<WebArticleCard[]>('/api/v1/public/articles'),
+  });
 
   useEffect(() => {
     let mounted = true;
@@ -456,6 +463,33 @@ export default function LandingPage() {
             ))}
           </div>
         </section>
+
+        {publishedArticles.data && publishedArticles.data.length > 0 && (
+          <section className="landing-articles" aria-labelledby="landing-articles-title">
+            <div className="landing-articles__intro">
+              <p className="landing-kicker">Разобраться до действия</p>
+              <h2 id="landing-articles-title">Избранные материалы</h2>
+              <p>
+                Короткий путь к понятному контексту: тренировки, питание и прогресс с источниками и
+                честными ограничениями.
+              </p>
+              <AppLink className="landing-core__self-link" to="/articles">
+                Все статьи <Icon name="arrow-right" size={20} />
+              </AppLink>
+            </div>
+            <div className="landing-articles__grid">
+              {publishedArticles.data.slice(0, 3).map((article) => (
+                <article key={article.slug}>
+                  <small>{article.topics[0] ?? 'YFC'}</small>
+                  <h3>
+                    <AppLink to={`/articles/${article.slug}`}>{article.title}</AppLink>
+                  </h3>
+                  <p>{article.description}</p>
+                </article>
+              ))}
+            </div>
+          </section>
+        )}
 
         <section className="landing-trainer" aria-labelledby="trainer-title">
           <div className="landing-trainer__copy">

--- a/frontend/src/pages/landing/landing.css
+++ b/frontend/src/pages/landing/landing.css
@@ -12,6 +12,85 @@
     linear-gradient(180deg, rgba(255, 255, 255, 0.68), transparent 40rem), var(--landing-paper);
 }
 
+.landing-articles {
+  width: min(var(--landing-content), calc(100% - (var(--landing-gutter) * 2)));
+  margin: 0 auto;
+  padding: clamp(64px, 8vw, 112px) 0;
+  border-top: 1px solid var(--landing-line);
+  display: grid;
+  grid-template-columns: minmax(220px, 0.7fr) minmax(0, 1.3fr);
+  gap: clamp(34px, 7vw, 96px);
+}
+
+.landing-articles__intro {
+  max-width: 430px;
+}
+
+.landing-articles__intro h2 {
+  margin: 0;
+  font-size: clamp(2.2rem, 4vw, 4.2rem);
+  letter-spacing: -0.06em;
+  line-height: 0.98;
+}
+
+.landing-articles__intro > p:not(.landing-kicker) {
+  margin: 24px 0 28px;
+  color: var(--landing-muted);
+  line-height: 1.65;
+}
+
+.landing-articles__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.landing-articles__grid article {
+  min-height: 230px;
+  padding: 24px;
+  border: 1px solid var(--landing-line);
+  border-radius: 22px;
+  background: var(--landing-raised);
+}
+
+.landing-articles__grid small {
+  color: var(--landing-kicker);
+  font-size: 0.68rem;
+  font-weight: 850;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.landing-articles__grid h3 {
+  margin: 34px 0 14px;
+  font-size: 1.2rem;
+  line-height: 1.12;
+}
+
+.landing-articles__grid h3 a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.landing-articles__grid p {
+  margin: 0;
+  color: var(--landing-muted);
+  font-size: 0.88rem;
+  line-height: 1.55;
+}
+
+@media (max-width: 900px) {
+  .landing-articles {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .landing-articles__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .public-shell--dark.landing-page {
   --landing-surface: rgba(18, 24, 20, 0.88);
   --landing-surface-solid: #121814;

--- a/frontend/src/pages/public/ArticlesPage.tsx
+++ b/frontend/src/pages/public/ArticlesPage.tsx
@@ -6,6 +6,7 @@ import { appUrlForHostname } from '../../shared/navigation/appUrl';
 import { AppLink, Redirect, useNavigation } from '../../shared/navigation/router';
 import { applyArticleRouteMetadata, type PublicArticleSeoData } from '../../shared/seo/metadata';
 import { productEventSurface, trackProductEvent } from '../../shared/analytics/productEvents';
+import { PUBLIC_TELEGRAM_LINKS } from '../../shared/telegram/publicLinks';
 import { useWebTheme } from '../../shared/useWebTheme';
 import { Icon } from '../../shared/ui/Icon';
 import { PublicFooter, PublicHeader } from './PublicContentPage';
@@ -229,7 +230,12 @@ function ArticleDetail({ slug }: { slug: string }) {
   const relatedArticles =
     related.data?.filter((item) => data.related_slugs.includes(item.slug)) ?? [];
   const appUrl = appUrlForHostname(window.location.hostname);
-  const ctaHref = data.cta.destination === 'landing' ? '/' : appUrl;
+  const ctaHref =
+    data.cta.destination === 'landing'
+      ? '/'
+      : data.cta.destination === 'tma'
+        ? PUBLIC_TELEGRAM_LINKS.miniApp
+        : appUrl;
 
   return (
     <ArticleLayout>

--- a/frontend/src/pages/public/ArticlesPage.tsx
+++ b/frontend/src/pages/public/ArticlesPage.tsx
@@ -1,0 +1,370 @@
+import { useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { WebArticle, WebArticleCard } from '../../shared/api/types';
+import { api, ApiError } from '../../shared/api/client';
+import { appUrlForHostname } from '../../shared/navigation/appUrl';
+import { AppLink, Redirect, useNavigation } from '../../shared/navigation/router';
+import { applyArticleRouteMetadata, type PublicArticleSeoData } from '../../shared/seo/metadata';
+import { productEventSurface, trackProductEvent } from '../../shared/analytics/productEvents';
+import { useWebTheme } from '../../shared/useWebTheme';
+import { Icon } from '../../shared/ui/Icon';
+import { PublicFooter, PublicHeader } from './PublicContentPage';
+import NotFoundPage from '../NotFoundPage';
+import '../../shared/ui/public-shell.css';
+import '../landing/landing.css';
+import './public-content.css';
+
+const ARTICLE_KIND_LABELS: Record<WebArticleCard['article_kind'], string> = {
+  evergreen_explainer: 'Объяснение',
+  practical_guide: 'Практический разбор',
+  evidence_review: 'Разбор evidence',
+  myth_busting: 'Разбор мифов',
+  research_update: 'Исследование',
+  comparison: 'Сравнение',
+  product_education: 'Возможности продукта',
+};
+
+function formatDate(value: string): string {
+  return new Intl.DateTimeFormat('ru-RU', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(value));
+}
+
+function ArticleCard({ article }: { article: WebArticleCard }) {
+  return (
+    <article className="public-guide-card article-card">
+      <p>{ARTICLE_KIND_LABELS[article.article_kind]}</p>
+      <h2>
+        <AppLink to={`/articles/${article.slug}`}>{article.title}</AppLink>
+      </h2>
+      <p>{article.description}</p>
+      <time dateTime={article.updated_at}>Обновлено {formatDate(article.updated_at)}</time>
+      <AppLink className="public-inline-link" to={`/articles/${article.slug}`}>
+        Читать статью <Icon name="arrow-right" size={16} />
+      </AppLink>
+    </article>
+  );
+}
+
+function ArticleLayout({ children }: { children: React.ReactNode }) {
+  const { colorScheme: theme } = useWebTheme();
+  return (
+    <div
+      className={`public-shell public-shell--design-v2 public-shell--${theme} landing-page landing-page--${theme} public-page public-page--design-v2`}
+    >
+      <PublicHeader theme={theme} />
+      {children}
+      <PublicFooter theme={theme} />
+    </div>
+  );
+}
+
+function ArticlesIndex() {
+  const articles = useQuery({
+    queryKey: ['public', 'articles'],
+    queryFn: () => api<WebArticleCard[]>('/api/v1/public/articles'),
+  });
+
+  useEffect(() => {
+    applyArticleRouteMetadata('/articles');
+  }, []);
+
+  return (
+    <ArticleLayout>
+      <main id="public-content" className="public-main articles-index" tabIndex={-1}>
+        <nav className="public-breadcrumbs" aria-label="Хлебные крошки">
+          <ol>
+            <li>
+              <AppLink to="/">Главная</AppLink>
+            </li>
+            <li>
+              <span aria-current="page">Статьи</span>
+            </li>
+          </ol>
+        </nav>
+        <header className="public-hero articles-index__hero">
+          <div className="public-hero__copy">
+            <p className="landing-kicker">Редакционные материалы</p>
+            <h1>Статьи, которые помогают разобраться.</h1>
+            <p className="public-hero__lead">
+              Самостоятельные разборы о тренировках, питании и прогрессе. Сначала — понятный ответ
+              на вопрос, затем источники, ограничения и следующий шаг.
+            </p>
+          </div>
+          <aside className="public-hero__summary" aria-label="Подход к статьям">
+            <span>Подход редакции</span>
+            <strong>Меньше страниц. Больше полезного контекста.</strong>
+            <p>
+              Публикуем только материалы с понятным intent, источниками и человеческой проверкой.
+            </p>
+          </aside>
+        </header>
+        <section
+          className="public-directory articles-index__directory"
+          aria-labelledby="articles-title"
+        >
+          <div className="public-section-heading">
+            <p className="landing-kicker">Опубликовано</p>
+            <h2 id="articles-title">Выберите тему</h2>
+          </div>
+          {articles.isLoading && <p role="status">Загружаем статьи…</p>}
+          {articles.error && (
+            <div role="alert" className="public-inline-error">
+              <p>Статьи временно недоступны. Попробуйте ещё раз.</p>
+              <button
+                type="button"
+                className="landing-button"
+                onClick={() => void articles.refetch()}
+              >
+                Повторить
+              </button>
+            </div>
+          )}
+          {articles.data && (
+            <div className="public-guide-grid">
+              {articles.data.map((article) => (
+                <ArticleCard key={article.slug} article={article} />
+              ))}
+              {articles.data.length === 0 && (
+                <p>
+                  Новые материалы появятся здесь после проверки источников и редакторского review.
+                </p>
+              )}
+            </div>
+          )}
+        </section>
+      </main>
+    </ArticleLayout>
+  );
+}
+
+function ArticleMetadata({ article }: { article: WebArticle }) {
+  return (
+    <dl className="public-guide-meta">
+      <div>
+        <dt>Автор</dt>
+        <dd>{article.author.name}</dd>
+      </div>
+      <div>
+        <dt>Редактор</dt>
+        <dd>{article.editor.name}</dd>
+      </div>
+      {article.domain_reviewer && (
+        <div>
+          <dt>Проверил</dt>
+          <dd>{article.domain_reviewer.name}</dd>
+        </div>
+      )}
+      <div>
+        <dt>Опубликовано</dt>
+        <dd>
+          <time dateTime={article.published_at}>{formatDate(article.published_at)}</time>
+        </dd>
+      </div>
+      <div>
+        <dt>Обновлено</dt>
+        <dd>
+          <time dateTime={article.updated_at}>{formatDate(article.updated_at)}</time>
+        </dd>
+      </div>
+    </dl>
+  );
+}
+
+function ArticleDetail({ slug }: { slug: string }) {
+  const article = useQuery({
+    queryKey: ['public', 'article', slug],
+    queryFn: () => api<WebArticle>(`/api/v1/public/articles/${slug}`),
+  });
+  const related = useQuery({
+    queryKey: ['public', 'articles'],
+    queryFn: () => api<WebArticleCard[]>('/api/v1/public/articles'),
+  });
+
+  useEffect(() => {
+    if (!article.data) return;
+    const seoData: PublicArticleSeoData = {
+      slug: article.data.slug,
+      title: article.data.title,
+      description: article.data.description,
+      canonical_url: article.data.canonical_url,
+      published_at: article.data.published_at,
+      updated_at: article.data.updated_at,
+      author: article.data.author,
+      editor: article.data.editor,
+      domain_reviewer: article.data.domain_reviewer,
+    };
+    applyArticleRouteMetadata(`/articles/${slug}`, seoData);
+    trackProductEvent(
+      { name: 'article_viewed', surface: productEventSurface(), content_key: article.data.slug },
+      { dedupe: 'session', dedupeKey: article.data.slug },
+    );
+  }, [article.data, slug]);
+
+  if (article.isLoading)
+    return (
+      <ArticleLayout>
+        <main className="public-main">
+          <p role="status">Загружаем статью…</p>
+        </main>
+      </ArticleLayout>
+    );
+  if (article.error instanceof ApiError && article.error.status === 404) return <NotFoundPage />;
+  if (article.error || !article.data) {
+    return (
+      <ArticleLayout>
+        <main className="public-main">
+          <div role="alert" className="public-inline-error">
+            <p>Статья временно недоступна.</p>
+          </div>
+        </main>
+      </ArticleLayout>
+    );
+  }
+
+  const data = article.data;
+  const relatedArticles =
+    related.data?.filter((item) => data.related_slugs.includes(item.slug)) ?? [];
+  const appUrl = appUrlForHostname(window.location.hostname);
+  const ctaHref = data.cta.destination === 'landing' ? '/' : appUrl;
+
+  return (
+    <ArticleLayout>
+      <main id="public-content" className="public-main" tabIndex={-1}>
+        <nav className="public-breadcrumbs" aria-label="Хлебные крошки">
+          <ol>
+            <li>
+              <AppLink to="/">Главная</AppLink>
+            </li>
+            <li>
+              <AppLink to="/articles">Статьи</AppLink>
+            </li>
+            <li>
+              <span aria-current="page">{data.title}</span>
+            </li>
+          </ol>
+        </nav>
+        <article className="public-article public-article--guide public-article--web-article">
+          <header className="public-hero">
+            <div className="public-hero__copy">
+              <p className="landing-kicker">{data.topics.join(' · ')}</p>
+              <h1>{data.title}</h1>
+              <p className="public-hero__lead">{data.lead}</p>
+              <ArticleMetadata article={data} />
+            </div>
+            <aside className="public-hero__summary" aria-label="Коротко о статье">
+              <span>{ARTICLE_KIND_LABELS[data.article_kind]}</span>
+              <strong>Ответ на intent — с источниками и ограничениями.</strong>
+              <p>
+                Материал не заменяет индивидуальную медицинскую помощь и не обещает гарантированный
+                результат.
+              </p>
+            </aside>
+          </header>
+          <nav className="public-contents" aria-label="Оглавление">
+            <strong>В этом материале</strong>
+            <ol>
+              {data.body_sections.map((section, index) => (
+                <li key={section.heading}>
+                  <a href={`#article-section-${index + 1}`}>{section.heading}</a>
+                </li>
+              ))}
+            </ol>
+          </nav>
+          <div className="public-body">
+            {data.body_sections.map((section, index) => (
+              <section id={`article-section-${index + 1}`} key={section.heading}>
+                <h2>{section.heading}</h2>
+                {section.paragraphs.map((paragraph) => (
+                  <p key={paragraph}>{paragraph}</p>
+                ))}
+                {section.points.length > 0 && (
+                  <ul>
+                    {section.points.map((point) => (
+                      <li key={point}>{point}</li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            ))}
+          </div>
+          <section className="public-sources" aria-labelledby="article-sources-title">
+            <div className="public-section-heading">
+              <p className="landing-kicker">Проверяемые утверждения</p>
+              <h2 id="article-sources-title">Источники</h2>
+            </div>
+            <ol>
+              {data.sources.map((source) => (
+                <li key={source.source_id}>
+                  <a href={source.url} target="_blank" rel="noreferrer">
+                    {source.title}
+                  </a>
+                  <span>{source.publisher}</span>
+                </li>
+              ))}
+            </ol>
+          </section>
+          {relatedArticles.length > 0 && (
+            <section className="public-related" aria-labelledby="article-related-title">
+              <div className="public-section-heading">
+                <p className="landing-kicker">Продолжить</p>
+                <h2 id="article-related-title">Связанные статьи</h2>
+              </div>
+              <div className="public-related-grid">
+                {relatedArticles.map((item) => (
+                  <AppLink
+                    className="public-related-card"
+                    key={item.slug}
+                    to={`/articles/${item.slug}`}
+                  >
+                    <strong>{item.title}</strong>
+                    <span>{item.description}</span>
+                    <small>
+                      Открыть <Icon name="arrow-right" size={16} />
+                    </small>
+                  </AppLink>
+                ))}
+              </div>
+            </section>
+          )}
+          <section className="public-cta" aria-labelledby="article-cta-title">
+            <div>
+              <p className="landing-kicker">Следующий шаг</p>
+              <h2 id="article-cta-title">{data.cta.label}</h2>
+              <p>{data.cta.description}</p>
+            </div>
+            <a
+              className="landing-button landing-action"
+              href={ctaHref}
+              onClick={() =>
+                trackProductEvent({
+                  name: 'article_cta_clicked',
+                  surface: productEventSurface(),
+                  content_key: data.slug,
+                  destination: data.cta.destination,
+                })
+              }
+            >
+              {data.cta.label}
+              <span className="landing-action__arrow" aria-hidden="true">
+                <Icon name="external-link" size={16} />
+              </span>
+            </a>
+          </section>
+        </article>
+      </main>
+    </ArticleLayout>
+  );
+}
+
+export default function ArticlesPage() {
+  const { path } = useNavigation();
+  if (window.Telegram?.WebApp?.initData) return <Redirect to="/app" />;
+  if (path === '/articles') return <ArticlesIndex />;
+  const slug = path.slice('/articles/'.length);
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) return <NotFoundPage />;
+  return <ArticleDetail slug={slug} />;
+}

--- a/frontend/src/pages/public/PublicContentPage.tsx
+++ b/frontend/src/pages/public/PublicContentPage.tsx
@@ -22,7 +22,7 @@ import '../landing/landing.css';
 import './public-content.css';
 import NotFoundPage from '../NotFoundPage';
 
-function PublicHeader({ theme }: { theme: 'light' | 'dark' }) {
+export function PublicHeader({ theme }: { theme: 'light' | 'dark' }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const closeMenu = () => setMenuOpen(false);
 
@@ -64,6 +64,9 @@ function PublicHeader({ theme }: { theme: 'light' | 'dark' }) {
         </AppLink>
         <AppLink to="/knowledge" onClick={closeMenu}>
           База знаний
+        </AppLink>
+        <AppLink to="/articles" onClick={closeMenu}>
+          Статьи
         </AppLink>
         <AppLink to="/exercises" onClick={closeMenu}>
           Упражнения
@@ -401,7 +404,7 @@ function RelatedContent({ page }: { page: PublicContentPageData }) {
   );
 }
 
-function PublicFooter({ theme }: { theme: 'light' | 'dark' }) {
+export function PublicFooter({ theme }: { theme: 'light' | 'dark' }) {
   return (
     <footer className="landing-footer public-footer">
       <AppLink className="landing-brand" to="/" aria-label="Your Fitness Coach — на главную">
@@ -415,6 +418,7 @@ function PublicFooter({ theme }: { theme: 'light' | 'dark' }) {
         <AppLink to="/training">Тренировки</AppLink>
         <AppLink to="/nutrition">Питание</AppLink>
         <AppLink to="/knowledge">База знаний</AppLink>
+        <AppLink to="/articles">Статьи</AppLink>
         <AppLink to="/exercises">Упражнения</AppLink>
         <AppLink to="/for-trainers">Тренерам</AppLink>
       </nav>

--- a/frontend/src/pages/public/public-content.css
+++ b/frontend/src/pages/public/public-content.css
@@ -171,6 +171,23 @@
   padding: 24px;
 }
 
+.public-article--web-article .public-hero h1,
+.articles-index__hero h1 {
+  font-size: clamp(2.8rem, 5.4vw, 5.8rem);
+  line-height: 0.98;
+}
+
+.article-card time {
+  display: block;
+  margin-top: 18px;
+  color: var(--landing-muted);
+  font-size: 0.78rem;
+}
+
+.article-card .public-inline-link {
+  margin-top: 22px;
+}
+
 .public-guide-meta {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/shared/analytics/productEvents.ts
+++ b/frontend/src/shared/analytics/productEvents.ts
@@ -16,6 +16,7 @@ export type ProductCoreAction =
 export type LandingTelegramPlacement = 'hero' | 'continuity' | 'footer';
 export type EditorialCtaDestination = 'tma' | 'web' | 'landing' | 'article';
 export type EditorialCtaCampaign = 'telegram_editorial_v1';
+export type PublicArticleCtaDestination = 'tma' | 'web' | 'landing';
 
 type ContextFreeProductEventName =
   | 'landing_viewed'
@@ -104,6 +105,17 @@ export type ProductEvent =
       surface: ProductSurface;
       destination: EditorialCtaDestination;
       campaign: EditorialCtaCampaign;
+    }
+  | {
+      name: 'article_viewed';
+      surface: ProductSurface;
+      content_key: string;
+    }
+  | {
+      name: 'article_cta_clicked';
+      surface: ProductSurface;
+      content_key: string;
+      destination: PublicArticleCtaDestination;
     };
 
 export type ProductEventName = ProductEvent['name'];
@@ -244,6 +256,8 @@ function eventPropertyKeys(name: string): readonly string[] {
   if (name === 'food_log_started' || name === 'food_logged') return ['entry_method'];
   if (name === 'tma_core_action_completed') return ['action'];
   if (name === 'telegram_news_cta_clicked') return ['destination', 'campaign'];
+  if (name === 'article_viewed') return ['content_key'];
+  if (name === 'article_cta_clicked') return ['content_key', 'destination'];
   return [];
 }
 
@@ -271,6 +285,18 @@ function hasValidEventProperties(value: Record<string, unknown>): boolean {
     return (
       ['tma', 'web', 'landing', 'article'].includes(value.destination as string) &&
       value.campaign === 'telegram_editorial_v1'
+    );
+  }
+  if (value.name === 'article_viewed') {
+    return (
+      typeof value.content_key === 'string' && /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value.content_key)
+    );
+  }
+  if (value.name === 'article_cta_clicked') {
+    return (
+      typeof value.content_key === 'string' &&
+      /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value.content_key) &&
+      ['tma', 'web', 'landing'].includes(value.destination as string)
     );
   }
   return false;

--- a/frontend/src/shared/api/schema.d.ts
+++ b/frontend/src/shared/api/schema.d.ts
@@ -55,6 +55,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/public/articles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Public Articles */
+        get: operations["get_public_articles_api_v1_public_articles_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/public/articles/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Public Article */
+        get: operations["get_public_article_api_v1_public_articles__slug__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/demo/sessions": {
         parameters: {
             query?: never;
@@ -2927,6 +2961,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/hermes/articles/intake": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Receive Hermes Web Article Intake */
+        post: operations["receive_hermes_web_article_intake_api_v1_hermes_articles_intake_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/health": {
         parameters: {
             query?: never;
@@ -3022,6 +3073,40 @@ export interface paths {
         };
         /** Landing Page */
         get: operations["landing_page__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/articles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Articles Index Page */
+        get: operations["articles_index_page_articles_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/articles/{slug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Article Page */
+        get: operations["article_page_articles__slug__get"];
         put?: never;
         post?: never;
         delete?: never;
@@ -3423,6 +3508,80 @@ export interface components {
             reason: "security_incident" | "abuse" | "account_recovery" | "support_request" | "relationship_safety";
             /** Is Active */
             is_active: boolean;
+        };
+        /** ArticleBodySection */
+        ArticleBodySection: {
+            /** Heading */
+            heading: string;
+            /** Paragraphs */
+            paragraphs: string[];
+            /** Points */
+            points?: string[];
+        };
+        /** ArticleClaim */
+        ArticleClaim: {
+            /** Claim Id */
+            claim_id: string;
+            /** Claim Text */
+            claim_text: string;
+            /** Normalized Claim */
+            normalized_claim: string;
+        };
+        /** ArticleClaimSourceMatrixItem */
+        ArticleClaimSourceMatrixItem: {
+            /** Claim Id */
+            claim_id: string;
+            /** Source Ids */
+            source_ids: string[];
+            /**
+             * Support Level
+             * @enum {string}
+             */
+            support_level: "supports" | "partially_supports" | "does_not_support" | "unclear";
+            /**
+             * Limitations
+             * @default
+             */
+            limitations: string;
+            /**
+             * Review Status
+             * @default pending
+             * @enum {string}
+             */
+            review_status: "pending" | "verified" | "blocked";
+        };
+        /** ArticlePerson */
+        ArticlePerson: {
+            /** Name */
+            name: string;
+            /**
+             * Type
+             * @enum {string}
+             */
+            type: "Organization" | "Person";
+        };
+        /** ArticleSource */
+        ArticleSource: {
+            /** Source Id */
+            source_id: string;
+            /** Title */
+            title: string;
+            /** Publisher */
+            publisher: string;
+            /**
+             * Url
+             * Format: uri
+             */
+            url: string;
+            /** Source Type */
+            source_type: string;
+            /** Published At */
+            published_at?: string | null;
+            /**
+             * Limitations
+             * @default
+             */
+            limitations: string;
         };
         /** AssignTemplateSelfRequest */
         AssignTemplateSelfRequest: {
@@ -5577,6 +5736,27 @@ export interface components {
             risk_reasons: string[];
             /** Preview Text */
             preview_text: string;
+        };
+        /** HermesWebArticleIntakeResponse */
+        HermesWebArticleIntakeResponse: {
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "accepted" | "duplicate";
+            /** Submission Id */
+            submission_id: string;
+            /** Article Id */
+            article_id: string;
+            /**
+             * Article Status
+             * @enum {string}
+             */
+            article_status: "candidate" | "researching" | "draft" | "review" | "approved" | "published" | "update_required" | "archived" | "retracted";
+            /** Content Version */
+            content_version: number;
+            /** Review Blockers */
+            review_blockers: string[];
         };
         /**
          * HydrationBeverageType
@@ -7780,6 +7960,108 @@ export interface components {
             /** Context */
             ctx?: Record<string, never>;
         };
+        /** WebArticleCard */
+        WebArticleCard: {
+            /** Slug */
+            slug: string;
+            /** Title */
+            title: string;
+            /** Description */
+            description: string;
+            /** Lead */
+            lead: string;
+            /** Topics */
+            topics: string[];
+            /**
+             * Article Kind
+             * @enum {string}
+             */
+            article_kind: "evergreen_explainer" | "practical_guide" | "evidence_review" | "myth_busting" | "research_update" | "comparison" | "product_education";
+            /**
+             * Published At
+             * Format: date-time
+             */
+            published_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** Canonical Url */
+            canonical_url: string;
+        };
+        /** WebArticleResponse */
+        WebArticleResponse: {
+            /** Slug */
+            slug: string;
+            /** Title */
+            title: string;
+            /** Description */
+            description: string;
+            /** Lead */
+            lead: string;
+            /** Topics */
+            topics: string[];
+            /**
+             * Article Kind
+             * @enum {string}
+             */
+            article_kind: "evergreen_explainer" | "practical_guide" | "evidence_review" | "myth_busting" | "research_update" | "comparison" | "product_education";
+            /**
+             * Published At
+             * Format: date-time
+             */
+            published_at: string;
+            /**
+             * Updated At
+             * Format: date-time
+             */
+            updated_at: string;
+            /** Canonical Url */
+            canonical_url: string;
+            /** Body Sections */
+            body_sections: components["schemas"]["ArticleBodySection"][];
+            /**
+             * Search Intent
+             * @enum {string}
+             */
+            search_intent: "informational" | "how_to" | "comparison" | "definition" | "evidence" | "mixed";
+            /** Primary Query */
+            primary_query: string;
+            /** Secondary Queries */
+            secondary_queries: string[];
+            /**
+             * Risk Level
+             * @enum {string}
+             */
+            risk_level: "low" | "moderate" | "high" | "critical" | "unknown";
+            /**
+             * Evidence Level
+             * @enum {string}
+             */
+            evidence_level: "high" | "moderate" | "limited" | "preliminary" | "conflicting" | "unknown";
+            /** Claims */
+            claims: components["schemas"]["ArticleClaim"][];
+            /** Sources */
+            sources: components["schemas"]["ArticleSource"][];
+            /** Claim Source Matrix */
+            claim_source_matrix: components["schemas"]["ArticleClaimSourceMatrixItem"][];
+            author: components["schemas"]["ArticlePerson"];
+            editor: components["schemas"]["ArticlePerson"];
+            domain_reviewer: components["schemas"]["ArticlePerson"] | null;
+            /** Related Slugs */
+            related_slugs: string[];
+            /** Cta */
+            cta: {
+                [key: string]: string;
+            };
+            /** Content Version */
+            content_version: number;
+            /** Generated With Ai */
+            generated_with_ai: boolean;
+            /** Research Assistance */
+            research_assistance: boolean;
+        };
         /** WeeklyCheckInAdaptiveSummary */
         WeeklyCheckInAdaptiveSummary: {
             /**
@@ -8694,6 +8976,57 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["PublicExerciseDetail"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_public_articles_api_v1_public_articles_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WebArticleCard"][];
+                };
+            };
+        };
+    };
+    get_public_article_api_v1_public_articles__slug__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WebArticleResponse"];
                 };
             };
             /** @description Validation Error */
@@ -14810,6 +15143,40 @@ export interface operations {
             };
         };
     };
+    receive_hermes_web_article_intake_api_v1_hermes_articles_intake_post: {
+        parameters: {
+            query?: never;
+            header?: {
+                "X-Hermes-Key-Id"?: string | null;
+                "X-Hermes-Timestamp"?: string | null;
+                "X-Hermes-Nonce"?: string | null;
+                "X-Hermes-Signature"?: string | null;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HermesWebArticleIntakeResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
     health_health_get: {
         parameters: {
             query?: never;
@@ -14952,6 +15319,57 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    articles_index_page_articles_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+        };
+    };
+    article_page_articles__slug__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                slug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };

--- a/frontend/src/shared/api/types.ts
+++ b/frontend/src/shared/api/types.ts
@@ -8,6 +8,58 @@ export type Exercise = ApiSchemas['ExerciseCatalogItem'];
 export type ExerciseGuide = ApiSchemas['ExerciseGuide'];
 export type PublicExerciseSummary = ApiSchemas['PublicExerciseSummary'];
 export type PublicExerciseDetail = ApiSchemas['PublicExerciseDetail'];
+export type ArticleKind =
+  | 'evergreen_explainer'
+  | 'practical_guide'
+  | 'evidence_review'
+  | 'myth_busting'
+  | 'research_update'
+  | 'comparison'
+  | 'product_education';
+export interface WebArticleCard {
+  slug: string;
+  title: string;
+  description: string;
+  lead: string;
+  topics: string[];
+  article_kind: ArticleKind;
+  published_at: string;
+  updated_at: string;
+  canonical_url: string;
+}
+export interface WebArticle extends WebArticleCard {
+  body_sections: Array<{ heading: string; paragraphs: string[]; points: string[] }>;
+  search_intent: 'informational' | 'how_to' | 'comparison' | 'definition' | 'evidence' | 'mixed';
+  primary_query: string;
+  secondary_queries: string[];
+  risk_level: 'low' | 'moderate' | 'high' | 'critical' | 'unknown';
+  evidence_level: 'high' | 'moderate' | 'limited' | 'preliminary' | 'conflicting' | 'unknown';
+  claims: Array<{ claim_id: string; claim_text: string; normalized_claim: string }>;
+  sources: Array<{
+    source_id: string;
+    title: string;
+    publisher: string;
+    url: string;
+    source_type: string;
+    published_at: string | null;
+    limitations: string;
+  }>;
+  claim_source_matrix: Array<{
+    claim_id: string;
+    source_ids: string[];
+    support_level: 'supports' | 'partially_supports' | 'does_not_support' | 'unclear';
+    limitations: string;
+    review_status: 'pending' | 'verified' | 'blocked';
+  }>;
+  author: { name: string; type: 'Organization' | 'Person' };
+  editor: { name: string; type: 'Organization' | 'Person' };
+  domain_reviewer: { name: string; type: 'Organization' | 'Person' } | null;
+  related_slugs: string[];
+  cta: { destination: 'tma' | 'web' | 'landing'; label: string; description: string };
+  content_version: number;
+  generated_with_ai: boolean;
+  research_assistance: boolean;
+}
 export type ProgramTemplate = ApiSchemas['ProgramTemplateResponse'];
 export type ProgramTemplateCreate = ApiSchemas['ProgramTemplateCreate'];
 export type ProgramRecommendationRequest = ApiSchemas['ProgramRecommendationRequest'];

--- a/frontend/src/shared/seo/metadata.ts
+++ b/frontend/src/shared/seo/metadata.ts
@@ -5,6 +5,21 @@ export const NOINDEX_ROBOTS = 'noindex, nofollow';
 export const SOCIAL_IMAGE_PATH = '/assets/brand/yfc-social-preview.png';
 export const SOCIAL_IMAGE_ALT =
   'Your Fitness Coach — тренировки, питание и прогресс в браузере и Telegram';
+export const ARTICLE_INDEX_TITLE = 'Статьи о тренировках, питании и прогрессе — Your Fitness Coach';
+export const ARTICLE_INDEX_DESCRIPTION =
+  'Понятные статьи о тренировках, питании, спортивном питании и прогрессе: источники, ограничения и практический смысл без громких обещаний.';
+
+export interface PublicArticleSeoData {
+  slug: string;
+  title: string;
+  description: string;
+  canonical_url: string;
+  published_at: string;
+  updated_at: string;
+  author: { name: string; type: 'Organization' | 'Person' };
+  editor: { name: string; type: 'Organization' | 'Person' };
+  domain_reviewer: { name: string; type: 'Organization' | 'Person' } | null;
+}
 
 function upsertMeta(
   selector: string,
@@ -171,4 +186,72 @@ export function applyRouteMetadata(path: string, page?: PublicContentPage): void
     removeSocialMetadata();
   }
   replaceStructuredData(page);
+}
+
+export function applyArticleRouteMetadata(path: string, article?: PublicArticleSeoData): void {
+  const isIndex = path === '/articles';
+  const title = article?.title ?? (isIndex ? ARTICLE_INDEX_TITLE : 'Your Fitness Coach');
+  const description =
+    article?.description ?? (isIndex ? ARTICLE_INDEX_DESCRIPTION : 'Статья Your Fitness Coach.');
+  const canonical = article?.canonical_url ?? absoluteUrl('/articles');
+
+  document.title = title;
+  upsertMeta('meta[name="description"]', 'name', 'description', description);
+  upsertMeta('meta[name="robots"]', 'name', 'robots', INDEX_ROBOTS);
+  upsertMeta('meta[name="yandex"]', 'name', 'yandex', INDEX_ROBOTS);
+  let canonicalElement = document.head.querySelector<HTMLLinkElement>('link[rel="canonical"]');
+  if (!canonicalElement) {
+    canonicalElement = document.createElement('link');
+    canonicalElement.rel = 'canonical';
+    document.head.append(canonicalElement);
+  }
+  canonicalElement.href = canonical;
+  upsertMeta('meta[property="og:title"]', 'property', 'og:title', title);
+  upsertMeta('meta[property="og:description"]', 'property', 'og:description', description);
+  upsertMeta('meta[property="og:type"]', 'property', 'og:type', article ? 'article' : 'website');
+  upsertMeta('meta[property="og:url"]', 'property', 'og:url', canonical);
+  upsertMeta('meta[property="og:site_name"]', 'property', 'og:site_name', 'Your Fitness Coach');
+  upsertMeta('meta[property="og:locale"]', 'property', 'og:locale', 'ru_RU');
+  upsertMeta('meta[property="og:image"]', 'property', 'og:image', absoluteUrl(SOCIAL_IMAGE_PATH));
+  upsertMeta('meta[property="og:image:type"]', 'property', 'og:image:type', 'image/png');
+  upsertMeta('meta[property="og:image:width"]', 'property', 'og:image:width', '1200');
+  upsertMeta('meta[property="og:image:height"]', 'property', 'og:image:height', '630');
+  upsertMeta('meta[property="og:image:alt"]', 'property', 'og:image:alt', SOCIAL_IMAGE_ALT);
+  upsertMeta('meta[name="twitter:card"]', 'name', 'twitter:card', 'summary_large_image');
+  upsertMeta('meta[name="twitter:title"]', 'name', 'twitter:title', title);
+  upsertMeta('meta[name="twitter:description"]', 'name', 'twitter:description', description);
+  upsertMeta('meta[name="twitter:image"]', 'name', 'twitter:image', absoluteUrl(SOCIAL_IMAGE_PATH));
+  upsertMeta('meta[name="twitter:image:alt"]', 'name', 'twitter:image:alt', SOCIAL_IMAGE_ALT);
+
+  const graph: Record<string, unknown> = isIndex
+    ? {
+        '@type': 'CollectionPage',
+        name: title,
+        description,
+        url: canonical,
+      }
+    : {
+        '@type': 'Article',
+        headline: article?.title,
+        description,
+        url: canonical,
+        mainEntityOfPage: canonical,
+        datePublished: article?.published_at.slice(0, 10),
+        dateModified: article?.updated_at.slice(0, 10),
+        author: article?.author,
+        editor: article?.editor,
+        reviewedBy: article?.domain_reviewer ?? undefined,
+        publisher: { '@type': 'Organization', name: 'Your Fitness Coach' },
+      };
+  document.head
+    .querySelectorAll('script[type="application/ld+json"]')
+    .forEach((element) => element.remove());
+  const structured = document.createElement('script');
+  structured.type = 'application/ld+json';
+  structured.dataset.publicSeo = 'true';
+  structured.textContent = JSON.stringify({
+    '@context': 'https://schema.org',
+    ...graph,
+  }).replaceAll('</', '<\\/');
+  document.head.append(structured);
 }

--- a/frontend/tests/e2e/landing-production.spec.ts
+++ b/frontend/tests/e2e/landing-production.spec.ts
@@ -89,6 +89,7 @@ async function settleForScreenshot(page: Page) {
 test('landing keeps a minimal premium product story across themes and viewports', async ({
   page,
 }) => {
+  await page.route('**/api/v1/public/articles*', (route) => route.fulfill({ json: [] }));
   const browserErrors: string[] = [];
   page.on('console', (message) => {
     if (message.type() === 'error') browserErrors.push(message.text());

--- a/frontend/tests/e2e/performance-hardening.spec.ts
+++ b/frontend/tests/e2e/performance-hardening.spec.ts
@@ -87,6 +87,9 @@ test('Landing and login keep public/auth initial work bounded in mobile lab', as
     const page = await context.newPage();
     const consoleFailures = captureConsoleFailures(page);
     await observeLabCls(page);
+    if (route === '/') {
+      await page.route('**/api/v1/public/articles*', (request) => request.fulfill({ json: [] }));
+    }
     if (route === '/login') await installLoginApi(page);
 
     await page.goto(route);

--- a/frontend/tests/e2e/public-content.spec.ts
+++ b/frontend/tests/e2e/public-content.spec.ts
@@ -264,9 +264,10 @@ test('public article index and detail stay readable and crawlable across desktop
     await page.goto('/articles/strength-basics');
     await expect(page.getByRole('heading', { level: 1, name: publicArticle.title })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Источники' })).toBeVisible();
+    expect(publicArticle.sources).toHaveLength(1);
     await expect(page.getByRole('link', { name: 'Physical activity guidance' })).toHaveAttribute(
       'href',
-      publicArticle.sources[0].url,
+      publicArticle.sources[0]!.url,
     );
     await expect(page.getByRole('link', { name: 'Открыть Your Fitness Coach' })).toHaveAttribute(
       'href',

--- a/frontend/tests/e2e/public-content.spec.ts
+++ b/frontend/tests/e2e/public-content.spec.ts
@@ -43,6 +43,78 @@ const representativePages = [
   },
 ];
 
+const publicArticleCard = {
+  slug: 'strength-basics',
+  title: 'Основы силовых тренировок',
+  description: 'План, записи и ограничения для понятного старта.',
+  lead: 'Начните с посильного плана и записывайте факты.',
+  topics: ['training', 'strength_hypertrophy'],
+  article_kind: 'evergreen_explainer',
+  published_at: '2026-09-01T10:00:00Z',
+  updated_at: '2026-09-02T10:00:00Z',
+  canonical_url: 'http://127.0.0.1:4173/articles/strength-basics',
+};
+
+const publicArticle = {
+  ...publicArticleCard,
+  body_sections: [
+    {
+      heading: 'С чего начать',
+      paragraphs: ['Выберите посильные движения и заранее определите дни занятий.'],
+      points: ['Записывайте фактические подходы'],
+    },
+    {
+      heading: 'Как читать записи',
+      paragraphs: ['Сверяйте план и факт по нескольким занятиям.'],
+      points: [],
+    },
+  ],
+  search_intent: 'informational',
+  primary_query: 'как начать силовые тренировки',
+  secondary_queries: ['план силовых тренировок'],
+  risk_level: 'low',
+  evidence_level: 'moderate',
+  claims: [
+    {
+      claim_id: 'plan-context',
+      claim_text: 'Повторяемый план помогает сравнивать записи.',
+      normalized_claim: 'repeatable plan supports comparison',
+    },
+  ],
+  sources: [
+    {
+      source_id: 'source-guideline',
+      title: 'Physical activity guidance',
+      publisher: 'World Health Organization',
+      url: 'https://www.who.int/news-room/fact-sheets/detail/physical-activity',
+      source_type: 'official_organization',
+      published_at: null,
+      limitations: 'Общие рекомендации.',
+    },
+  ],
+  claim_source_matrix: [
+    {
+      claim_id: 'plan-context',
+      source_ids: ['source-guideline'],
+      support_level: 'supports',
+      limitations: 'Источник не задаёт индивидуальную программу.',
+      review_status: 'verified',
+    },
+  ],
+  author: { name: 'Your Fitness Coach', type: 'Organization' },
+  editor: { name: 'YFC Editorial Desk', type: 'Organization' },
+  domain_reviewer: null,
+  related_slugs: [],
+  cta: {
+    destination: 'web',
+    label: 'Открыть Your Fitness Coach',
+    description: 'Сохраняйте план и фактические результаты.',
+  },
+  content_version: 1,
+  generated_with_ai: true,
+  research_assistance: true,
+};
+
 test('legacy app knowledge URLs hand off to the equivalent Public Web article', async ({
   page,
 }) => {
@@ -155,6 +227,61 @@ test('публичные страницы сохраняют hierarchy и не �
         expect(heroGutters.right).toBeGreaterThanOrEqual(40);
       }
     }
+  }
+});
+
+test('public article index and detail stay readable and crawlable across desktop and mobile', async ({
+  page,
+}) => {
+  await page.route('**/api/v1/public/articles/strength-basics', async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify(publicArticle),
+    });
+  });
+  await page.route('**/api/v1/public/articles', async (route) => {
+    await route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify([publicArticleCard]),
+    });
+  });
+
+  for (const viewport of [
+    { width: 1440, height: 900 },
+    { width: 390, height: 844 },
+  ]) {
+    await page.setViewportSize(viewport);
+    await page.goto('/articles');
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'Статьи, которые помогают разобраться.' }),
+    ).toBeVisible();
+    await expect(page.getByRole('link', { name: /Основы силовых тренировок/ })).toHaveAttribute(
+      'href',
+      '/articles/strength-basics',
+    );
+    await expect(page.locator('meta[name="robots"]')).toHaveAttribute('content', 'index, follow');
+
+    await page.goto('/articles/strength-basics');
+    await expect(page.getByRole('heading', { level: 1, name: publicArticle.title })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Источники' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Physical activity guidance' })).toHaveAttribute(
+      'href',
+      publicArticle.sources[0].url,
+    );
+    await expect(page.getByRole('link', { name: 'Открыть Your Fitness Coach' })).toHaveAttribute(
+      'href',
+      '/app',
+    );
+    await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+      'href',
+      publicArticle.canonical_url,
+    );
+    expect(
+      await page.evaluate(() => ({
+        content: document.documentElement.scrollWidth,
+        viewport: window.innerWidth,
+      })),
+    ).toEqual({ content: viewport.width, viewport: viewport.width });
   }
 });
 

--- a/frontend/tests/unit/pages/landing/LandingPage.test.tsx
+++ b/frontend/tests/unit/pages/landing/LandingPage.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import LandingPage, {
   appUrlForHostname,
@@ -12,10 +13,14 @@ import {
 import { NavigationProvider } from '../../../../src/shared/navigation/router';
 
 function renderLanding() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
   return render(
-    <NavigationProvider>
-      <LandingPage />
-    </NavigationProvider>,
+    <QueryClientProvider client={queryClient}>
+      <NavigationProvider>
+        <LandingPage />
+      </NavigationProvider>
+    </QueryClientProvider>,
   );
 }
 

--- a/frontend/tests/unit/pages/public/ArticlesPage.test.tsx
+++ b/frontend/tests/unit/pages/public/ArticlesPage.test.tsx
@@ -152,8 +152,12 @@ describe('ArticlesPage', () => {
   it('renders article evidence, related links, CTA and route metadata', async () => {
     renderPath('/articles/strength-basics');
 
-    expect(await screen.findByRole('heading', { level: 1, name: article.title })).toBeInTheDocument();
-    expect(screen.getByText('Выберите посильные движения и заранее определите дни занятий.')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { level: 1, name: article.title }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Выберите посильные движения и заранее определите дни занятий.'),
+    ).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Источники' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Physical activity guidance' })).toHaveAttribute(
       'href',

--- a/frontend/tests/unit/pages/public/ArticlesPage.test.tsx
+++ b/frontend/tests/unit/pages/public/ArticlesPage.test.tsx
@@ -1,0 +1,189 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ArticlesPage from '../../../../src/pages/public/ArticlesPage';
+import { api } from '../../../../src/shared/api/client';
+import type { WebArticle, WebArticleCard } from '../../../../src/shared/api/types';
+import { NavigationProvider } from '../../../../src/shared/navigation/router';
+
+vi.mock('../../../../src/shared/api/client', () => ({
+  api: vi.fn(),
+  ApiError: class ApiError extends Error {
+    status: number;
+
+    constructor(message: string, status: number) {
+      super(message);
+      this.status = status;
+    }
+  },
+}));
+
+const mockedApi = vi.mocked(api);
+
+const articleCard: WebArticleCard = {
+  slug: 'strength-basics',
+  title: 'Основы силовых тренировок',
+  description: 'План, записи и ограничения для понятного старта.',
+  lead: 'Начните с посильного плана и записывайте факты.',
+  topics: ['training', 'strength_hypertrophy'],
+  article_kind: 'evergreen_explainer',
+  published_at: '2026-09-01T10:00:00Z',
+  updated_at: '2026-09-02T10:00:00Z',
+  canonical_url: 'https://your-fitness-coach.ru/articles/strength-basics',
+};
+
+const relatedCard: WebArticleCard = {
+  ...articleCard,
+  slug: 'recovery-basics',
+  title: 'Восстановление после тренировки',
+  canonical_url: 'https://your-fitness-coach.ru/articles/recovery-basics',
+};
+
+const sourceUrl = 'https://www.who.int/news-room/fact-sheets/detail/physical-activity';
+
+const article: WebArticle = {
+  ...articleCard,
+  body_sections: [
+    {
+      heading: 'С чего начать',
+      paragraphs: ['Выберите посильные движения и заранее определите дни занятий.'],
+      points: ['Записывайте фактические подходы'],
+    },
+    {
+      heading: 'Как читать записи',
+      paragraphs: ['Сверяйте план и факт по нескольким занятиям.'],
+      points: [],
+    },
+  ],
+  search_intent: 'informational',
+  primary_query: 'как начать силовые тренировки',
+  secondary_queries: ['план силовых тренировок'],
+  risk_level: 'low',
+  evidence_level: 'moderate',
+  claims: [
+    {
+      claim_id: 'plan-context',
+      claim_text: 'Повторяемый план помогает сравнивать записи.',
+      normalized_claim: 'repeatable plan supports comparison',
+    },
+  ],
+  sources: [
+    {
+      source_id: 'source-guideline',
+      title: 'Physical activity guidance',
+      publisher: 'World Health Organization',
+      url: 'https://www.who.int/news-room/fact-sheets/detail/physical-activity',
+      source_type: 'official_organization',
+      published_at: null,
+      limitations: 'Общие рекомендации.',
+    },
+  ],
+  claim_source_matrix: [
+    {
+      claim_id: 'plan-context',
+      source_ids: ['source-guideline'],
+      support_level: 'supports',
+      limitations: 'Источник не задаёт индивидуальную программу.',
+      review_status: 'verified',
+    },
+  ],
+  author: { name: 'Your Fitness Coach', type: 'Organization' },
+  editor: { name: 'YFC Editorial Desk', type: 'Organization' },
+  domain_reviewer: null,
+  related_slugs: ['recovery-basics'],
+  cta: {
+    destination: 'web',
+    label: 'Открыть Your Fitness Coach',
+    description: 'Сохраняйте план и фактические результаты.',
+  },
+  content_version: 1,
+  generated_with_ai: true,
+  research_assistance: true,
+};
+
+function renderPath(path: string) {
+  window.history.replaceState({}, '', path);
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <NavigationProvider>
+        <ArticlesPage />
+      </NavigationProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('ArticlesPage', () => {
+  beforeEach(() => {
+    mockedApi.mockImplementation((path: string) => {
+      if (path === '/api/v1/public/articles') return Promise.resolve([articleCard, relatedCard]);
+      if (path === '/api/v1/public/articles/strength-basics') return Promise.resolve(article);
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.head
+      .querySelectorAll(
+        'meta[name="description"], meta[name="robots"], meta[name="yandex"], meta[name^="twitter:"], meta[property^="og:"], link[rel="canonical"], script[type="application/ld+json"]',
+      )
+      .forEach((element) => element.remove());
+    window.history.replaceState({}, '', '/');
+    vi.restoreAllMocks();
+  });
+
+  it('renders a crawlable article index with ordinary internal links', async () => {
+    renderPath('/articles');
+
+    expect(
+      await screen.findByRole('heading', { name: 'Статьи, которые помогают разобраться.' }),
+    ).toBeInTheDocument();
+    expect(await screen.findByRole('link', { name: /Основы силовых тренировок/ })).toHaveAttribute(
+      'href',
+      '/articles/strength-basics',
+    );
+    expect(document.querySelector('meta[name="robots"]')).toHaveAttribute(
+      'content',
+      'index, follow',
+    );
+  });
+
+  it('renders article evidence, related links, CTA and route metadata', async () => {
+    renderPath('/articles/strength-basics');
+
+    expect(await screen.findByRole('heading', { level: 1, name: article.title })).toBeInTheDocument();
+    expect(screen.getByText('Выберите посильные движения и заранее определите дни занятий.')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Источники' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Physical activity guidance' })).toHaveAttribute(
+      'href',
+      sourceUrl,
+    );
+    expect(screen.getByRole('link', { name: /Восстановление после тренировки/ })).toHaveAttribute(
+      'href',
+      '/articles/recovery-basics',
+    );
+    expect(screen.getByRole('link', { name: 'Открыть Your Fitness Coach' })).toHaveAttribute(
+      'href',
+      '/app',
+    );
+    expect(document.querySelector('link[rel="canonical"]')).toHaveAttribute(
+      'href',
+      article.canonical_url,
+    );
+    expect(document.querySelector('meta[property="og:type"]')).toHaveAttribute(
+      'content',
+      'article',
+    );
+    const structuredData = document.querySelector<HTMLScriptElement>(
+      'script[type="application/ld+json"][data-public-seo]',
+    );
+    expect(structuredData).not.toBeNull();
+    expect(JSON.parse(structuredData?.textContent ?? '{}')).toMatchObject({
+      '@type': 'Article',
+      headline: article.title,
+      datePublished: article.published_at.slice(0, 10),
+      dateModified: article.updated_at.slice(0, 10),
+    });
+  });
+});

--- a/frontend/tests/unit/shared/analytics/productEvents.test.ts
+++ b/frontend/tests/unit/shared/analytics/productEvents.test.ts
@@ -222,6 +222,39 @@ describe('product event contract', () => {
     ).toBe(true);
   });
 
+  it('keeps public article analytics limited to a slug and canonical CTA destination', () => {
+    expect(
+      isProductEvent({
+        name: 'article_viewed',
+        surface: 'mobile_web',
+        content_key: 'kak-nachat-silovye-trenirovki',
+      }),
+    ).toBe(true);
+    expect(
+      isProductEvent({
+        name: 'article_cta_clicked',
+        surface: 'desktop_web',
+        content_key: 'kak-nachat-silovye-trenirovki',
+        destination: 'tma',
+      }),
+    ).toBe(true);
+    expect(
+      isProductEvent({
+        name: 'article_viewed',
+        surface: 'desktop_web',
+        content_key: 'article?query=private',
+      }),
+    ).toBe(false);
+    expect(
+      isProductEvent({
+        name: 'article_cta_clicked',
+        surface: 'desktop_web',
+        content_key: 'article-slug',
+        destination: 'https://example.com/private',
+      } as unknown as ProductEvent),
+    ).toBe(false);
+  });
+
   it('rejects unknown schema versions, legacy surfaces and malformed timestamps', () => {
     const envelope = {
       name: 'workout_started',


### PR DESCRIPTION
## Summary

- add public `/articles` and `/articles/<slug>` routes with crawlable metadata, canonical URLs, JSON-LD, sitemap integration, and safe public status handling;
- add an evidence-bound editorial lifecycle with immutable revisions, corrections, archive/retraction, source provenance, reviewer decisions, and bounded Hermes intake;
- keep landing article discovery curated and privacy-safe, with no live Hermes/provider setup, external SEO tooling, or article publication in this task.

## Verification

- exact local pre-push gate passed for `e6230d0bf453a12777ca96e701c3dc2f6aff59b4`;
- backend: `903 passed, 1 skipped`;
- frontend E2E: `233 passed, 4 skipped`;
- migrated PostgreSQL API smoke: `2 passed`; migrated browser smoke: `1 passed`;
- dependency audits, policy tests, CI contract, and deployment contract passed.

The editorial workflow remains default-off until an owner/editor/domain review and a separately authorized first real publication.
