### PR TITLE
[Task 129] Fix shared-host Hermes launchers

### DIFF
--- a/deploy/hermes-discovery/README.md
+++ b/deploy/hermes-discovery/README.md
@@ -100,7 +100,6 @@ install -o root -g root -m 0644 hermes-discovery.target /etc/systemd/system/herm
 install -o root -g root -m 0644 hermes-discovery.timer /etc/systemd/system/hermes-discovery.timer
 systemd-analyze verify /etc/systemd/system/hermes-discovery.service /etc/systemd/system/hermes-worker-drain.service /etc/systemd/system/hermes-discovery.target /etc/systemd/system/hermes-discovery.timer
 systemctl daemon-reload
-systemctl enable hermes-discovery.timer
 ```
 
 До включения timer проверить exact boundary без запуска job:
@@ -113,8 +112,14 @@ systemctl cat hermes-discovery.service hermes-worker-drain.service
 systemctl status hermes-discovery.timer --no-pager
 ```
 
-`systemctl start hermes-discovery.target` выполняется только после отдельного owner approval на
-внешний Gate A и подготовленных credentials; до этого timer можно только установить и проверить.
+После отдельного owner approval на внешний Gate A и подготовки credentials активировать schedule
+нужно одной командой: `systemctl enable --now hermes-discovery.timer`. Она одновременно включает
+timer на boot и запускает его в текущем boot; затем для немедленного bounded smoke можно выполнить
+`systemctl start hermes-discovery.target`. До этого timer можно только установить и проверить.
+
+Если `/var/lib/hermes/state.json` был создан предыдущей дефектной версией от `root:root`, перед
+первым запуском после обновления восстановить владельца state для контейнерного UID/GID:
+`chown -R 10000:10000 /var/lib/hermes`.
 
 `hermes_worker_drain.py` — host-side launcher; secrets передаются только worker container.
 Discovery service не получает ни provider key, ни YFC HMAC secret. Рабочий runtime запускается

--- a/deploy/hermes-discovery/README.md
+++ b/deploy/hermes-discovery/README.md
@@ -68,7 +68,7 @@ state не создаёт новый idempotency key автоматически.
 только после bounded age threshold. Missed timer run не replay'ится (`Persistent=false`), а
 следующий запуск снова применяет dedupe без publication quota.
 
-## Установка после approval (не выполняется этим PR)
+## Установка после Gate A (не выполняется этим PR)
 
 1. Из exact release bundle сгенерировать definitions из canonical registry и зафиксировать
    SHA-256 самого deployment-файла.
@@ -76,14 +76,45 @@ state не создаёт новый idempotency key автоматически.
    этот SHA-256 как `HERMES_DISCOVERY_DEFINITIONS_SHA256`; floating `latest` запрещён.
 3. Создать отдельную Linux x86_64 Hermes VM и `/etc/hermes/source-definitions.json` (0444),
    `/etc/hermes/worker.env` (0600), `/var/lib/hermes` (0700). Для bind mount каталога
-   container UID/GID `10000:10000` должны иметь запись в `/var/lib/hermes`; host service account
-   `hermes` должен быть согласован с этим UID/GID и иметь только требуемый Docker/rootless-Docker
-   доступ. VM не содержит YFC repo/runtime/DB.
+   container UID/GID `10000:10000` должны иметь запись в `/var/lib/hermes`. Пользователь `hermes`
+   должен иметь UID/GID `10000:10000`, но не должен состоять в группе `docker` и не должен видеть
+   `/var/run/docker.sock`. Оба host-side systemd launcher-а запускаются от `root` только для
+   точной команды Docker; внутри обоих контейнеров остаются `--user 10000:10000`, `--read-only`,
+   `--cap-drop ALL` и `no-new-privileges`, без socket mount. VM не содержит YFC repo/runtime/DB.
+   Обе units используют одну owner-approved сеть `HERMES_DOCKER_NETWORK=hermes-net`; имя для
+   worker drain дополнительно проверяется allowlist-ом `hermes-*` и встроенные Docker-сети
+   отвергаются.
 4. Настроить default-deny egress firewall: exact approved source hosts для discovery, exact
    Groq host и exact YFC intake host/path для worker; deny Telegram Bot API, PostgreSQL/Redis,
    SSH, metadata, registry и arbitrary internet. Inbound Hermes ports отсутствуют.
 5. Включить timer только после Gate A и owner-approved credentials. `HERMES_INTAKE_ENABLED`
    остаётся false до отдельного approval; production `NEWS_*` flags не меняются.
