### PR TITLE
[Task 129] Enforce LF source provenance

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 * text=auto
 
+# Canonical news source provenance hashes raw bytes; keep the registry LF-only on every checkout.
+/backend/fitminiapp_api/resources/news_sources.json text eol=lf
+
 # Container entrypoints must remain executable POSIX shell text on Windows clones.
 *.sh text eol=lf
 

--- a/scripts/generate_hermes_source_definitions.py
+++ b/scripts/generate_hermes_source_definitions.py
@@ -50,6 +50,16 @@ class RegistryError(ValueError):
     """Raised when the canonical registry cannot produce a safe deployment file."""
 
 
+def _read_lf_only_registry(source_registry_path: Path) -> bytes:
+    """Read registry bytes only when their provenance line endings are unambiguous."""
+    raw_bytes = source_registry_path.read_bytes()
+    if b"\r\n" in raw_bytes:
+        raise RegistryError("source_registry_crlf_not_allowed")
+    if b"\r" in raw_bytes:
+        raise RegistryError("source_registry_bare_cr_not_allowed")
+    return raw_bytes
+
+
 def _normalise_host(value: object) -> str:
     if not isinstance(value, str):
         raise RegistryError("source_host_must_be_string")
@@ -162,7 +172,7 @@ def _validate_source(raw: object) -> dict[str, Any]:
 
 
 def render_registry(source_registry_path: Path) -> dict[str, Any]:
-    raw_bytes = source_registry_path.read_bytes()
+    raw_bytes = _read_lf_only_registry(source_registry_path)
     try:
         document = json.loads(raw_bytes.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:

--- a/tests/integration/hermes_editorial_worker/test_discovery_contract.py
+++ b/tests/integration/hermes_editorial_worker/test_discovery_contract.py
@@ -138,6 +138,54 @@ def test_worker_drain_rejects_non_immutable_or_floating_images(
         hermes_worker_drain._worker_image()
 
 
+def test_canonical_registry_is_lf_only() -> None:
+    registry = WORKSPACE / "backend" / "fitminiapp_api" / "resources" / "news_sources.json"
+
+    assert b"\r" not in registry.read_bytes()
+
+
+def test_gitattributes_pins_canonical_registry_to_lf() -> None:
+    attributes = (WORKSPACE / ".gitattributes").read_text(encoding="utf-8")
+
+    assert (
+        "/backend/fitminiapp_api/resources/news_sources.json text eol=lf" in attributes.splitlines()
+    )
+
+
+@pytest.mark.parametrize(
+    ("line_ending", "error"),
+    [
+        (b"\r\n", "source_registry_crlf_not_allowed"),
+        (b"\r", "source_registry_bare_cr_not_allowed"),
+    ],
+)
+def test_registry_non_lf_line_endings_fail_closed(
+    tmp_path: Path, line_ending: bytes, error: str
+) -> None:
+    registry = WORKSPACE / "backend" / "fitminiapp_api" / "resources" / "news_sources.json"
+    raw = registry.read_bytes()
+    synthetic = raw.replace(b"\n", line_ending)
+    path = tmp_path / "news_sources.json"
+    path.write_bytes(synthetic)
+
+    with pytest.raises(GENERATOR_MODULE.RegistryError, match=error):
+        GENERATOR_MODULE.render_registry(path)
+
+
+def test_exact_lf_registry_is_deterministic_and_hashes_raw_bytes(tmp_path: Path) -> None:
+    registry = WORKSPACE / "backend" / "fitminiapp_api" / "resources" / "news_sources.json"
+    raw = registry.read_bytes()
+    path = tmp_path / "news_sources.json"
+    path.write_bytes(raw)
+
+    first = GENERATOR_MODULE.render_registry(path)
+    second = GENERATOR_MODULE.render_registry(path)
+    expected_hash = hashlib.sha256(raw).hexdigest()
+
+    assert first == second
+    assert first["source_registry_sha256"] == expected_hash
+
+
 def test_canonical_registry_renders_versioned_allowlist() -> None:
     registry = WORKSPACE / "backend" / "fitminiapp_api" / "resources" / "news_sources.json"
     document = GENERATOR_MODULE.render_registry(registry)


### PR DESCRIPTION
## Summary

- pins the canonical Hermes/YFC source registry to LF line endings in `.gitattributes`;
- rejects CRLF and bare CR registry bytes before provenance hashing;
- adds deterministic LF/provenance regression coverage.

The canonical registry semantic content is unchanged. PubMed query/source enablement, editorial logic, provider/credentials, Telegram, feature flags and Hermes VPS are out of scope. Generated source definitions remain build output and are regenerated by `scripts/generate_hermes_source_definitions.py`.

## Verification

- targeted Hermes discovery contract tests: 40 passed;
- pre-commit and ruff checks: passed;
- local PRE_PUSH_CI_PASS: 143 passed; CI/deployment contracts valid;
- canonical raw registry: CRLF=0, bare CR=0;
- canonical SHA-256: 47ecf5536275068ddcaab1397e9243ec01de9214dd2c56d12ac2c7e4ee16aae8;
- generated definitions SHA-256: 1c030dc2a51c7f227a32c7d2013c988b9295afe82361b38f679b363258cbaf10.