### PR TITLE
[Task 129] Disable legacy news discovery in Hermes production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,9 @@ AUDIT_EVENT_RETENTION_DAYS=365
 # Editorial ingestion remains off until the owner confirms the private moderation
 # workflow, channel identity, rubrics, frequency, sources and copyright policy.
 NEWS_INGESTION_ENABLED=false
+# Backward-compatible local default. Production sets this to false after Hermes activation;
+# this flag disables only legacy YFC source acquisition, not downstream review/publication flow.
+NEWS_LEGACY_SOURCE_FETCH_ENABLED=true
 NEWS_CHANNEL_ID=
 # Optional for a private channel without a public username.
 NEWS_CHANNEL_USERNAME=

--- a/backend/fitminiapp_api/core/config.py
+++ b/backend/fitminiapp_api/core/config.py
@@ -88,6 +88,7 @@ class Settings(BaseSettings):
     notification_delivery_concurrency: int = Field(default=8, ge=1, le=30)
     audit_event_retention_days: int = Field(default=365, ge=90, le=3650)
     news_ingestion_enabled: bool = False
+    news_legacy_source_fetch_enabled: bool = True
     news_channel_id: int | None = None
     news_channel_username: str = ""
     news_ingestion_cycle_seconds: int = Field(default=900, ge=60, le=86400)