+
+После рендера шаблонов с exact image digests и definitions digest установить units можно так
+(команды выполняются на Hermes VM, не в этом локальном PR):
+
+```sh
+install -o root -g root -m 0644 hermes-discovery.service /etc/systemd/system/hermes-discovery.service
+install -o root -g root -m 0644 hermes-worker-drain.service /etc/systemd/system/hermes-worker-drain.service
+install -o root -g root -m 0644 hermes-discovery.target /etc/systemd/system/hermes-discovery.target
+install -o root -g root -m 0644 hermes-discovery.timer /etc/systemd/system/hermes-discovery.timer
+systemd-analyze verify /etc/systemd/system/hermes-discovery.service /etc/systemd/system/hermes-worker-drain.service /etc/systemd/system/hermes-discovery.target /etc/systemd/system/hermes-discovery.timer
+systemctl daemon-reload
+systemctl enable hermes-discovery.timer
+```
+
+До включения timer проверить exact boundary без запуска job:
+
+```sh
+id hermes
+id -nG hermes
+docker network inspect hermes-net
+systemctl cat hermes-discovery.service hermes-worker-drain.service
+systemctl status hermes-discovery.timer --no-pager
+```
+
+`systemctl start hermes-discovery.target` выполняется только после отдельного owner approval на
+внешний Gate A и подготовленных credentials; до этого timer можно только установить и проверить.
 
 `hermes_worker_drain.py` — host-side launcher; secrets передаются только worker container.
 Discovery service не получает ни provider key, ни YFC HMAC secret. Рабочий runtime запускается

--- a/deploy/hermes-discovery/discovery_runner.py
+++ b/deploy/hermes-discovery/discovery_runner.py
@@ -891,7 +891,34 @@ def _load_state(path: Path) -> dict[str, Any]:
     return document
 
 
+def _file_owner(path: Path) -> tuple[int, int] | None:
+    try:
+        metadata = path.stat()
+    except FileNotFoundError:
+        return None
+    uid = getattr(metadata, "st_uid", None)
+    gid = getattr(metadata, "st_gid", None)
+    if isinstance(uid, int) and isinstance(gid, int):
+        return uid, gid
+    return None
+
+
+def _restore_file_owner(path: Path, owner: tuple[int, int] | None) -> None:
+    if owner is None or _file_owner(path) == owner:
+        return
+    chown = getattr(os, "chown", None)
+    if chown is None:
+        raise DiscoveryError("state_owner_preservation_unsupported")
+    try:
+        chown(path, *owner)
+    except OSError as exc:
+        raise DiscoveryError("state_owner_preservation_failed") from exc
+    if _file_owner(path) != owner:
+        raise DiscoveryError("state_owner_preservation_failed")
+
+
 def _atomic_write_json(path: Path, document: Mapping[str, Any]) -> None:
