### PR TITLE
[Task 129] Fix Hermes discovery timer target

### DIFF
--- a/deploy/hermes-discovery/systemd/hermes-discovery.timer
+++ b/deploy/hermes-discovery/systemd/hermes-discovery.timer
@@ -2,7 +2,7 @@
 Description=Task 129 bounded Hermes discovery schedule
 
 [Timer]
-Unit=hermes-discovery.target
+Unit=hermes-worker-drain.service
 OnBootSec=5min
 OnUnitActiveSec=6h
 RandomizedDelaySec=5min

--- a/docs/telegram-news-editorial-automation.md
+++ b/docs/telegram-news-editorial-automation.md
@@ -345,8 +345,8 @@ safety. Фактический набор enabled/disabled источников 
 Discovery не делает обязательных publication quotas и не отбрасывает материал из-за неизвестного
 topic; taxonomy/risk/publication eligibility остаются серверной ответственностью YFC.
 
-На будущей отдельной Hermes VM systemd timer активирует `hermes-discovery.target`, который
-последовательно запускает `hermes-discovery.service` и `hermes-worker-drain.service`. Первый
+На будущей отдельной Hermes VM systemd timer напрямую активирует `hermes-worker-drain.service`;
+его `Requires`/`After` сначала запускают `hermes-discovery.service`. Первый
 контейнер не получает provider/YFC secrets. Только второй host-side drain передаёт bounded job в
 hardened worker с provider key и YFC HMAC secret. Входящих Hermes ports нет; source discovery
 имеет exact host allowlist из definitions, HTTPS-only external mode, DNS resolution с запретом

--- a/tests/integration/hermes_editorial_worker/test_discovery_contract.py
+++ b/tests/integration/hermes_editorial_worker/test_discovery_contract.py
@@ -52,6 +52,27 @@ def test_install_instructions_start_enabled_timer_after_gate_a() -> None:
     assert "systemctl enable hermes-discovery.timer\n" not in readme
 
 
+def test_discovery_timer_runs_worker_drain_and_preserves_scheduler_guardrails() -> None:
+    timer = _systemd_unit("hermes-discovery.timer")
+
+    assert timer == (
+        "[Unit]\n"
+        "Description=Task 129 bounded Hermes discovery schedule\n"
+        "\n"
+        "[Timer]\n"
+        "Unit=hermes-worker-drain.service\n"
+        "OnBootSec=5min\n"
+        "OnUnitActiveSec=6h\n"
+        "RandomizedDelaySec=5min\n"
+        "AccuracySec=1min\n"
+        "Persistent=false\n"
+        "\n"
+        "[Install]\n"
+        "WantedBy=timers.target\n"
+    )
+    assert "Unit=hermes-discovery.target" not in timer
+
+
 def test_shared_host_systemd_launchers_are_root_only_and_container_hardening_is_explicit() -> None:
     discovery_unit = _systemd_unit("hermes-discovery.service.template")
     drain_unit = _systemd_unit("hermes-worker-drain.service.template")


### PR DESCRIPTION
## Summary

- Point the recurring Hermes timer at hermes-worker-drain.service, whose existing Requires/After wiring starts discovery first.
- Add a regression test that locks the drain target and all existing cadence/guardrail values.
- Correct the durable scheduler documentation to match the released wiring.

## Verification

- 	ests/integration/hermes_editorial_worker: 78 passed
- discovery provenance check: passed
- exact-HEAD pre-push gate: passed (quality, policy, workflow-config, image-contract, deployment-contract)

No provider/Groq calls, secrets, feature flags, Telegram behavior, images, or production configuration are changed by this PR.