### PR TITLE
[Task 129] Fix production-success artifact closeout guard

### DIFF
--- a/scripts/artifact_manager.py
+++ b/scripts/artifact_manager.py
@@ -74,6 +74,9 @@ DEFAULT_RETENTION = {
     "logs": "limited-retention; delete-after-closeout-when-not-needed",
 }
 TERMINAL_STATES = {"dev-ci-success", "finished", "terminal-success", "success"}
+# A production-success lease is still owned by the controller until ``finish`` records the
+# final history state.  It is nevertheless safe for task-scoped temporary-artifact cleanup.
+CONTROLLER_TERMINAL_LEASE_STATES = TERMINAL_STATES | {"production-success"}
 CONTROLLER_STATE_NAME = "codex-task-sessions-v1"
 FILE_ATTRIBUTE_REPARSE_POINT = 0x400
 
@@ -667,7 +670,8 @@ class ArtifactManager:
                     active_task_ids.append(lease_task)
                 elif (
                     lease_task == task_id
-                    and str(payload.get("lifecycle_state", "")) not in TERMINAL_STATES
+                    and str(payload.get("lifecycle_state", ""))
+                    not in CONTROLLER_TERMINAL_LEASE_STATES
                 ):
                     issues.append(f"target task lease is not terminal: {path.name}")
         if task_id is None and active_task_ids:

--- a/tests/test_artifact_manager.py
+++ b/tests/test_artifact_manager.py
@@ -151,6 +151,32 @@ def test_cleanup_task_blocks_non_terminal_target_lease(tmp_path: Path) -> None:
     assert result["preserved"] == ["tasks/133/temporary/run/open.txt"]
 
 
+def test_cleanup_task_allows_production_success_target_lease(tmp_path: Path) -> None:
+    manager = _manager(tmp_path)
+    state = tmp_path / "state"
+    (state / "leases").mkdir(parents=True)
+    (state / "leases" / "task-133.json").write_text(
+        json.dumps({"task_id": "133", "mode": "write", "lifecycle_state": "production-success"}),
+        encoding="utf-8",
+    )
+    manager.controller_state_dir = state
+    target = manager.allocate_directory(
+        "133",
+        "temporary",
+        "temporary/run",
+        purpose="terminal closeout output",
+        command="test",
+    )
+    artifact = target / "closeout.txt"
+    artifact.write_text("remove after production success\n", encoding="utf-8")
+
+    result = manager.cleanup_task("133", terminal_state="finished")
+
+    assert result["status"] == "completed"
+    assert result["removed_count"] == 1
+    assert not artifact.exists()
+
+
 def test_shared_cleanup_blocks_parallel_lease_and_unfinished_task_132(tmp_path: Path) -> None:
     manager = _manager(tmp_path)
     state = tmp_path / "state"


### PR DESCRIPTION
Bounded lifecycle maintenance for Task 129 closeout. Allows the controller cleanup guard to recognize the existing production-success lease as terminal only for exact task-scoped temporary artifact cleanup, while preserving all unfinished/parallel lease protections. Adds a regression test with a real temporary artifact. No application, provider, Telegram, production flag, or deployment behavior changes.