+    owner = _file_owner(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary: Path | None = None
     try:
@@ -908,6 +935,7 @@ def _atomic_write_json(path: Path, document: Mapping[str, Any]) -> None:
             handle.flush()
             os.fsync(handle.fileno())
         os.chmod(temporary, 0o600)
+        _restore_file_owner(temporary, owner)
         os.replace(temporary, path)
     finally:
         if temporary is not None and temporary.exists():

--- a/deploy/hermes-discovery/hermes_worker_drain.py
+++ b/deploy/hermes-discovery/hermes_worker_drain.py
@@ -27,9 +27,12 @@ from discovery_runner import (
 )
 
 IMAGE_DIGEST_PATTERN = re.compile(r"^[^\s@]+@sha256:[0-9a-f]{64}$")
+DOCKER_NETWORK_NAME_PATTERN = re.compile(r"^hermes-[a-z0-9][a-z0-9_.-]{0,56}$")
 JOB_NAME_PATTERN = re.compile(r"^[0-9a-f]{64}\.json$")
 DEFAULT_MAX_JOBS = 1
 MAX_JOBS = 20
+DEFAULT_DOCKER_NETWORK = "hermes-net"
+RESERVED_DOCKER_NETWORK_NAMES = frozenset({"bridge", "default", "host", "none"})
 WORKER_ENV_NAMES = (
     "HERMES_PROVIDER_BASE_URL",
     "HERMES_PROVIDER_API_KEY",
@@ -91,14 +94,31 @@ def _worker_image() -> str:
     return value
 
 
-def _worker_command(job: Path, *, image: str, source_allowlist: str) -> list[str]:
+def _validate_docker_network(value: str) -> str:
+    network = value.strip()
+    if (
+        network.casefold() in RESERVED_DOCKER_NETWORK_NAMES
+        or DOCKER_NETWORK_NAME_PATTERN.fullmatch(network) is None
+    ):
+        raise DrainError("hermes_docker_network_invalid")
+    return network
+
+
+def _docker_network() -> str:
+    return _validate_docker_network(os.environ.get("HERMES_DOCKER_NETWORK", DEFAULT_DOCKER_NETWORK))
+
+
+def _worker_command(
+    job: Path, *, image: str, source_allowlist: str, network: str | None = None
+) -> list[str]:
     job_dir = job.parent
+    docker_network = _validate_docker_network(network) if network is not None else _docker_network()
     command = [
         "docker",
         "run",
         "--rm",
         "--network",
-        "bridge",
+        docker_network,
         "--read-only",
         "--tmpfs",
         "/tmp:rw,noexec,nosuid,nodev,size=64m,uid=10000,gid=10000,mode=700",
@@ -109,7 +129,7 @@ def _worker_command(job: Path, *, image: str, source_allowlist: str) -> list[str
         "--security-opt",
         "no-new-privileges:true",
         "--pids-limit",
-        "64",
+        "32",
         "--memory",
         "512m",
         "--cpus",
@@ -155,6 +175,7 @@ def drain_once() -> dict[str, Any]:
     state_dir = _state_dir()
     outbox_dir = _outbox_dir()
     image = _worker_image()
+    network = _docker_network()
     max_jobs = _bounded_int("HERMES_WORKER_MAX_JOBS", DEFAULT_MAX_JOBS, 1, MAX_JOBS)
     timeout_seconds = _bounded_int("HERMES_WORKER_TIMEOUT_SECONDS", 120, 10, 300)
     stale_seconds = _bounded_int("HERMES_DISCOVERY_LOCK_STALE_SECONDS", 900, 30, 86_400)
@@ -182,7 +203,12 @@ def drain_once() -> dict[str, Any]:
         for job in jobs:
             try:
                 completed = subprocess.run(
-                    _worker_command(job, image=image, source_allowlist=source_allowlist),
+                    _worker_command(
+                        job,
+                        image=image,
+                        source_allowlist=source_allowlist,
+                        network=network,
+                    ),
                     capture_output=True,
                     text=True,
                     check=False,

--- a/deploy/hermes-discovery/systemd/hermes-discovery.service.template
+++ b/deploy/hermes-discovery/systemd/hermes-discovery.service.template
@@ -5,10 +5,13 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-User=hermes
-Group=hermes
+# The host-side launcher is the only root process here.  The container itself
+# remains non-root and has no Docker socket or host tooling mounted into it.
+User=root
+Group=root
 UMask=0077
-ExecStart=/usr/bin/docker run --rm --name hermes-discovery-once --network bridge --read-only --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m,uid=10000,gid=10000,mode=700 --mount type=bind,source=/etc/hermes/source-definitions.json,target=/opt/hermes/config/source-definitions.json,readonly --mount type=bind,source=/var/lib/hermes,target=/opt/data --cap-drop ALL --security-opt no-new-privileges:true --pids-limit 64 --memory 512m --cpus 0.50 --user 10000:10000 --env HERMES_DISCOVERY_MODE=external --env HERMES_DISCOVERY_MAX_SOURCES=20 --env HERMES_DISCOVERY_MAX_CONCURRENCY=4 --env HERMES_DISCOVERY_TIMEOUT_SECONDS=10 --env HERMES_DISCOVERY_MAX_RESPONSE_BYTES=524288 --env HERMES_DISCOVERY_MAX_ITEMS_PER_SOURCE=20 --env HERMES_DISCOVERY_DEFINITIONS=/opt/hermes/config/source-definitions.json --env HERMES_DISCOVERY_DEFINITIONS_SHA256=@SOURCE_DEFINITIONS_SHA256@ @DISCOVERY_IMAGE@
+Environment=HERMES_DOCKER_NETWORK=hermes-net
+ExecStart=/usr/bin/docker run --rm --name hermes-discovery-once --network=${HERMES_DOCKER_NETWORK} --read-only --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m,uid=10000,gid=10000,mode=700 --mount type=bind,source=/etc/hermes/source-definitions.json,target=/opt/hermes/config/source-definitions.json,readonly --mount type=bind,source=/var/lib/hermes,target=/opt/data --cap-drop ALL --security-opt no-new-privileges:true --pids-limit 32 --memory 256m --cpus 0.25 --user 10000:10000 --env HERMES_DISCOVERY_MODE=external --env HERMES_DISCOVERY_MAX_SOURCES=20 --env HERMES_DISCOVERY_MAX_CONCURRENCY=4 --env HERMES_DISCOVERY_TIMEOUT_SECONDS=10 --env HERMES_DISCOVERY_MAX_RESPONSE_BYTES=524288 --env HERMES_DISCOVERY_MAX_ITEMS_PER_SOURCE=20 --env HERMES_DISCOVERY_DEFINITIONS=/opt/hermes/config/source-definitions.json --env HERMES_DISCOVERY_DEFINITIONS_SHA256=@SOURCE_DEFINITIONS_SHA256@ @DISCOVERY_IMAGE@ --once
 TimeoutStartSec=180s
 RuntimeMaxSec=180s
 KillMode=mixed
@@ -21,6 +24,6 @@ ReadWritePaths=/var/lib/hermes
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 RestrictSUIDSGID=true
 LockPersonality=true
-TasksMax=64
-MemoryMax=768M
-CPUQuota=75%
+TasksMax=32
+MemoryMax=256M
+CPUQuota=25%

--- a/deploy/hermes-discovery/systemd/hermes-worker-drain.service.template
+++ b/deploy/hermes-discovery/systemd/hermes-worker-drain.service.template
@@ -5,10 +5,13 @@ After=hermes-discovery.service
 
 [Service]
 Type=oneshot
-User=hermes
-Group=hermes
+# The host-side launcher needs Docker access and is intentionally root-owned.
+# The spawned worker remains UID/GID 10000:10000; no Docker socket is mounted.
+User=root
+Group=root
 UMask=0077
 EnvironmentFile=/etc/hermes/worker.env
+Environment=HERMES_DOCKER_NETWORK=hermes-net
 Environment=HERMES_DISCOVERY_DEFINITIONS=/etc/hermes/source-definitions.json
 Environment=HERMES_DISCOVERY_DEFINITIONS_SHA256=@SOURCE_DEFINITIONS_SHA256@
 Environment=HERMES_DISCOVERY_STATE_DIR=/var/lib/hermes
@@ -29,6 +32,6 @@ ReadWritePaths=/var/lib/hermes
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 RestrictSUIDSGID=true
 LockPersonality=true
-TasksMax=64
-MemoryMax=768M
-CPUQuota=75%
+TasksMax=32
+MemoryMax=512M
+CPUQuota=50%

--- a/deploy/hermes-editorial-worker/.env.example
+++ b/deploy/hermes-editorial-worker/.env.example
@@ -1,6 +1,8 @@
 # Local/mock contract only. Keep this mode until a separate Gate A approval.
 HERMES_HOME=/opt/data
 HERMES_SOURCE_ALLOWLIST=journal-one
+# Must remain the same owner-approved isolated network as the discovery unit.
+HERMES_DOCKER_NETWORK=hermes-net
 HERMES_PROVIDER_MODE=local_mock
 HERMES_PROVIDER_BASE_URL=http://127.0.0.1:18080/v1
 HERMES_PROVIDER_API_KEY=

--- a/docs/telegram-news-editorial-automation.md
+++ b/docs/telegram-news-editorial-automation.md
@@ -354,8 +354,12 @@ non-global адресов, revalidation каждого redirect, MIME/size/time/
 JavaScript/browser. Host firewall должен быть default-deny и отдельно разрешать только approved
 source hosts, Groq и YFC intake.
 До установки нужен host preflight: account `hermes` и bind-mounted `/var/lib/hermes` должны
-согласовать UID/GID `10000:10000` контейнеров, а доступ к Docker должен быть явно ограничен
-rootless/systemd policy; этот PR не устанавливает Docker или VM.
+согласовать UID/GID `10000:10000` контейнеров, но `hermes` не должен иметь membership в группе
+`docker` или доступ к `/var/run/docker.sock`. Host-side discovery/drain units запускаются от
+`root` только для точных Docker/launcher commands; сами контейнеры остаются non-root с
+`--user 10000:10000`, read-only rootfs, cap-drop ALL и no-new-privileges. Обе units закрепляют
+одну owner-approved Docker network `hermes-net`; worker drain валидирует только bounded `hermes-*`
+имя и отвергает встроенные `bridge`/`host`/`none` сети. Этот PR не устанавливает Docker или VM.
 
 State — только bounded hashes, fetch metadata, reason codes и candidate metadata. Stable dedupe key
 использует `source_id + canonical URL + content hash + event date`; restart/uncertain state не

--- a/scripts/hermes_discovery.py
+++ b/scripts/hermes_discovery.py
@@ -68,6 +68,8 @@ def provenance() -> None:
     drain_unit = (root / "systemd" / "hermes-worker-drain.service.template").read_text(
         encoding="utf-8"
     )
+    drain_path = root / "hermes_worker_drain.py"
+    drain_source = drain_path.read_text(encoding="utf-8")
     timer_unit = (root / "systemd" / "hermes-discovery.timer").read_text(encoding="utf-8")
     tree = ast.parse(runner_path.read_text(encoding="utf-8"), filename=str(runner_path))
     imports = {
@@ -96,6 +98,54 @@ def provenance() -> None:
         "systemd.definitions_digest": all(
             "HERMES_DISCOVERY_DEFINITIONS_SHA256=@SOURCE_DEFINITIONS_SHA256@" in unit
             for unit in (discovery_unit, drain_unit)
+        ),
+        "systemd.discovery_once": "@DISCOVERY_IMAGE@ --once" in discovery_unit,
+        "systemd.discovery_network": (
+            "Environment=HERMES_DOCKER_NETWORK=hermes-net" in discovery_unit
+            and "--network=${HERMES_DOCKER_NETWORK}" in discovery_unit
+        ),
+        "systemd.drain_network": "Environment=HERMES_DOCKER_NETWORK=hermes-net" in drain_unit,
+        "systemd.shared_host_root_launchers": all(
+            "User=root" in unit
+            and "Group=root" in unit
+            and "User=hermes" not in unit
+            and "docker.sock" not in unit
+            for unit in (discovery_unit, drain_unit)
+        ),
+        "systemd.discovery_container_hardening": all(
+            token in discovery_unit
+            for token in (
+                "--read-only",
+                "--cap-drop ALL",
+                "--security-opt no-new-privileges:true",
+                "--pids-limit 32",
+                "--memory 256m",
+                "--cpus 0.25",
+                "--user 10000:10000",
+            )
+        ),
+        "systemd.discovery_no_floating_image": ":latest" not in discovery_unit,
+        "systemd.discovery_no_bridge": "--network bridge" not in discovery_unit,
+        "systemd.drain_service_resources": all(
+            token in drain_unit for token in ("TasksMax=32", "MemoryMax=512M", "CPUQuota=50%")
+        ),
+        "worker.docker_network_validation": all(
+            token in drain_source
+            for token in (
+                "HERMES_DOCKER_NETWORK",
+                "_validate_docker_network",
+                '"--network",',
+                '"--user",\n        "10000:10000"',
+            )
+        ),
+        "worker.no_hardcoded_bridge": '"--network",\n        "bridge"' not in drain_source,
+        "worker.resources": all(
+            token in drain_source
+            for token in (
+                '"--pids-limit",\n        "32"',
+                '"--memory",\n        "512m"',
+                '"--cpus",\n        "0.50"',
+            )
         ),
         "systemd.no_missed_run_replay": "Persistent=false" in timer_unit,
         "source.runner_imports": not imports.intersection(forbidden_imports),

--- a/tests/integration/hermes_editorial_worker/test_discovery_contract.py
+++ b/tests/integration/hermes_editorial_worker/test_discovery_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 import json
+import os
 import sys
 from pathlib import Path
 from subprocess import CompletedProcess
@@ -28,6 +29,26 @@ GENERATOR_SPEC.loader.exec_module(GENERATOR_MODULE)
 
 def _systemd_unit(name: str) -> str:
     return (SYSTEMD_ROOT / name).read_text(encoding="utf-8")
+
+
+def test_state_rewrite_preserves_existing_owner(tmp_path: Path) -> None:
+    state_path = tmp_path / "state.json"
+    state_path.write_text('{"before": true}\n', encoding="utf-8")
+    before = os.stat(state_path)
+
+    discovery_runner._atomic_write_json(state_path, {"after": True})
+
+    after = os.stat(state_path)
+    if hasattr(before, "st_uid") and hasattr(before, "st_gid"):
+        assert (after.st_uid, after.st_gid) == (before.st_uid, before.st_gid)
+    assert json.loads(state_path.read_text(encoding="utf-8")) == {"after": True}
+
+
+def test_install_instructions_start_enabled_timer_after_gate_a() -> None:
+    readme = (DISCOVERY_ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "systemctl enable --now hermes-discovery.timer" in readme
+    assert "systemctl enable hermes-discovery.timer\n" not in readme
 
 
 def test_shared_host_systemd_launchers_are_root_only_and_container_hardening_is_explicit() -> None:

--- a/tests/integration/hermes_editorial_worker/test_discovery_contract.py
+++ b/tests/integration/hermes_editorial_worker/test_discovery_contract.py
@@ -11,6 +11,7 @@ import pytest
 
 WORKSPACE = Path(__file__).resolve().parents[3]
 DISCOVERY_ROOT = WORKSPACE / "deploy" / "hermes-discovery"
+SYSTEMD_ROOT = DISCOVERY_ROOT / "systemd"
 sys.path.insert(0, str(DISCOVERY_ROOT))
 
 import discovery_runner  # noqa: E402
@@ -23,6 +24,96 @@ GENERATOR_SPEC = importlib.util.spec_from_file_location(
 assert GENERATOR_SPEC is not None and GENERATOR_SPEC.loader is not None
 GENERATOR_MODULE = importlib.util.module_from_spec(GENERATOR_SPEC)
 GENERATOR_SPEC.loader.exec_module(GENERATOR_MODULE)
+
+
+def _systemd_unit(name: str) -> str:
+    return (SYSTEMD_ROOT / name).read_text(encoding="utf-8")
+
+
+def test_shared_host_systemd_launchers_are_root_only_and_container_hardening_is_explicit() -> None:
+    discovery_unit = _systemd_unit("hermes-discovery.service.template")
+    drain_unit = _systemd_unit("hermes-worker-drain.service.template")
+
+    assert "User=root" in discovery_unit
+    assert "Group=root" in discovery_unit
+    assert "User=hermes" not in discovery_unit
+    assert "Group=hermes" not in discovery_unit
+    assert "Environment=HERMES_DOCKER_NETWORK=hermes-net" in discovery_unit
+    assert "--network=${HERMES_DOCKER_NETWORK}" in discovery_unit
+    assert "@DISCOVERY_IMAGE@ --once" in discovery_unit
+    assert "--read-only" in discovery_unit
+    assert "--cap-drop ALL" in discovery_unit
+    assert "--security-opt no-new-privileges:true" in discovery_unit
+    assert "--user 10000:10000" in discovery_unit
+    assert "--pids-limit 32" in discovery_unit
+    assert "--memory 256m" in discovery_unit
+    assert "--cpus 0.25" in discovery_unit
+    assert "TasksMax=32" in discovery_unit
+    assert "MemoryMax=256M" in discovery_unit
+    assert "CPUQuota=25%" in discovery_unit
+
+    assert "User=root" in drain_unit
+    assert "Group=root" in drain_unit
+    assert "User=hermes" not in drain_unit
+    assert "Group=hermes" not in drain_unit
+    assert "Environment=HERMES_DOCKER_NETWORK=hermes-net" in drain_unit
+    assert "ExecStart=/usr/bin/python3 /opt/hermes/hermes_worker_drain.py --once" in drain_unit
+    assert "TasksMax=32" in drain_unit
+    assert "MemoryMax=512M" in drain_unit
+    assert "CPUQuota=50%" in drain_unit
+
+    for unit in (discovery_unit, drain_unit):
+        assert "docker.sock" not in unit
+        assert "--privileged" not in unit
+        assert ":latest" not in unit
+
+
+def test_worker_drain_network_has_a_safe_default_and_strict_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HERMES_DOCKER_NETWORK", raising=False)
+    assert hermes_worker_drain._docker_network() == "hermes-net"
+    assert hermes_worker_drain._validate_docker_network("hermes-shadow") == "hermes-shadow"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "bridge",
+        "default",
+        "host",
+        "none",
+        "other-network",
+        "Hermes-net",
+        "hermes net",
+        "hermes/net",
+        "hermes-",
+        "hermes-" + "a" * 58,
+    ],
+)
+def test_worker_drain_rejects_unsafe_or_unbounded_network_names(
+    value: str,
+) -> None:
+    with pytest.raises(hermes_worker_drain.DrainError, match="hermes_docker_network_invalid"):
+        hermes_worker_drain._validate_docker_network(value)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "registry.invalid/hermes-worker:latest",
+        "registry.invalid/hermes-worker:stable",
+        "registry.invalid/hermes-worker",
+    ],
+)
+def test_worker_drain_rejects_non_immutable_or_floating_images(
+    value: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_WORKER_IMAGE", value)
+    with pytest.raises(hermes_worker_drain.DrainError, match="hermes_worker_image_not_immutable"):
+        hermes_worker_drain._worker_image()
 
 
 def test_canonical_registry_renders_versioned_allowlist() -> None:
@@ -167,6 +258,14 @@ def test_worker_drain_handoff_is_immutable_and_does_not_put_secret_values_in_arg
     for name in hermes_worker_drain.WORKER_ENV_NAMES:
         assert name in command
         assert f"{name}=" not in command
+    assert command[command.index("--network") + 1] == "hermes-net"
+    assert command[command.index("--pids-limit") + 1] == "32"
+    assert command[command.index("--memory") + 1] == "512m"
+    assert command[command.index("--cpus") + 1] == "0.50"
+    assert command[command.index("--user") + 1] == "10000:10000"
+    assert "--read-only" in command
+    assert "--cap-drop" in command
+    assert "docker.sock" not in command
 
     monkeypatch.setattr(
         hermes_worker_drain.subprocess,


### PR DESCRIPTION
Bounded deployment follow-up for the already released Task 129 implementation. No editorial logic, provider behavior, feature flags, secrets, firewall, VM, or Hermes VPS changes.\n\nChanges: discovery launcher passes --once; host-side systemd launchers run only exact root-owned Docker commands while containers remain UID/GID 10000:10000, non-root, read-only, cap-drop ALL, no-new-privileges, no Docker socket; discovery and drain share validated HERMES_DOCKER_NETWORK=hermes-net; resource ceilings and PID limits are preserved; tests cover network/image/launcher/hardening boundaries.\n\nVerification: targeted tests, ruff, provenance, hardening, pre-commit, and the repository pre-push gate passed at exact head b06f9e2bd194a266c3d524fc40d2ebba7a522bfd against origin/master e71f92d55949251c9317341c4b7630d5ff26936e.\n\nThis PR must not enable Hermes or change existing NEWS_* flags. No live provider, Telegram, production, or VPS action is included.