--- a/backend/fitminiapp_api/services/news_hermes.py
+++ b/backend/fitminiapp_api/services/news_hermes.py
@@ -341,7 +341,9 @@ def accept_hermes_submission(
         evidence_metadata={
             "source_packet_hash": payload.source.content_hash,
             "trusted_source_url": packet.primary_url or packet.canonical_url,
-            "source_published_at": payload.source.published_at.isoformat(),
+            "source_published_at": (
+                payload.source.published_at.isoformat() if payload.source.published_at else None
+            ),
             "primary_topic": classification.primary_topic,
             "topics": list(classification.topics),
             "content_type": classification.content_type,

--- a/backend/fitminiapp_api/services/news_hermes.py
+++ b/backend/fitminiapp_api/services/news_hermes.py
@@ -341,6 +341,7 @@ def accept_hermes_submission(
         evidence_metadata={
             "source_packet_hash": payload.source.content_hash,
             "trusted_source_url": packet.primary_url or packet.canonical_url,
+            "source_published_at": payload.source.published_at.isoformat(),
             "primary_topic": classification.primary_topic,
             "topics": list(classification.topics),
             "content_type": classification.content_type,

--- a/backend/fitminiapp_api/services/news_worker.py
+++ b/backend/fitminiapp_api/services/news_worker.py
@@ -641,6 +641,7 @@ async def run_news_pipeline_once(
 ) -> NewsCycleStats:
     started = monotonic()
     cycle_stats = NewsCycleStats()
+    legacy_source_fetch_enabled = settings.news_legacy_source_fetch_enabled
     with get_session_context() as db:
         prune_news_editorial(db, retention_days=settings.news_retention_days)
     timeout = httpx.Timeout(settings.news_source_timeout_seconds)
@@ -650,7 +651,9 @@ async def run_news_pipeline_once(
             if publication_ready
             else 0
         )
-        counts = await fetch_due_sources(client) if fetch_sources else {}
+        counts = (
+            await fetch_due_sources(client) if legacy_source_fetch_enabled and fetch_sources else {}
+        )
         cycle_stats.sources_total = counts.get("sources_total", 0)
         cycle_stats.sources_checked = counts.get("sources_checked", 0)
         cycle_stats.sources_success = counts.get("sources_success", 0)
@@ -661,7 +664,8 @@ async def run_news_pipeline_once(
         cycle_stats.candidates_stale = counts.get("stale", 0)
         cycle_stats.candidates_below_threshold = counts.get("below_threshold", 0)
         cycle_stats.candidates_eligible = counts.get("eligible", 0)
-        await generate_candidate_drafts(client, cycle_stats=cycle_stats)
+        if legacy_source_fetch_enabled:
+            await generate_candidate_drafts(client, cycle_stats=cycle_stats)
         await generate_pending_images(client)
         with get_session_context() as db:
             enqueue_review_deliveries(db, settings.admin_telegram_id_set)
@@ -672,7 +676,7 @@ async def run_news_pipeline_once(
             publication_ready,
             cycle_stats=cycle_stats,
         )
-    if fetch_sources or any(
+    if (legacy_source_fetch_enabled and fetch_sources) or any(
         (
             cycle_stats.drafts_created,
             delivered,

--- a/backend/tests/test_news_editorial.py
+++ b/backend/tests/test_news_editorial.py
@@ -260,6 +260,7 @@ def test_news_activation_requires_owner_ids_and_confirmed_channel() -> None:
         news_channel_id=-1001234567890,
     )
     assert configured.news_ingestion_enabled is True
+    assert configured.news_legacy_source_fetch_enabled is True
 
 
 def test_canonical_url_removes_tracking_but_preserves_semantic_query() -> None:

--- a/backend/tests/test_news_hermes.py
+++ b/backend/tests/test_news_hermes.py
@@ -1,14 +1,24 @@
+import asyncio
 import hashlib
 import json
 import time
 from datetime import UTC, datetime
+from types import SimpleNamespace
 
 from pydantic import SecretStr
 
 from fitminiapp_api.core.config import settings
 from fitminiapp_api.db.session import get_session_context
-from fitminiapp_api.models.news import HermesEditorialSubmission, NewsSource
+from fitminiapp_api.models.news import (
+    HermesEditorialSubmission,
+    NewsCluster,
+    NewsDraftRevision,
+    NewsReviewDelivery,
+    NewsSource,
+)
+from fitminiapp_api.services import news_worker
 from fitminiapp_api.services.news_hermes import _canonical_source_hash, hermes_signature
+from fitminiapp_api.services.news_worker import run_news_pipeline_once
 
 
 def _payload() -> dict:
@@ -121,3 +131,89 @@ def test_hermes_intake_rejects_bad_signature_without_source_processing(client, m
     response = client.post("/api/v1/hermes/editorial/intake", content=body, headers=headers)
 
     assert response.status_code == 403
+
+
+def test_hermes_image_pending_downstream_survives_disabled_legacy_fetch(
+    client, monkeypatch
+) -> None:
+    monkeypatch.setattr(settings, "hermes_intake_enabled", True)
+    monkeypatch.setattr(settings, "hermes_intake_key_id", "hermes-test")
+    monkeypatch.setattr(
+        settings,
+        "hermes_intake_shared_secret",
+        SecretStr("test-hermes-shared-secret-that-is-long-enough"),
+    )
+    monkeypatch.setattr(settings, "news_ingestion_enabled", True)
+    monkeypatch.setattr(settings, "news_legacy_source_fetch_enabled", False)
+    monkeypatch.setattr(settings, "news_image_provider", "disabled")
+    monkeypatch.setattr(settings, "admin_telegram_user_ids", "7001")
+
+    with get_session_context() as db:
+        db.add(
+            NewsSource(
+                id="journal-one",
+                name="Journal One",
+                source_type="primary_research",
+                fetch_kind="rss",
+                feed_url="https://example.com/feed",
+                language="en",
+                enabled=True,
+            )
+        )
+
+    body = json.dumps(_payload(), ensure_ascii=False, separators=(",", ":")).encode()
+    intake = client.post(
+        "/api/v1/hermes/editorial/intake",
+        content=body,
+        headers=_signed_headers(body),
+    )
+    assert intake.status_code == 200, intake.text
+    assert intake.json()["status"] == "accepted"
+
+    async def unexpected_fetch(_client):
+        raise AssertionError("legacy source fetching must be disabled")
+
+    async def unexpected_candidate_generation(*_args, **_kwargs):
+        raise AssertionError("legacy candidate draft generation must be disabled")
+
+    monkeypatch.setattr(news_worker, "fetch_due_sources", unexpected_fetch)
+    monkeypatch.setattr(news_worker, "generate_candidate_drafts", unexpected_candidate_generation)
+    preview_calls: list[int] = []
+    control_calls: list[int] = []
+
+    async def send_preview(_client, chat_id, *_args, **_kwargs):
+        preview_calls.append(chat_id)
+        return SimpleNamespace(message_id=501, message_date=datetime.now(UTC))
+
+    async def send_control(_client, chat_id, *_args, **_kwargs):
+        control_calls.append(chat_id)
+        return 502
+
+    async def send_publication(*_args, **_kwargs):
+        raise AssertionError("publication is not part of this manual-required flow")
+
+    asyncio.run(
+        run_news_pipeline_once(
+            send_message=send_control,
+            send_preview=send_preview,
+            send_publication=send_publication,
+            publication_ready=True,
+            fetch_sources=True,
+        )
+    )
+
+    with get_session_context() as db:
+        submission = db.query(HermesEditorialSubmission).one()
+        draft = db.get(NewsDraftRevision, submission.draft_id)
+        assert draft is not None
+        assert draft.evidence_metadata["source_published_at"]
+    assert preview_calls == [7001]
+    assert control_calls == [7001]
+    with get_session_context() as db:
+        submission = db.query(HermesEditorialSubmission).one()
+        cluster = db.get(NewsCluster, submission.cluster_id)
+        assert cluster is not None
+        assert cluster.status == "awaiting_review"
+        assert cluster.current_image_revision == 1
+        delivery = db.query(NewsReviewDelivery).one()
+        assert delivery.status == "sent"

--- a/backend/tests/test_news_hermes.py
+++ b/backend/tests/test_news_hermes.py
@@ -116,6 +116,56 @@ def test_signed_hermes_intake_creates_preview_and_is_idempotent(client, monkeypa
         assert db.query(HermesEditorialSubmission).count() == 1
 
 
+def test_signed_hermes_intake_preserves_missing_source_publication_date(
+    client, monkeypatch
+) -> None:
+    monkeypatch.setattr(settings, "hermes_intake_enabled", True)
+    monkeypatch.setattr(settings, "hermes_intake_key_id", "hermes-test")
+    monkeypatch.setattr(
+        settings,
+        "hermes_intake_shared_secret",
+        SecretStr("test-hermes-shared-secret-that-is-long-enough"),
+    )
+    with get_session_context() as db:
+        db.add(
+            NewsSource(
+                id="journal-one",
+                name="Journal One",
+                source_type="primary_research",
+                fetch_kind="rss",
+                feed_url="https://example.com/feed",
+                language="en",
+                enabled=True,
+            )
+        )
+
+    payload = _payload()
+    payload["idempotency_key"] = "hermes-test-missing-published-at"
+    payload["request_nonce"] = "hermes-test-nonce-1"
+    payload["source"]["published_at"] = None
+    payload["source"]["content_hash"] = _canonical_source_hash(
+        title=payload["source"]["title"],
+        summary=payload["source"]["summary"],
+        canonical_url=payload["source"]["canonical_url"],
+        published_at=None,
+    )
+    body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
+
+    response = client.post(
+        "/api/v1/hermes/editorial/intake",
+        content=body,
+        headers=_signed_headers(body),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "accepted"
+    with get_session_context() as db:
+        submission = db.query(HermesEditorialSubmission).one()
+        draft = db.get(NewsDraftRevision, submission.draft_id)
+        assert draft is not None
+        assert draft.evidence_metadata["source_published_at"] is None
+
+
 def test_hermes_intake_rejects_bad_signature_without_source_processing(client, monkeypatch) -> None:
     monkeypatch.setattr(settings, "hermes_intake_enabled", True)
     monkeypatch.setattr(settings, "hermes_intake_key_id", "hermes-test")

--- a/backend/tests/test_news_publishing.py
+++ b/backend/tests/test_news_publishing.py
@@ -24,7 +24,7 @@ from fitminiapp_api.models.news import (
     NewsReviewDelivery,
     NewsSource,
 )
-from fitminiapp_api.services import news_images, news_publication
+from fitminiapp_api.services import news_images, news_publication, news_worker
 from fitminiapp_api.services.news_content import EditorialContent, parse_editorial_content
 from fitminiapp_api.services.news_drafts import create_draft_revision
 from fitminiapp_api.services.news_editorial import (
@@ -1317,6 +1317,56 @@ def test_successful_pipeline_fetches_scores_drafts_and_delivers_for_approval(
         event = db.query(AuditEvent).filter_by(action="news.preview_created").one()
         assert event.details["preview_message_id"] == 301
         assert event.details["control_message_id"] == 302
+
+
+def test_legacy_source_fetch_flag_preserves_downstream_pipeline(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "news_ingestion_enabled", True)
+    monkeypatch.setattr(settings, "news_legacy_source_fetch_enabled", False)
+    calls: list[str] = []
+
+    async def unexpected_fetch(_client):
+        raise AssertionError("legacy source fetching must be disabled")
+
+    async def unexpected_candidate_generation(*_args, **_kwargs):
+        raise AssertionError("legacy candidate draft generation must be disabled")
+
+    async def publish(_client, _send_publication, _send_message):
+        calls.append("publish")
+        return 1
+
+    async def generate_images(_client):
+        calls.append("images")
+        return 0
+
+    def enqueue(_db, _admin_telegram_user_ids):
+        calls.append("enqueue")
+        return 0
+
+    async def deliver(*_args, **_kwargs):
+        calls.append("deliver")
+        return 0
+
+    monkeypatch.setattr(news_worker, "fetch_due_sources", unexpected_fetch)
+    monkeypatch.setattr(news_worker, "generate_candidate_drafts", unexpected_candidate_generation)
+    monkeypatch.setattr(news_worker, "publish_due_snapshots", publish)
+    monkeypatch.setattr(news_worker, "generate_pending_images", generate_images)
+    monkeypatch.setattr(news_worker, "enqueue_review_deliveries", enqueue)
+    monkeypatch.setattr(news_worker, "deliver_review_queue", deliver)
+
+    async def unused(*_args, **_kwargs):
+        return None
+
+    asyncio.run(
+        run_news_pipeline_once(
+            send_message=unused,
+            send_preview=unused,
+            send_publication=unused,
+            publication_ready=True,
+            fetch_sources=True,
+        )
+    )
+
+    assert calls == ["publish", "images", "enqueue", "deliver"]
 
 
 def test_over_limit_photo_control_card_shows_measurement_and_recovery_actions(

--- a/docs/telegram-news-editorial-automation.md
+++ b/docs/telegram-news-editorial-automation.md
@@ -16,12 +16,12 @@ NEWS_LEGACY_SOURCE_FETCH_ENABLED=true
 NEWS_PUBLICATION_ENABLED=false
 ```
 
-`NEWS_LEGACY_SOURCE_FETCH_ENABLED=true` is the backward-compatible local/default value. In the
-production Hermes configuration it is normalized to `false`, while `NEWS_INGESTION_ENABLED=true`
-remains enabled for downstream YFC worker stages. The flag disables only legacy YFC source
-acquisition and candidate-draft generation; Hermes intake, image processing, review queue, manual
-editing/confirmation, scheduling and publication management continue to run. It must not be
-implemented by changing `NEWS_INGESTION_ENABLED`.
+`NEWS_LEGACY_SOURCE_FETCH_ENABLED=true` — обратно совместимое локальное значение по умолчанию. В
+production-конфигурации Hermes оно нормализуется в `false`, а `NEWS_INGESTION_ENABLED=true`
+остаётся включённым для downstream-этапов YFC. Этот флаг отключает только legacy-получение
+источников YFC и генерацию candidate-draft; intake Hermes, обработка изображений, очередь review,
+ручное редактирование/подтверждение, планирование и управление публикацией продолжают работать.
+Его нельзя реализовывать изменением `NEWS_INGESTION_ENABLED`.
 
 После production release целевые значения для разделения контуров такие:
 
@@ -31,7 +31,7 @@ NEWS_LEGACY_SOURCE_FETCH_ENABLED=false
 NEWS_AUTO_PUBLISH_LOW_RISK=false
 ```
 
-`NEWS_INGESTION_ENABLED` поддерживает downstream processing; `NEWS_PUBLICATION_ENABLED` и
+`NEWS_INGESTION_ENABLED` поддерживает downstream-обработку; `NEWS_PUBLICATION_ENABLED` и
 остальные существующие `NEWS_*` flags не меняются этим follow-up.
 
 Telegram Bot API polling continues to have one owner.  No second polling process, bot token,
@@ -329,10 +329,10 @@ account до owner verification не считаются подтверждённ
 
 Kill switch — `HERMES_INTAKE_ENABLED=false`; keep it off until Gate A. The existing production
 `NEWS_INGESTION_ENABLED` and `NEWS_PUBLICATION_ENABLED` values are not changed by this integration,
-and `NEWS_AUTO_PUBLISH_LOW_RISK=false` remains required. Production sets
-`NEWS_LEGACY_SOURCE_FETCH_ENABLED=false` through the normal deployment normalizer; rollback of this
-bounded flag change restores the previous environment value only through an owner-approved release.
-Rollback is to stop/remove
+and `NEWS_AUTO_PUBLISH_LOW_RISK=false` remains required. Production задаёт
+`NEWS_LEGACY_SOURCE_FETCH_ENABLED=false` через штатный deployment normalizer; rollback этого
+ограниченного изменения флага восстанавливает прежнее значение окружения только через
+owner-approved release. Rollback — это остановка/удаление
 the separate worker workload, revoke only its approved intake/provider identities, remove its
 egress rules, and return to the existing YFC manual/editorial path. Existing news pipeline flags
 and publisher ownership are not rollback targets. Any later production rollback must use the

--- a/docs/telegram-news-editorial-automation.md
+++ b/docs/telegram-news-editorial-automation.md
@@ -12,8 +12,27 @@ The intake flag is off by default:
 HERMES_INTAKE_ENABLED=false
 NEWS_AUTO_PUBLISH_LOW_RISK=false
 NEWS_INGESTION_ENABLED=false
+NEWS_LEGACY_SOURCE_FETCH_ENABLED=true
 NEWS_PUBLICATION_ENABLED=false
 ```
+
+`NEWS_LEGACY_SOURCE_FETCH_ENABLED=true` is the backward-compatible local/default value. In the
+production Hermes configuration it is normalized to `false`, while `NEWS_INGESTION_ENABLED=true`
+remains enabled for downstream YFC worker stages. The flag disables only legacy YFC source
+acquisition and candidate-draft generation; Hermes intake, image processing, review queue, manual
+editing/confirmation, scheduling and publication management continue to run. It must not be
+implemented by changing `NEWS_INGESTION_ENABLED`.
+
+После production release целевые значения для разделения контуров такие:
+
+```text
+NEWS_INGESTION_ENABLED=true
+NEWS_LEGACY_SOURCE_FETCH_ENABLED=false
+NEWS_AUTO_PUBLISH_LOW_RISK=false
+```
+
+`NEWS_INGESTION_ENABLED` поддерживает downstream processing; `NEWS_PUBLICATION_ENABLED` и
+остальные существующие `NEWS_*` flags не меняются этим follow-up.
 
 Telegram Bot API polling continues to have one owner.  No second polling process, bot token,
 channel id or BotFather change is introduced by this task.
@@ -310,7 +329,10 @@ account до owner verification не считаются подтверждённ
 
 Kill switch — `HERMES_INTAKE_ENABLED=false`; keep it off until Gate A. The existing production
 `NEWS_INGESTION_ENABLED` and `NEWS_PUBLICATION_ENABLED` values are not changed by this integration,
-and `NEWS_AUTO_PUBLISH_LOW_RISK=false` remains required. Rollback is to stop/remove
+and `NEWS_AUTO_PUBLISH_LOW_RISK=false` remains required. Production sets
+`NEWS_LEGACY_SOURCE_FETCH_ENABLED=false` through the normal deployment normalizer; rollback of this
+bounded flag change restores the previous environment value only through an owner-approved release.
+Rollback is to stop/remove
 the separate worker workload, revoke only its approved intake/provider identities, remove its
 egress rules, and return to the existing YFC manual/editorial path. Existing news pipeline flags
 and publisher ownership are not rollback targets. Any later production rollback must use the

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -86,6 +86,9 @@ python3 scripts/configure_production_food_search.py .env
 echo "Normalizing the production news image provider"
 python3 scripts/normalize_production_news_image_provider.py .env
 
+echo "Disabling legacy YFC news source fetching while preserving downstream news processing"
+python3 scripts/normalize_production_news_legacy_source_fetch.py .env
+
 echo "Validating Compose configuration for $TARGET_SHA"
 docker compose config --quiet
 

--- a/scripts/normalize_production_news_legacy_source_fetch.py
+++ b/scripts/normalize_production_news_legacy_source_fetch.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+PRODUCTION_FLAG = "NEWS_LEGACY_SOURCE_FETCH_ENABLED"
+PRODUCTION_VALUE = "false"
+
+
+def normalize_production_news_legacy_source_fetch(path: Path) -> str:
+    if not path.is_file():
+        raise FileNotFoundError(f"Environment file does not exist: {path}")
+
+    original = path.read_text(encoding="utf-8")
+    trailing_newline = original.endswith("\n")
+    seen = False
+    updated_lines: list[str] = []
+    for line in original.splitlines():
+        key, separator, _value = line.partition("=")
+        if separator and key == PRODUCTION_FLAG:
+            if not seen:
+                updated_lines.append(f"{PRODUCTION_FLAG}={PRODUCTION_VALUE}")
+                seen = True
+            continue
+        updated_lines.append(line)
+
+    if not seen:
+        updated_lines.append(f"{PRODUCTION_FLAG}={PRODUCTION_VALUE}")
+
+    content = "\n".join(updated_lines) + ("\n" if trailing_newline else "")
+    mode = path.stat().st_mode
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="\n",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary.write(content)
+            temporary_name = temporary.name
+        os.chmod(temporary_name, mode)
+        os.replace(temporary_name, path)
+    finally:
+        if temporary_name is not None:
+            Path(temporary_name).unlink(missing_ok=True)
+
+    return PRODUCTION_VALUE
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: normalize_production_news_legacy_source_fetch.py ENV_FILE")
+    value = normalize_production_news_legacy_source_fetch(Path(sys.argv[1]))
+    print(f"Production legacy news source fetching: {value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/zero_downtime_deploy.py
+++ b/scripts/zero_downtime_deploy.py
@@ -254,10 +254,13 @@ def _image_digest(image: str, expected_revision: str) -> str:
     digests = json.loads(digests_json)
     if not isinstance(digests, list) or not digests:
         raise DeploymentError(f"image {image} has no immutable repository digest")
-    repository = image.split("@", 1)[0].rsplit(":", 1)[0]
-    matching = [
-        value for value in digests if isinstance(value, str) and value.startswith(repository)
-    ]
+    if image.startswith("sha256:"):
+        matching = [value for value in digests if isinstance(value, str)]
+    else:
+        repository = image.split("@", 1)[0].rsplit(":", 1)[0]
+        matching = [
+            value for value in digests if isinstance(value, str) and value.startswith(repository)
+        ]
     digest = matching[0] if matching else digests[0]
     if not isinstance(digest, str) or "@sha256:" not in digest:
         raise DeploymentError(f"image {image} returned an invalid repository digest")
@@ -1144,8 +1147,11 @@ def _legacy_running_image(service: str) -> str:
     container_id = _compose("ps", "-q", service, capture=True).stdout.strip()
     if not container_id or not _service_is_running(service):
         raise DeploymentError(f"single-slot rollout requires running legacy service {service}")
+    # A single-slot reclaim may remove a mutable tag from an image that the running
+    # container still references.  Snapshot the immutable image ID so provenance and
+    # rollback do not depend on that tag surviving reclaim.
     image = _run(
-        ["docker", "inspect", "--format", "{{.Config.Image}}", container_id],
+        ["docker", "inspect", "--format", "{{.Image}}", container_id],
         capture=True,
     ).stdout.strip()
     if not image:
@@ -1306,14 +1312,7 @@ def single_slot_deploy(config: DeployConfig) -> Evidence:
     services_stopped = False
 
     try:
-        with _stage(evidence, "single_slot_docker_reclaim"):
-            _reclaim_single_slot_docker_space()
-
-        with _stage(evidence, "single_slot_preflight"):
-            evidence.capacity = _single_slot_capacity()
-            _compose("config", "--quiet")
-            _switch_gateway("legacy", "legacy")
-            _public_smoke(config)
+        with _stage(evidence, "single_slot_legacy_provenance"):
             old_backend = _image_digest(_legacy_running_image("backend"), active_revision)
             old_bot = _image_digest(_legacy_running_image("bot"), active_revision)
             old_worker = _image_digest(_legacy_running_image("worker"), active_revision)
@@ -1322,6 +1321,15 @@ def single_slot_deploy(config: DeployConfig) -> Evidence:
                     "legacy backend and worker do not use the same verified image digest"
                 )
             _legacy_running_image("edge")
+
+        with _stage(evidence, "single_slot_docker_reclaim"):
+            _reclaim_single_slot_docker_space()
+
+        with _stage(evidence, "single_slot_preflight"):
+            evidence.capacity = _single_slot_capacity()
+            _compose("config", "--quiet")
+            _switch_gateway("legacy", "legacy")
+            _public_smoke(config)
 
         with _stage(evidence, "pull_and_verify"):
             preliminary_env = _legacy_environment(

--- a/tests/test_normalize_production_news_legacy_source_fetch.py
+++ b/tests/test_normalize_production_news_legacy_source_fetch.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import pytest
+from scripts.normalize_production_news_legacy_source_fetch import (
+    normalize_production_news_legacy_source_fetch,
+)
+
+
+def test_disables_legacy_source_fetch_without_changing_other_values(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "NEWS_INGESTION_ENABLED=true\n"
+        "NEWS_LEGACY_SOURCE_FETCH_ENABLED=true\n"
+        "NEWS_AUTO_PUBLISH_LOW_RISK=false\n"
+        "SECRET_KEY=keep-this-secret\n",
+        encoding="utf-8",
+    )
+
+    value = normalize_production_news_legacy_source_fetch(env_file)
+
+    assert value == "false"
+    assert env_file.read_text(encoding="utf-8") == (
+        "NEWS_INGESTION_ENABLED=true\n"
+        "NEWS_LEGACY_SOURCE_FETCH_ENABLED=false\n"
+        "NEWS_AUTO_PUBLISH_LOW_RISK=false\n"
+        "SECRET_KEY=keep-this-secret\n"
+    )
+
+
+def test_adds_one_disabled_flag_and_is_idempotent(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("APP_ENV=prod\n", encoding="utf-8")
+
+    first = normalize_production_news_legacy_source_fetch(env_file)
+    second = normalize_production_news_legacy_source_fetch(env_file)
+
+    assert first == second == "false"
+    assert env_file.read_text(encoding="utf-8") == (
+        "APP_ENV=prod\nNEWS_LEGACY_SOURCE_FETCH_ENABLED=false\n"
+    )
+
+
+def test_removes_duplicate_flag_definitions(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "NEWS_LEGACY_SOURCE_FETCH_ENABLED=true\nNEWS_LEGACY_SOURCE_FETCH_ENABLED=false\n",
+        encoding="utf-8",
+    )
+
+    normalize_production_news_legacy_source_fetch(env_file)
+
+    assert env_file.read_text(encoding="utf-8") == ("NEWS_LEGACY_SOURCE_FETCH_ENABLED=false\n")
+
+
+def test_refuses_missing_environment_file(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        normalize_production_news_legacy_source_fetch(tmp_path / ".env")
+
+
+def test_production_deploy_normalizes_flag_before_compose_validation() -> None:
+    root = Path(__file__).resolve().parents[1]
+    deploy = (root / "scripts" / "deploy_production.sh").read_text(encoding="utf-8")
+
+    normalize = "python3 scripts/normalize_production_news_legacy_source_fetch.py .env"
+    assert normalize in deploy
+    assert deploy.index(normalize) < deploy.index("docker compose config --quiet")

--- a/tests/test_zero_downtime_deploy.py
+++ b/tests/test_zero_downtime_deploy.py
@@ -58,6 +58,19 @@ def test_production_migration_command_uses_immutable_manifest(monkeypatch) -> No
     assert command[-2:] == ["--manifest", "deployment-migration-manifest.json"]
 
 
+def test_image_digest_resolves_repo_digest_from_immutable_image_id(monkeypatch) -> None:
+    repo_digest = "registry/backend@sha256:" + "d" * 64
+    monkeypatch.setattr(
+        deploy,
+        "_run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args, 0, stdout=f"[{json.dumps(repo_digest)}]|{OLD_SHA}\n"
+        ),
+    )
+
+    assert deploy._image_digest("sha256:" + "c" * 64, OLD_SHA) == repo_digest
+
+
 def test_config_can_keep_rollout_state_outside_immutable_release(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -691,6 +704,55 @@ def test_single_slot_docker_reclaim_never_removes_container_data_or_volumes(
         (["docker", "builder", "prune", "--all", "--force"], {}),
     ]
     assert all("volume" not in args and "container" not in args for args, _ in calls)
+
+
+def test_legacy_running_image_uses_immutable_container_image_id(monkeypatch) -> None:
+    image_id = "sha256:" + "c" * 64
+    monkeypatch.setattr(
+        deploy,
+        "_compose",
+        lambda *args, **kwargs: subprocess.CompletedProcess(args, 0, stdout="container-id\n"),
+    )
+    commands = []
+
+    def run(args, **kwargs):
+        del kwargs
+        commands.append(args)
+        return subprocess.CompletedProcess(args, 0, stdout=image_id + "\n")
+
+    monkeypatch.setattr(deploy, "_run", run)
+    monkeypatch.setattr(deploy, "_service_is_running", lambda _service: True)
+
+    assert deploy._legacy_running_image("backend") == image_id
+    assert commands == [["docker", "inspect", "--format", "{{.Image}}", "container-id"]]
+
+
+def test_single_slot_snapshots_legacy_provenance_before_reclaim(
+    tmp_path: Path, monkeypatch
+) -> None:
+    _patch_single_slot_runtime(tmp_path, monkeypatch)
+    events: list[str] = []
+
+    def running_image(service: str) -> str:
+        events.append(f"running:{service}")
+        return f"sha256:{'a' * 64}"
+
+    def image_digest(image: str, revision: str) -> str:
+        events.append(f"digest:{image}")
+        return f"registry/backend@sha256:{revision[0] * 64}"
+
+    monkeypatch.setattr(deploy, "_legacy_running_image", running_image)
+    monkeypatch.setattr(deploy, "_image_digest", image_digest)
+    monkeypatch.setattr(
+        deploy,
+        "_reclaim_single_slot_docker_space",
+        lambda: events.append("reclaim"),
+    )
+
+    deploy.single_slot_deploy(_config(tmp_path))
+
+    assert events.index("digest:sha256:" + "a" * 64) < events.index("reclaim")
+    assert events.index("running:edge") < events.index("reclaim")
 
 
 def test_single_slot_reclaims_docker_space_before_capacity_gate(


### PR DESCRIPTION
## Summary
- disable legacy YFC source acquisition in production with a backward-compatible default-on flag while preserving Hermes downstream image/review/manual publication flow;
- retain the Task 129 Hermes intake source timestamp needed by the existing freshness boundary;
- make single-slot deployment provenance resilient to reclaim removing a mutable active image tag by snapshotting the running container image ID before reclaim and resolving its immutable repository digest.

## Verification
- targeted Task 129/news/deployment tests: 124 passed;
- repository-native pre-push gate on exact head: hooks PASS, policy suite 146 passed, CI/deployment contracts PASS;
- no production commands or external provider/Telegram calls were performed by this PR.

Task: 129