### PR TITLE
[Task 140] Add scope-aware CI routing and cache hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     types: [opened, reopened, ready_for_review, synchronize]
   push:
     branches: [master]
+  schedule:
+    - cron: "17 2 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -12,10 +15,9 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  NPM_CONFIG_CACHE: ${{ github.workspace }}/.artifacts/runtime/cache/npm
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PYTHONDONTWRITEBYTECODE: "1"
   PYTHONUNBUFFERED: "1"
@@ -23,9 +25,68 @@ env:
   UV_SYSTEM_PYTHON: "1"
 
 jobs:
+  scope-router:
+    name: CI scope router
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      profile: ${{ steps.route.outputs.profile }}
+      required_groups: ${{ steps.route.outputs.required_groups }}
+      required_jobs: ${{ steps.route.outputs.required_jobs }}
+      skipped_groups: ${{ steps.route.outputs.skipped_groups }}
+      changed_paths: ${{ steps.route.outputs.changed_paths }}
+      run_quality: ${{ steps.route.outputs.run_quality }}
+      run_policy: ${{ steps.route.outputs.run_policy }}
+      run_frontend: ${{ steps.route.outputs.run_frontend }}
+      run_frontend_smoke: ${{ steps.route.outputs.run_frontend_smoke }}
+      run_python: ${{ steps.route.outputs.run_python }}
+      run_migrated_stack: ${{ steps.route.outputs.run_migrated_stack }}
+      run_dependency_audit: ${{ steps.route.outputs.run_dependency_audit }}
+      run_full_dependency_audit: ${{ steps.route.outputs.run_full_dependency_audit }}
+      run_frontend_dependency_audit: ${{ steps.route.outputs.run_frontend_dependency_audit }}
+      run_python_dependency_audit: ${{ steps.route.outputs.run_python_dependency_audit }}
+      run_containers: ${{ steps.route.outputs.run_containers }}
+      run_critical_smoke: ${{ steps.route.outputs.run_critical_smoke }}
+      run_workflow_contracts: ${{ steps.route.outputs.run_workflow_contracts }}
+      run_workflow_config: ${{ steps.route.outputs.run_workflow_config }}
+      run_image_contract: ${{ steps.route.outputs.run_image_contract }}
+      run_deployment_contract: ${{ steps.route.outputs.run_deployment_contract }}
+      run_merge_provenance: ${{ steps.route.outputs.run_merge_provenance }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - name: Route exact repository scope
+        id: route
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          TARGET_REF: ${{ github.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -Eeuo pipefail
+          if [ "$EVENT_NAME" = schedule ] || [ "$EVENT_NAME" = workflow_dispatch ]; then
+            test "$TARGET_REF" = refs/heads/master
+          fi
+          if [ "$EVENT_NAME" = pull_request ]; then
+            python scripts/ci_contract.py route \
+              --event "$EVENT_NAME" \
+              --base-sha "$BASE_SHA" \
+              --head-sha "$HEAD_SHA" \
+              --github-output "$GITHUB_OUTPUT"
+          else
+            python scripts/ci_contract.py route \
+              --event "$EVENT_NAME" \
+              --github-output "$GITHUB_OUTPUT"
+          fi
+
   task-provenance:
     name: Task provenance
-    if: github.event_name == 'pull_request'
+    needs: scope-router
+    if: github.event_name == 'pull_request' && needs.scope-router.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -39,7 +100,8 @@ jobs:
 
   merge-provenance:
     name: Merged master provenance
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: scope-router
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master' && needs.scope-router.result == 'success' && needs.scope-router.outputs.run_merge_provenance == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -53,7 +115,8 @@ jobs:
 
   quality:
     name: Python quality
-    if: github.event_name == 'pull_request'
+    needs: scope-router
+    if: needs.scope-router.result == 'success' && needs.scope-router.outputs.run_quality == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -70,7 +133,8 @@ jobs:
 
   policy:
     name: Delivery policy
-    if: github.event_name == 'pull_request'
+    needs: scope-router
+    if: needs.scope-router.result == 'success' && needs.scope-router.outputs.run_policy == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -96,16 +160,22 @@ jobs:
 
   frontend:
     name: Frontend
-    if: github.event_name == 'pull_request'
+    needs: scope-router
+    if: needs.scope-router.result == 'success' && needs.scope-router.outputs.run_frontend == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        id: npm-setup
         with:
           node-version: "24"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
+      - name: Report npm cache
+        run: |
+          echo "CI_CACHE package=npm hit=${{ steps.npm-setup.outputs.cache-hit }}"
+          echo "CI_CACHE package=npm path=$(npm config get cache)"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.14"
@@ -126,7 +196,8 @@ jobs:
 
   frontend-smoke:
     name: Frontend smoke (${{ matrix.shard }}/4)
-    if: github.event_name == 'pull_request'
+    needs: scope-router
+    if: needs.scope-router.result == 'success' && needs.scope-router.outputs.run_frontend_smoke == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -137,10 +208,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        id: npm-setup
         with:
           node-version: "24"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
+      - name: Report npm cache
+        run: |
+          echo "CI_CACHE package=npm hit=${{ steps.npm-setup.outputs.cache-hit }}"
+          echo "CI_CACHE package=npm path=$(npm config get cache)"
       - name: Install frontend dependencies
         working-directory: frontend
         run: npm ci
@@ -169,7 +245,8 @@ jobs:
 
   python-tests:
     name: Python tests (${{ matrix.shard }}/4)
-    if: github.event_name == 'pull_request'
+    needs: scope-router
+    if: needs.scope-router.result == 'success' && needs.scope-router.outputs.run_python == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -218,7 +295,8 @@ jobs:
 
   migrated-stack:
     name: Migrated PostgreSQL stack
-    if: github.event_name == 'pull_request'
+    needs: scope-router
+    if: needs.scope-router.result == 'success' && needs.scope-router.outputs.run_migrated_stack == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     services:
@@ -238,10 +316,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        id: npm-setup
         with:
           node-version: "24"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
+      - name: Report npm cache
+        run: |
+          echo "CI_CACHE package=npm hit=${{ steps.npm-setup.outputs.cache-hit }}"
+          echo "CI_CACHE package=npm path=$(npm config get cache)"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.14"
@@ -284,16 +367,24 @@ jobs:
 
   dependency-audit:
     name: Dependency audit
-    if: github.event_name == 'pull_request'
+    needs: scope-router
+    if: needs.scope-router.result == 'success' && needs.scope-router.outputs.run_dependency_audit == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
+        id: npm-setup
+        if: needs.scope-router.outputs.run_frontend_dependency_audit == 'true' || needs.scope-router.outputs.run_full_dependency_audit == 'true'
         with:
           node-version: "24"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
+      - name: Report npm cache
+        if: needs.scope-router.outputs.run_frontend_dependency_audit == 'true' || needs.scope-router.outputs.run_full_dependency_audit == 'true'
+        run: |
+          echo "CI_CACHE package=npm hit=${{ steps.npm-setup.outputs.cache-hit }}"
+          echo "CI_CACHE package=npm path=$(npm config get cache)"
       - uses: actions/setup-python@v5
         with:
           python-version: "3.14"
@@ -306,15 +397,66 @@ jobs:
             bot/requirements.txt
           cache-local-path: ${{ env.UV_CACHE_DIR }}
           cache-suffix: dependency-audit
-      - name: Install frontend dependencies
-        working-directory: frontend
-        run: npm ci
-      - name: Run shared dependency audit group
+      - name: Run shared full dependency audit group
+        if: needs.scope-router.outputs.run_full_dependency_audit == 'true'
         run: python scripts/ci_contract.py run-group dependency-audit
+      - name: Run shared frontend dependency audit group
+        if: needs.scope-router.outputs.run_frontend_dependency_audit == 'true' && needs.scope-router.outputs.run_full_dependency_audit != 'true'
+        run: python scripts/ci_contract.py run-group frontend-dependency-audit
+      - name: Run shared Python dependency audit group
+        if: needs.scope-router.outputs.run_python_dependency_audit == 'true' && needs.scope-router.outputs.run_full_dependency_audit != 'true'
+        run: python scripts/ci_contract.py run-group python-dependency-audit
+
+  critical-smoke:
+    name: Critical application smoke
+    needs: scope-router
+    if: needs.scope-router.result == 'success' && needs.scope-router.outputs.run_critical_smoke == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
+        with:
+          version: "0.11.32"
+          enable-cache: true
+          cache-dependency-glob: |
+            backend/requirements-runtime.txt
+            bot/requirements.txt
+          cache-local-path: ${{ env.UV_CACHE_DIR }}
+          cache-suffix: critical-smoke
+      - name: Install application runtime dependencies
+        run: uv pip install -r backend/requirements-runtime.txt -r bot/requirements.txt
+      - name: Run shared critical smoke group
+        run: python scripts/ci_contract.py run-group critical-smoke
+
+  workflow-contracts:
+    name: Workflow contracts
+    needs: scope-router
+    if: needs.scope-router.result == 'success' && needs.scope-router.outputs.run_workflow_contracts == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+      - name: Validate shared CI contract
+        if: needs.scope-router.outputs.run_workflow_config == 'true'
+        run: python scripts/ci_contract.py run-group workflow-config
+      - name: Validate image contract
+        if: needs.scope-router.outputs.run_image_contract == 'true'
+        run: python scripts/ci_contract.py run-group image-contract
+      - name: Validate deployment contract
+        if: needs.scope-router.outputs.run_deployment_contract == 'true'
+        run: python scripts/ci_contract.py run-group deployment-contract
 
   containers:
     name: Container (${{ matrix.image }})
-    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    needs: scope-router
+    if: needs.scope-router.result == 'success' && needs.scope-router.outputs.run_containers == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -323,7 +465,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [backend, bot]
+        include:
+          - image: backend
+            context: .
+            dockerfile: backend/Dockerfile
+            no_cache: false
+          - image: bot
+            context: bot
+            dockerfile: bot/Dockerfile
+            # Keep the bot image fail-closed until shared COPY-cache provenance is proven.
+            no_cache: true
     steps:
       - uses: actions/checkout@v4
       - name: Run shared container contract group
@@ -337,15 +488,27 @@ jobs:
       - name: Build and scan production image
         uses: docker/build-push-action@v7
         with:
-          context: ${{ matrix.image == 'backend' && '.' || 'bot' }}
-          file: ${{ matrix.image == 'backend' && 'backend/Dockerfile' || 'bot/Dockerfile' }}
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
           load: true
           labels: |
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
           tags: ${{ steps.image.outputs.local_tag }}
+          no-cache: ${{ matrix.no_cache }}
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+      - name: Verify bot runtime image contract
+        if: matrix.image == 'bot'
+        shell: bash
+        env:
+          LOCAL_TAG: ${{ steps.image.outputs.local_tag }}
+        run: |
+          docker run --rm --network none \
+            --env TELEGRAM_BOT_TOKEN=ci-image-contract-token \
+            --env BOT_INTERNAL_TOKEN=ci-image-contract-internal-token \
+            "$LOCAL_TAG" \
+            python -c "import fitminiapp_bot.profile_sync; import fitminiapp_bot.public_profile; import fitminiapp_bot.telegram_client"
       - name: Scan image
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
         with:
@@ -363,7 +526,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Publish immutable image after merge
+      - name: Publish scanned image
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         env:
           LOCAL_TAG: ${{ steps.image.outputs.local_tag }}
@@ -374,13 +537,22 @@ jobs:
     name: ${{ github.event_name == 'pull_request' && 'checks' || 'branch-checks' }}
     if: always()
     needs:
-      [task-provenance, merge-provenance, quality, policy, frontend, frontend-smoke, python-tests, migrated-stack, dependency-audit, containers]
+      [scope-router, task-provenance, merge-provenance, quality, policy, frontend, frontend-smoke, python-tests, migrated-stack, dependency-audit, containers, critical-smoke, workflow-contracts]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
       - name: Verify required result set
         env:
           EVENT_NAME: ${{ github.event_name }}
+          PROFILE: ${{ needs.scope-router.outputs.profile }}
+          EXPECTED_JOBS: ${{ needs.scope-router.outputs.required_jobs }}
+          REQUIRED_GROUPS: ${{ needs.scope-router.outputs.required_groups }}
+          SKIPPED_GROUPS: ${{ needs.scope-router.outputs.skipped_groups }}
+          SCOPE_ROUTER_RESULT: ${{ needs.scope-router.result }}
           TASK_PROVENANCE_RESULT: ${{ needs.task-provenance.result }}
           MERGE_PROVENANCE_RESULT: ${{ needs.merge-provenance.result }}
           QUALITY_RESULT: ${{ needs.quality.result }}
@@ -391,19 +563,41 @@ jobs:
           MIGRATED_STACK_RESULT: ${{ needs.migrated-stack.result }}
           DEPENDENCY_AUDIT_RESULT: ${{ needs.dependency-audit.result }}
           CONTAINERS_RESULT: ${{ needs.containers.result }}
+          CRITICAL_SMOKE_RESULT: ${{ needs.critical-smoke.result }}
+          WORKFLOW_CONTRACTS_RESULT: ${{ needs.workflow-contracts.result }}
         run: |
           set -Eeuo pipefail
-          if [ "$EVENT_NAME" = pull_request ]; then
-            test "$TASK_PROVENANCE_RESULT" = success
-            test "$QUALITY_RESULT" = success
-            test "$POLICY_RESULT" = success
-            test "$FRONTEND_RESULT" = success
-            test "$FRONTEND_SMOKE_RESULT" = success
-            test "$PYTHON_TESTS_RESULT" = success
-            test "$MIGRATED_STACK_RESULT" = success
-            test "$DEPENDENCY_AUDIT_RESULT" = success
-            test "$CONTAINERS_RESULT" = success
-          else
-            test "$MERGE_PROVENANCE_RESULT" = success
-            test "$CONTAINERS_RESULT" = success
-          fi
+          test "$SCOPE_ROUTER_RESULT" = success
+          test -n "$EXPECTED_JOBS"
+          echo "CI_RESULT_PROFILE=$PROFILE"
+          echo "CI_RESULT_REQUIRED_GROUPS=$REQUIRED_GROUPS"
+          echo "CI_RESULT_SKIPPED_GROUPS=$SKIPPED_GROUPS"
+          RESULTS_JSON="$(python - <<'PY'
+          import json
+          import os
+
+          result_names = (
+              "scope-router",
+              "task-provenance",
+              "merge-provenance",
+              "quality",
+              "policy",
+              "frontend",
+              "frontend-smoke",
+              "python-tests",
+              "migrated-stack",
+              "dependency-audit",
+              "containers",
+              "critical-smoke",
+              "workflow-contracts",
+          )
+          env_names = {
+              name: name.upper().replace("-", "_") + "_RESULT"
+              for name in result_names
+          }
+          print(json.dumps({name: os.environ[env_name] for name, env_name in env_names.items()}))
+          PY
+          )"
+          python scripts/ci_contract.py verify-results \
+            --expected-jobs "$EXPECTED_JOBS" \
+            --results-json "$RESULTS_JSON"

--- a/docs/mobile-tma-quality-gate.md
+++ b/docs/mobile-tma-quality-gate.md
@@ -72,7 +72,7 @@ production hooks только ради удобства теста.
 
 ### Lanes и evidence
 
-- `npm run e2e:ci` — authoritative Chromium suite; в CI он выполняется тремя shards и включает
+- `npm run e2e:ci` — authoritative Chromium suite; в CI он выполняется четырьмя shards и включает
   `tma-smoke.spec.ts` и `demo-mode.spec.ts`.
 - `npm run e2e:migrated-stack` — отдельный authoritative Chromium lane с FastAPI и PostgreSQL;
   он проверяет реальный browser/API/database path и не заменяется route mock.

--- a/docs/task-branch-integration.md
+++ b/docs/task-branch-integration.md
@@ -38,7 +38,8 @@ approval между merge и normal deploy не создаётся.
 ## Shared gate
 
 `scripts/ci_contract.py` — единственный registry команд CI. Он содержит детерминированные профили:
-`frontend`, `backend`, `cross-stack`, `workflow-platform`, `documentation`. GitHub workflow и
+`frontend`, `backend`, `migration`, `cross-stack`, `workflow-platform`, `documentation`.
+GitHub workflow и
 локальный `scripts/pre_push_gate.py` вызывают одни и те же group IDs; profile выбирается по
 изменённым путям консервативно, а отсутствующий prerequisite даёт `PRE_PUSH_CI_BLOCKED`.
 
@@ -48,6 +49,36 @@ approval между merge и normal deploy не создаётся.
 target base, scope/profile, группы, timestamps, contract version/digest, clean-worktree marker и
 самопроверяемый evidence digest. `PRE_PUSH_CI_PASS` действителен только для exact HEAD и exact
 base; изменение кода, CI contract, base или рабочей директории инвалидирует его.
+
+## Scope-aware remote CI
+
+GitHub PR CI сначала запускает дешёвый `scope-router`. Он получает exact diff между
+`pull_request.base.sha` и `pull_request.head.sha`, вызывает `scripts/ci_contract.py route` и передаёт
+один decision в остальные jobs. `scripts/ci_contract.py` остаётся единственным registry команд и
+одновременно используется локальным `pre-push` gate, поэтому path classification не дублируется в
+workflow `if:`.
+
+Router выбирает консервативный профиль: documentation-only оставляет quality,
+workflow-contract и aggregate `checks` (policy добавляется для policy-файлов); frontend/backend/migration/API и dependency changes
+получают соответствующий минимальный safe set; unknown или shared CI contract автоматически
+поднимаются до `cross-stack`. Для каждого запуска в логе видны `CI_SCOPE`, `CI_CHANGED_PATHS`,
+`CI_REQUIRED_GROUPS`, `CI_REQUIRED_JOBS` и причины `CI_SKIPPED_GROUPS`. Aggregate job передаёт этот
+expected result set в `scripts/ci_contract.py verify-results`; required job со статусом `skipped`,
+`cancelled` или отсутствующий job не может дать зелёный `checks`.
+
+Обычные PR runs используют `cancel-in-progress` только для одного PR: новый SHA отменяет устаревший
+незавершённый run того же PR. Production/release workflow сохраняет `group: production` и
+`cancel-in-progress: false`. `schedule` и `workflow_dispatch` запускают полный cross-stack profile
+на текущем `master`, но не вызывают production deployment. Push в `master` остаётся минимальным
+post-merge набором exact provenance и immutable container delivery.
+
+Frontend jobs используют стандартный download cache `actions/setup-node` с ключом от
+`frontend/package-lock.json`; `node_modules` не является artifact или cache. Dependency audit не
+делает `npm ci`: для frontend выполняется `npm audit --omit=dev --audit-level=high`, а Python audit
+выбирается отдельно. Только подтверждённые transient `429/5xx` и network errors получают максимум
+три попытки с bounded backoff; найденная vulnerability, malformed lockfile или другая
+воспроизводимая ошибка остаётся blocking без retry. Timing выводится как `CI_TIMING` для каждой
+команды, cache signal — как `CI_CACHE`.
 
 `scripts/task_session.py mark-ready` фиксирует durable `READY_FOR_DELIVERY`: clean task worktree,
 commit provenance, approved review/QA, исходный base SHA, текущий task HEAD и локальное evidence

--- a/scripts/ci_contract.py
+++ b/scripts/ci_contract.py
@@ -15,11 +15,13 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path
 
 CONTRACT_VERSION = "ci-contract-v2"
+ROUTER_VERSION = "ci-router-v2"
 CI_SHARD_COUNT = 4
 SHARDABLE_GROUPS = frozenset({"frontend-e2e", "python-tests"})
 SHARD_RE = re.compile(r"(?P<number>[1-9][0-9]*)/(?P<count>[1-9][0-9]*)\Z")
@@ -36,6 +38,9 @@ class CommandSpec:
     name: str
     argv: tuple[str, ...]
     cwd: str = "."
+    retry_on_transient: bool = False
+    retry_max_attempts: int = 1
+    retry_delays_seconds: tuple[int, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -47,8 +52,22 @@ class GroupSpec:
     prerequisites: tuple[str, ...] = ()
 
 
-def _cmd(name: str, *argv: str, cwd: str = ".") -> CommandSpec:
-    return CommandSpec(name=name, argv=argv, cwd=cwd)
+def _cmd(
+    name: str,
+    *argv: str,
+    cwd: str = ".",
+    retry_on_transient: bool = False,
+    retry_max_attempts: int = 1,
+    retry_delays_seconds: tuple[int, ...] = (),
+) -> CommandSpec:
+    return CommandSpec(
+        name=name,
+        argv=argv,
+        cwd=cwd,
+        retry_on_transient=retry_on_transient,
+        retry_max_attempts=retry_max_attempts,
+        retry_delays_seconds=retry_delays_seconds,
+    )
 
 
 COMMAND_GROUPS: dict[str, GroupSpec] = {
@@ -146,6 +165,9 @@ COMMAND_GROUPS: dict[str, GroupSpec] = {
                 "--omit=dev",
                 "--audit-level=high",
                 cwd="frontend",
+                retry_on_transient=True,
+                retry_max_attempts=3,
+                retry_delays_seconds=(2, 10),
             ),
             _cmd(
                 "backend-dependency-audit",
@@ -155,6 +177,9 @@ COMMAND_GROUPS: dict[str, GroupSpec] = {
                 "pip-audit",
                 "-r",
                 "backend/requirements-runtime.txt",
+                retry_on_transient=True,
+                retry_max_attempts=3,
+                retry_delays_seconds=(2, 10),
             ),
             _cmd(
                 "bot-dependency-audit",
@@ -164,9 +189,59 @@ COMMAND_GROUPS: dict[str, GroupSpec] = {
                 "pip-audit",
                 "-r",
                 "bot/requirements.txt",
+                retry_on_transient=True,
+                retry_max_attempts=3,
+                retry_delays_seconds=(2, 10),
             ),
         ),
         prerequisites=("npm", "uvx"),
+    ),
+    "frontend-dependency-audit": GroupSpec(
+        name="frontend-dependency-audit",
+        commands=(
+            _cmd(
+                "frontend-dependency-audit",
+                "npm",
+                "audit",
+                "--omit=dev",
+                "--audit-level=high",
+                cwd="frontend",
+                retry_on_transient=True,
+                retry_max_attempts=3,
+                retry_delays_seconds=(2, 10),
+            ),
+        ),
+        prerequisites=("npm",),
+    ),
+    "python-dependency-audit": GroupSpec(
+        name="python-dependency-audit",
+        commands=(
+            _cmd(
+                "backend-dependency-audit",
+                "uvx",
+                "--from",
+                "pip-audit==2.10.1",
+                "pip-audit",
+                "-r",
+                "backend/requirements-runtime.txt",
+                retry_on_transient=True,
+                retry_max_attempts=3,
+                retry_delays_seconds=(2, 10),
+            ),
+            _cmd(
+                "bot-dependency-audit",
+                "uvx",
+                "--from",
+                "pip-audit==2.10.1",
+                "pip-audit",
+                "-r",
+                "bot/requirements.txt",
+                retry_on_transient=True,
+                retry_max_attempts=3,
+                retry_delays_seconds=(2, 10),
+            ),
+        ),
+        prerequisites=("uvx",),
     ),
     "policy": GroupSpec(
         name="policy",
@@ -250,12 +325,33 @@ COMMAND_GROUPS: dict[str, GroupSpec] = {
         ),
         prerequisites=("python",),
     ),
+    "critical-smoke": GroupSpec(
+        name="critical-smoke",
+        commands=(
+            _cmd(
+                "application-import-smoke",
+                "python",
+                "-c",
+                "import os, sys; sys.path.extend(['backend', 'bot']); os.environ.update({'APP_ENV': 'test', 'APP_NAME': 'Your Fitness Coach CI', 'APP_DEBUG': 'false', 'ACCESS_TOKEN_EXPIRE_MINUTES': '60', 'REFRESH_TOKEN_EXPIRE_DAYS': '30', 'DATABASE_URL': 'postgresql+psycopg://fitminiapp:test-password@127.0.0.1:5432/fitminiapp_test', 'ENABLE_DEV_AUTH': 'true', 'TELEGRAM_BOT_TOKEN': 'test-token', 'BOT_INTERNAL_TOKEN': 'test-bot-internal-token', 'SECRET_KEY': 'test-secret-key-at-least-thirty-two-characters'}); from fitminiapp_api.main import app; from fitminiapp_bot.bot import dp; assert app.title and dp is not None",
+            ),
+        ),
+        prerequisites=("python",),
+    ),
 }
 
 
 PROFILE_GROUPS: dict[str, tuple[str, ...]] = {
-    "frontend": ("quality", "frontend-checks", "frontend-e2e"),
-    "backend": ("quality", "python-tests"),
+    "frontend": ("quality", "frontend-checks", "frontend-e2e", "critical-smoke"),
+    "backend": ("quality", "python-tests", "critical-smoke"),
+    "migration": (
+        "quality",
+        "policy",
+        "python-tests",
+        "migrated-stack",
+        "critical-smoke",
+        "workflow-config",
+        "deployment-contract",
+    ),
     "cross-stack": (
         "quality",
         "frontend-checks",
@@ -263,9 +359,12 @@ PROFILE_GROUPS: dict[str, tuple[str, ...]] = {
         "python-tests",
         "migrated-stack",
         "dependency-audit",
+        "critical-smoke",
         "policy",
         "workflow-config",
+        "image-contract",
         "deployment-contract",
+        "container-contract",
     ),
     "workflow-platform": (
         "quality",
@@ -278,9 +377,574 @@ PROFILE_GROUPS: dict[str, tuple[str, ...]] = {
 }
 
 
+GROUP_TO_JOB: dict[str, str] = {
+    "quality": "quality",
+    "policy": "policy",
+    "frontend-checks": "frontend",
+    "frontend-e2e": "frontend-smoke",
+    "python-tests": "python-tests",
+    "migrated-stack": "migrated-stack",
+    "dependency-audit": "dependency-audit",
+    "frontend-dependency-audit": "dependency-audit",
+    "python-dependency-audit": "dependency-audit",
+    "container-contract": "containers",
+    "critical-smoke": "critical-smoke",
+    "workflow-config": "workflow-contracts",
+    "image-contract": "workflow-contracts",
+    "deployment-contract": "workflow-contracts",
+}
+
+ROUTER_JOB_NAMES: tuple[str, ...] = (
+    "scope-router",
+    "task-provenance",
+    "quality",
+    "policy",
+    "frontend",
+    "frontend-smoke",
+    "python-tests",
+    "migrated-stack",
+    "dependency-audit",
+    "containers",
+    "critical-smoke",
+    "workflow-contracts",
+    "merge-provenance",
+)
+
+ROUTER_OUTPUTS: dict[str, str] = {
+    "quality": "run_quality",
+    "policy": "run_policy",
+    "frontend": "run_frontend",
+    "frontend-smoke": "run_frontend_smoke",
+    "python-tests": "run_python",
+    "migrated-stack": "run_migrated_stack",
+    "dependency-audit": "run_dependency_audit",
+    "containers": "run_containers",
+    "critical-smoke": "run_critical_smoke",
+    "workflow-contracts": "run_workflow_contracts",
+    "merge-provenance": "run_merge_provenance",
+}
+
+ROUTER_GROUP_OUTPUTS: dict[str, str] = {
+    "workflow-config": "run_workflow_config",
+    "image-contract": "run_image_contract",
+    "deployment-contract": "run_deployment_contract",
+}
+
+_DOCUMENTATION_POLICY_PATHS = frozenset(
+    {"AGENTS.md", "codex-backlog/GLOBAL_RULES.md", "codex-backlog/TASK_EXECUTION_LIFECYCLE.md"}
+)
+_FRONTEND_DEPENDENCY_PATHS = frozenset({"frontend/package.json", "frontend/package-lock.json"})
+_PYTHON_DEPENDENCY_FILENAMES = frozenset(
+    {"requirements.txt", "requirements-runtime.txt", "requirements-dev.txt", "uv.lock"}
+)
+_WORKFLOW_FILENAMES = frozenset(
+    {
+        "Dockerfile",
+        ".dockerignore",
+        "docker-compose.yml",
+        "docker-compose.yaml",
+        "Caddyfile",
+        ".trivyignore.yaml",
+    }
+)
+_API_PREFIXES = (
+    "frontend/src/shared/api/",
+    "backend/fitminiapp_api/api/",
+    "backend/fitminiapp_api/schemas/",
+)
+_API_TOKENS = ("openapi", "auth", "session", "cookie", "telegram")
+_SHARED_CI_CONTRACT_PATHS = frozenset({"scripts/ci_contract.py"})
+_CONTAINER_SECURITY_PATHS = frozenset({".trivyignore.yaml"})
+_MIGRATION_PREFIXES = (
+    "backend/alembic/",
+    "backend/fitminiapp_api/db/",
+    "backend/fitminiapp_api/models/",
+)
+_ALL_ROUTABLE_GROUPS = tuple(sorted(COMMAND_GROUPS))
+
+
+def _normalized_paths(paths: Sequence[str]) -> list[str]:
+    normalized: set[str] = set()
+    for raw_path in paths:
+        if not raw_path:
+            continue
+        path = raw_path.replace("\\", "/")
+        while path.startswith("./"):
+            path = path[2:]
+        normalized.add(path)
+    return sorted(normalized)
+
+
+def _is_documentation_path(path: str) -> bool:
+    if path in _DOCUMENTATION_POLICY_PATHS:
+        return False
+    if path.casefold().endswith(".md"):
+        return True
+    return path.startswith("docs/") and path.casefold().endswith((".md", ".txt"))
+
+
+def _is_workflow_path(path: str) -> bool:
+    name = Path(path).name
+    return (
+        path in _DOCUMENTATION_POLICY_PATHS
+        or path.startswith((".github/", "scripts/", "deploy/"))
+        or name in _WORKFLOW_FILENAMES
+        or path.startswith(("docker-compose", "security/", ".docker/"))
+        or path in {".pre-commit-config.yaml", "pyproject.toml"}
+    )
+
+
+def _is_frontend_path(path: str) -> bool:
+    return path == "frontend" or path.startswith("frontend/")
+
+
+def _is_backend_path(path: str) -> bool:
+    return path in {"backend", "bot"} or path.startswith(("backend/", "bot/", "tests/integration/"))
+
+
+def _is_api_path(path: str) -> bool:
+    return path.startswith(_API_PREFIXES) or any(token in path.casefold() for token in _API_TOKENS)
+
+
+def _is_migration_path(path: str) -> bool:
+    lowered = path.casefold()
+    return path.startswith(_MIGRATION_PREFIXES) or any(
+        token in lowered.split("/") for token in ("migration", "migrations")
+    )
+
+
+def _is_container_security_path(path: str) -> bool:
+    return path in _CONTAINER_SECURITY_PATHS or path.startswith("security/")
+
+
+def _dependency_kind(path: str) -> tuple[bool, bool, bool]:
+    normalized = path.casefold()
+    name = Path(path).name.casefold()
+    frontend = normalized in {item.casefold() for item in _FRONTEND_DEPENDENCY_PATHS}
+    python = (
+        name in _PYTHON_DEPENDENCY_FILENAMES
+        and (path.startswith(("backend/", "bot/")) or path in {"uv.lock", "requirements.txt"})
+    ) or normalized == "pyproject.toml"
+    runtime = python and name in {"requirements.txt", "requirements-runtime.txt", "uv.lock"}
+    if normalized.endswith("/package-lock.json") or normalized.endswith("/package.json"):
+        frontend = True
+    return frontend, python, runtime
+
+
+def _profile_for_paths(
+    normalized: Sequence[str],
+) -> tuple[str, dict[str, bool], list[str], bool, bool, bool, bool]:
+    documentation = bool(normalized) and all(_is_documentation_path(path) for path in normalized)
+    frontend = any(_is_frontend_path(path) for path in normalized)
+    backend = any(_is_backend_path(path) for path in normalized)
+    workflow = any(_is_workflow_path(path) for path in normalized)
+    shared_ci_contract = any(path in _SHARED_CI_CONTRACT_PATHS for path in normalized)
+    container_security = any(
+        _is_container_security_path(path) for path in normalized if not _is_documentation_path(path)
+    )
+    api_contract = any(
+        _is_api_path(path) for path in normalized if not _is_documentation_path(path)
+    )
+    migration = any(
+        _is_migration_path(path) for path in normalized if not _is_documentation_path(path)
+    )
+    frontend_dependency = False
+    python_dependency = False
+    runtime_dependency = False
+    for path in normalized:
+        if _is_documentation_path(path):
+            continue
+        frontend_dep, python_dep, runtime_dep = _dependency_kind(path)
+        frontend_dependency |= frontend_dep
+        python_dependency |= python_dep
+        runtime_dependency |= runtime_dep
+
+    reasons: list[str] = []
+    if documentation:
+        reasons.append("all changed paths are documentation/backlog text")
+    if frontend:
+        reasons.append("frontend surface changed")
+    if backend:
+        reasons.append("backend, bot or integration-test surface changed")
+    if workflow:
+        reasons.append("workflow/platform/deployment surface changed")
+    if shared_ci_contract:
+        reasons.append("shared CI command contract changed; using full regression profile")
+    if api_contract:
+        reasons.append("API/auth/session/Telegram contract risk detected")
+    if migration:
+        reasons.append("migration or persistence boundary changed")
+    if container_security:
+        reasons.append("container security configuration changed; requiring image scan")
+    if frontend_dependency:
+        reasons.append("frontend dependency manifest changed")
+    if python_dependency:
+        reasons.append("Python dependency manifest changed")
+
+    if not normalized:
+        profile = "cross-stack"
+        reasons.append("empty diff is ambiguous; using conservative full profile")
+    elif documentation:
+        profile = "documentation"
+    elif (
+        shared_ci_contract
+        or api_contract
+        or (frontend and backend)
+        or (frontend and workflow)
+        or (backend and workflow)
+    ):
+        profile = "cross-stack"
+    elif migration:
+        profile = "migration"
+    elif workflow:
+        profile = "workflow-platform"
+    elif frontend:
+        profile = "frontend"
+    elif backend:
+        profile = "backend"
+    else:
+        profile = "cross-stack"
+        reasons.append("path scope is unknown; using conservative full profile")
+
+    signals = {
+        "frontend": frontend,
+        "backend": backend,
+        "workflow_platform": workflow,
+        "shared_ci_contract": shared_ci_contract,
+        "documentation": documentation,
+        "api_contract": api_contract,
+        "migration": migration,
+        "frontend_dependency": frontend_dependency,
+        "python_dependency": python_dependency,
+        "runtime_dependency": runtime_dependency,
+        "container_security": container_security,
+    }
+    return (
+        profile,
+        signals,
+        reasons,
+        frontend_dependency,
+        python_dependency,
+        runtime_dependency,
+        container_security,
+    )
+
+
+def expected_jobs_for_groups(groups: Sequence[str], *, event: str = "pull_request") -> list[str]:
+    unknown_groups = sorted(set(groups) - set(GROUP_TO_JOB))
+    if unknown_groups:
+        raise CIContractError(f"Unknown CI groups in expected result set: {unknown_groups}")
+    jobs = {"scope-router"}
+    if event == "pull_request":
+        jobs.add("task-provenance")
+    elif event == "push":
+        jobs.add("merge-provenance")
+    for group in groups:
+        job = GROUP_TO_JOB.get(group)
+        if job is not None:
+            jobs.add(job)
+    return sorted(jobs)
+
+
+def _decision_for_groups(
+    *,
+    profile: str,
+    paths: Sequence[str],
+    signals: Mapping[str, bool],
+    reasons: Sequence[str],
+    groups: Sequence[str],
+    event: str,
+) -> dict[str, object]:
+    selected_groups = list(dict.fromkeys(groups))
+    required_jobs = expected_jobs_for_groups(selected_groups, event=event)
+    selected_group_set = set(selected_groups)
+    skipped_groups = {
+        group: "not required by the selected conservative profile"
+        for group in _ALL_ROUTABLE_GROUPS
+        if group not in selected_group_set
+    }
+    dependency_full = "dependency-audit" in selected_group_set
+    dependency_frontend = dependency_full or "frontend-dependency-audit" in selected_group_set
+    dependency_python = dependency_full or "python-dependency-audit" in selected_group_set
+    outputs = {key: job in required_jobs for job, key in ROUTER_OUTPUTS.items()}
+    outputs.update(
+        {key: group in selected_group_set for group, key in ROUTER_GROUP_OUTPUTS.items()}
+    )
+    outputs.update(
+        {
+            "run_full_dependency_audit": dependency_full,
+            "run_frontend_dependency_audit": dependency_frontend,
+            "run_python_dependency_audit": dependency_python,
+        }
+    )
+    return {
+        "event": event,
+        "profile": profile,
+        "paths": list(paths),
+        "signals": dict(signals),
+        "reasons": list(reasons),
+        "groups": selected_groups,
+        "required_groups": selected_groups,
+        "required_jobs": required_jobs,
+        "skipped_groups": skipped_groups,
+        "outputs": outputs,
+    }
+
+
+def classify_scope(paths: Sequence[str]) -> dict[str, object]:
+    """Classify changed paths with a deterministic, conservative CI profile."""
+
+    normalized = _normalized_paths(paths)
+    (
+        profile,
+        signals,
+        reasons,
+        frontend_dependency,
+        python_dependency,
+        runtime_dependency,
+        container_security,
+    ) = _profile_for_paths(normalized)
+    groups = list(PROFILE_GROUPS[profile])
+    if frontend_dependency and "frontend-dependency-audit" not in groups:
+        groups.append("frontend-dependency-audit")
+    if python_dependency and "dependency-audit" not in groups:
+        groups.append("python-dependency-audit")
+    if runtime_dependency and "container-contract" not in groups:
+        groups.append("container-contract")
+    if container_security and "container-contract" not in groups:
+        groups.append("container-contract")
+    return _decision_for_groups(
+        profile=profile,
+        paths=normalized,
+        signals=signals,
+        reasons=reasons,
+        groups=groups,
+        event="pull_request",
+    )
+
+
+def _git_changed_paths(root: Path, base_sha: str, head_sha: str) -> list[str]:
+    command = [
+        "git",
+        "-c",
+        f"safe.directory={root.resolve().as_posix()}",
+        "diff",
+        "--no-ext-diff",
+        "--name-only",
+        "-z",
+        "--find-renames",
+        base_sha,
+        head_sha,
+    ]
+    completed = subprocess.run(
+        command,
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "unknown Git error"
+        raise CIContractError(f"Cannot calculate changed paths: {detail}")
+    return _normalized_paths(completed.stdout.split("\0"))
+
+
+def route_repository(
+    root: Path,
+    *,
+    event: str,
+    base_sha: str | None = None,
+    head_sha: str | None = None,
+) -> dict[str, object]:
+    """Build the CI route for a GitHub event from the exact repository diff."""
+
+    if event == "pull_request":
+        if not base_sha or not head_sha:
+            raise CIContractError("pull_request routing requires both base_sha and head_sha")
+        paths = _git_changed_paths(root, base_sha, head_sha)
+        decision = classify_scope(paths)
+        decision["base_sha"] = base_sha
+        decision["head_sha"] = head_sha
+        return decision
+    if event == "push":
+        return _decision_for_groups(
+            profile="post-merge",
+            paths=[],
+            signals={"post_merge": True},
+            reasons=["master push runs exact provenance and immutable container delivery"],
+            groups=("container-contract",),
+            event=event,
+        )
+    if event in {"schedule", "workflow_dispatch"}:
+        return _decision_for_groups(
+            profile="cross-stack",
+            paths=[],
+            signals={"scheduled_full_regression": True},
+            reasons=["scheduled/manual regression always uses the full authoritative profile"],
+            groups=PROFILE_GROUPS["cross-stack"],
+            event=event,
+        )
+    raise CIContractError(f"Unsupported CI event: {event}")
+
+
+def _router_log(decision: Mapping[str, object]) -> None:
+    print(f"CI_SCOPE profile={decision['profile']} event={decision['event']}", flush=True)
+    print(f"CI_CHANGED_PATHS {json.dumps(decision['paths'], ensure_ascii=False)}", flush=True)
+    print(
+        f"CI_REQUIRED_GROUPS {json.dumps(decision['required_groups'], ensure_ascii=False)}",
+        flush=True,
+    )
+    print(
+        f"CI_REQUIRED_JOBS {json.dumps(decision['required_jobs'], ensure_ascii=False)}", flush=True
+    )
+    print(
+        f"CI_SKIPPED_GROUPS {json.dumps(decision['skipped_groups'], ensure_ascii=False)}",
+        flush=True,
+    )
+    print(f"CI_SCOPE_REASONS {json.dumps(decision['reasons'], ensure_ascii=False)}", flush=True)
+
+
+def write_router_outputs(decision: Mapping[str, object], destination: Path) -> None:
+    outputs = decision.get("outputs")
+    if not isinstance(outputs, Mapping):
+        raise CIContractError("Router decision has no outputs mapping")
+    lines = [
+        f"profile={decision['profile']}",
+        f"required_groups={json.dumps(decision['required_groups'], ensure_ascii=False, separators=(',', ':'))}",
+        f"required_jobs={json.dumps(decision['required_jobs'], ensure_ascii=False, separators=(',', ':'))}",
+        f"skipped_groups={json.dumps(decision['skipped_groups'], ensure_ascii=False, separators=(',', ':'))}",
+        f"changed_paths={json.dumps(decision['paths'], ensure_ascii=False, separators=(',', ':'))}",
+    ]
+    for key, value in outputs.items():
+        lines.append(f"{key}={'true' if value else 'false'}")
+    with destination.open("a", encoding="utf-8", newline="\n") as stream:
+        stream.write("\n".join(lines) + "\n")
+
+
+def verify_results(expected_jobs: Sequence[str], results: Mapping[str, str]) -> None:
+    """Fail unless every expected job completed successfully."""
+
+    expected = list(dict.fromkeys(expected_jobs))
+    unknown_expected = sorted(set(expected) - set(ROUTER_JOB_NAMES))
+    if unknown_expected:
+        raise CIContractError(f"Unknown expected CI jobs: {unknown_expected}")
+    unknown_results = sorted(set(results) - set(ROUTER_JOB_NAMES))
+    if unknown_results:
+        raise CIContractError(f"Unknown actual CI jobs: {unknown_results}")
+    failures = {
+        job: results.get(job, "missing") for job in expected if results.get(job) != "success"
+    }
+    if failures:
+        raise CIContractError(f"Required CI jobs did not succeed: {failures}")
+    unexpected = {
+        job: status
+        for job, status in results.items()
+        if job not in expected and status != "skipped"
+    }
+    if unexpected:
+        raise CIContractError(f"Unexpected CI jobs ran outside the router result set: {unexpected}")
+
+
+def _run_command(
+    command: CommandSpec,
+    *,
+    argv: Sequence[str],
+    cwd: Path,
+    env: Mapping[str, str],
+    group: str,
+) -> None:
+    started = time.perf_counter()
+    attempts = 0
+    returncode: int | None = None
+    try:
+        while True:
+            attempts += 1
+            if command.retry_on_transient:
+                completed = subprocess.run(
+                    list(argv),
+                    cwd=cwd,
+                    env=dict(env),
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                )
+                if completed.stdout:
+                    print(completed.stdout, end="")
+                if completed.stderr:
+                    print(completed.stderr, end="", file=sys.stderr)
+            else:
+                completed = subprocess.run(list(argv), cwd=cwd, env=dict(env), check=False)
+            returncode = completed.returncode
+            if returncode == 0:
+                return
+            combined = "\n".join(
+                part
+                for part in (getattr(completed, "stdout", ""), getattr(completed, "stderr", ""))
+                if part
+            )
+            transient = command.retry_on_transient and _is_transient_failure(combined)
+            if not transient:
+                raise CIContractError(
+                    f"CI command group {group} failed at {command.name} with exit code {completed.returncode}"
+                )
+            if attempts >= command.retry_max_attempts:
+                raise CIContractError(
+                    f"BLOCKED_INFRASTRUCTURE: {group}/{command.name} exhausted "
+                    f"{attempts} attempts after a transient audit/network failure"
+                )
+            delay_index = min(attempts - 1, len(command.retry_delays_seconds) - 1)
+            delay = command.retry_delays_seconds[delay_index] if command.retry_delays_seconds else 0
+            print(
+                f"CI_RETRY group={group} command={command.name} attempt={attempts + 1}/"
+                f"{command.retry_max_attempts} delay_seconds={delay}",
+                flush=True,
+            )
+            time.sleep(delay)
+    finally:
+        duration = time.perf_counter() - started
+        status = "success" if returncode == 0 else "failed"
+        print(
+            f"CI_TIMING group={group} command={command.name} duration_seconds={duration:.3f} "
+            f"status={status} attempts={attempts}",
+            flush=True,
+        )
+
+
+def _is_transient_failure(output: str) -> bool:
+    lowered = output.casefold()
+    if re.search(
+        r"(?:http(?:\s+status|\s+error)?|status(?:\s+code)?|response|code)"
+        r"[^\d\r\n]{0,20}\b[e]?(?:429|500|502|503|504)\b",
+        lowered,
+    ):
+        return True
+    if re.search(
+        r"\b(?:429|500|502|503|504)\b\s+"
+        r"(?:too many requests|internal server error|bad gateway|service unavailable|gateway timeout)",
+        lowered,
+    ):
+        return True
+    return any(
+        marker in lowered
+        for marker in (
+            "eai_again",
+            "econnreset",
+            "etimedout",
+            "enotfound",
+            "network timeout",
+            "socket hang up",
+            "fetch failed",
+            "timed out",
+        )
+    )
+
+
 def contract_payload() -> dict[str, object]:
     return {
         "version": CONTRACT_VERSION,
+        "router_version": ROUTER_VERSION,
         "groups": {
             name: {
                 "commands": [asdict(command) for command in spec.commands],
@@ -294,6 +958,23 @@ def contract_payload() -> dict[str, object]:
             "python-tests": {
                 "count": CI_SHARD_COUNT,
                 "strategy": "pytest-node-round-robin",
+            },
+        },
+        "routing": {
+            "group_to_job": dict(sorted(GROUP_TO_JOB.items())),
+            "job_names": list(ROUTER_JOB_NAMES),
+            "outputs": dict(sorted(ROUTER_OUTPUTS.items())),
+            "group_outputs": dict(sorted(ROUTER_GROUP_OUTPUTS.items())),
+            "path_rules": {
+                "documentation_policy_paths": sorted(_DOCUMENTATION_POLICY_PATHS),
+                "frontend_dependency_paths": sorted(_FRONTEND_DEPENDENCY_PATHS),
+                "python_dependency_filenames": sorted(_PYTHON_DEPENDENCY_FILENAMES),
+                "workflow_filenames": sorted(_WORKFLOW_FILENAMES),
+                "api_prefixes": list(_API_PREFIXES),
+                "api_tokens": list(_API_TOKENS),
+                "shared_ci_contract_paths": sorted(_SHARED_CI_CONTRACT_PATHS),
+                "container_security_paths": sorted(_CONTAINER_SECURITY_PATHS),
+                "migration_prefixes": list(_MIGRATION_PREFIXES),
             },
         },
     }
@@ -519,12 +1200,13 @@ def run_group(
             argv = ["git", "-c", f"safe.directory={project_root.as_posix()}", *argv[1:]]
         cwd = (project_root / effective_command.cwd).resolve()
         print(f"$ (cd {effective_command.cwd} && {' '.join(argv)})", flush=True)
-        completed = subprocess.run(argv, cwd=cwd, env=effective_env, check=False)
-        if completed.returncode != 0:
-            raise CIContractError(
-                f"CI command group {group} failed at {effective_command.name} "
-                f"with exit code {completed.returncode}"
-            )
+        _run_command(
+            effective_command,
+            argv=argv,
+            cwd=cwd,
+            env=effective_env,
+            group=group,
+        )
 
 
 def validate_contract() -> None:
@@ -542,6 +1224,45 @@ def validate_contract() -> None:
         command_names = [item.name for item in spec.commands]
         if len(command_names) != len(set(command_names)):
             raise CIContractError(f"Duplicate command in group {name}")
+        for command in spec.commands:
+            if command.retry_max_attempts < 1:
+                raise CIContractError(f"Invalid retry limit for command {name}/{command.name}")
+            if not command.retry_on_transient and command.retry_max_attempts != 1:
+                raise CIContractError(
+                    f"Non-retryable command has a retry limit for {name}/{command.name}"
+                )
+            if command.retry_on_transient and command.retry_max_attempts > 3:
+                raise CIContractError(
+                    f"Retry limit exceeds three attempts for {name}/{command.name}"
+                )
+            if any(delay < 0 for delay in command.retry_delays_seconds):
+                raise CIContractError(f"Negative retry delay for command {name}/{command.name}")
+            if any(delay > 60 for delay in command.retry_delays_seconds):
+                raise CIContractError(f"Retry delay exceeds 60 seconds for {name}/{command.name}")
+            if len(command.retry_delays_seconds) > command.retry_max_attempts - 1:
+                raise CIContractError(f"Too many retry delays for command {name}/{command.name}")
+    if set(GROUP_TO_JOB) != set(COMMAND_GROUPS):
+        raise CIContractError("CI router group-to-job mapping is incomplete")
+    if set(ROUTER_OUTPUTS) != {
+        "quality",
+        "policy",
+        "frontend",
+        "frontend-smoke",
+        "python-tests",
+        "migrated-stack",
+        "dependency-audit",
+        "containers",
+        "critical-smoke",
+        "workflow-contracts",
+        "merge-provenance",
+    }:
+        raise CIContractError("CI router outputs do not cover the stable job set")
+    if set(ROUTER_GROUP_OUTPUTS) != {
+        "workflow-config",
+        "image-contract",
+        "deployment-contract",
+    }:
+        raise CIContractError("CI router group outputs do not cover workflow contract groups")
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -556,6 +1277,18 @@ def _parser() -> argparse.ArgumentParser:
     run.add_argument("group", choices=sorted(COMMAND_GROUPS))
     run.add_argument("--root", type=Path, default=Path.cwd())
     run.add_argument("--shard")
+    route = subparsers.add_parser("route")
+    route.add_argument(
+        "--event", choices=("pull_request", "push", "schedule", "workflow_dispatch"), required=True
+    )
+    route.add_argument("--base-sha")
+    route.add_argument("--head-sha")
+    route.add_argument("--root", type=Path, default=Path.cwd())
+    route.add_argument("--github-output", type=Path)
+    route.add_argument("--json", action="store_true")
+    verify = subparsers.add_parser("verify-results")
+    verify.add_argument("--expected-jobs", required=True)
+    verify.add_argument("--results-json", required=True)
     return parser
 
 
@@ -579,8 +1312,36 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.command == "run-group":
             run_group(args.group, root=args.root, shard=args.shard)
             return 0
+        if args.command == "route":
+            decision = route_repository(
+                args.root,
+                event=args.event,
+                base_sha=args.base_sha,
+                head_sha=args.head_sha,
+            )
+            if args.github_output is not None:
+                write_router_outputs(decision, args.github_output)
+            if args.json:
+                print(json.dumps(decision, ensure_ascii=False, sort_keys=True))
+            else:
+                _router_log(decision)
+            return 0
+        if args.command == "verify-results":
+            expected = json.loads(args.expected_jobs)
+            results = json.loads(args.results_json)
+            if not isinstance(expected, list) or not all(
+                isinstance(item, str) for item in expected
+            ):
+                raise CIContractError("Expected jobs must be a JSON string array")
+            if not isinstance(results, dict) or not all(
+                isinstance(key, str) and isinstance(value, str) for key, value in results.items()
+            ):
+                raise CIContractError("Results must be a JSON string map")
+            verify_results(expected, results)
+            print(f"CI_RESULT_SET_PASS expected={json.dumps(expected, separators=(',', ':'))}")
+            return 0
         raise AssertionError(f"Unhandled command: {args.command}")
-    except (CIContractError, OSError) as error:
+    except (CIContractError, OSError, json.JSONDecodeError) as error:
         print(f"ci contract error: {error}", file=sys.stderr)
         return 1
 

--- a/scripts/pre_push_gate.py
+++ b/scripts/pre_push_gate.py
@@ -19,8 +19,8 @@ try:
     from scripts.ci_contract import (
         COMMAND_GROUPS,
         CONTRACT_VERSION,
-        PROFILE_GROUPS,
         CIContractError,
+        classify_scope,
         contract_digest,
         missing_prerequisites,
         run_group,
@@ -29,8 +29,8 @@ except ModuleNotFoundError:
     from ci_contract import (  # type: ignore[no-redef]
         COMMAND_GROUPS,
         CONTRACT_VERSION,
-        PROFILE_GROUPS,
         CIContractError,
+        classify_scope,
         contract_digest,
         missing_prerequisites,
         run_group,
@@ -128,56 +128,10 @@ def _status(root: Path) -> list[str]:
 
 def _changed_paths(root: Path, base_sha: str, head_sha: str) -> list[str]:
     output = _run(
-        ["git", "diff", "--name-status", "--find-renames", base_sha, head_sha], cwd=root
+        ["git", "diff", "--no-ext-diff", "--name-only", "-z", "--find-renames", base_sha, head_sha],
+        cwd=root,
     ).stdout
-    paths: list[str] = []
-    for line in output.splitlines():
-        fields = line.split("\t")
-        if len(fields) >= 2:
-            paths.extend(item.replace("\\", "/") for item in fields[1:])
-    return sorted(set(paths))
-
-
-def classify_scope(paths: Sequence[str]) -> dict[str, Any]:
-    normalized = sorted({path.replace("\\", "/") for path in paths})
-    frontend = any(path == "frontend" or path.startswith("frontend/") for path in normalized)
-    backend = any(
-        path == "backend" or path.startswith(("backend/", "bot/", "tests/integration/"))
-        for path in normalized
-    )
-    workflow = any(
-        path.startswith((".github/", "scripts/", "deploy/"))
-        or path in {".pre-commit-config.yaml", "docker-compose.yml", "pyproject.toml"}
-        for path in normalized
-    )
-    documentation = bool(normalized) and all(
-        path.startswith(("docs/", "codex-backlog/", ".agents/"))
-        or path in {"README.md", "AGENTS.md"}
-        for path in normalized
-    )
-    if frontend and backend:
-        profile = "cross-stack"
-    elif workflow:
-        profile = "workflow-platform"
-    elif frontend:
-        profile = "frontend"
-    elif backend:
-        profile = "backend"
-    elif documentation:
-        profile = "documentation"
-    else:
-        profile = "cross-stack"
-    return {
-        "profile": profile,
-        "paths": normalized,
-        "signals": {
-            "frontend": frontend,
-            "backend": backend,
-            "workflow_platform": workflow,
-            "documentation": documentation,
-        },
-        "groups": list(PROFILE_GROUPS[profile]),
-    }
+    return sorted({item.replace("\\", "/") for item in output.split("\0") if item})
 
 
 def _validate_base(root: Path, base_sha: str, head_sha: str) -> None:

--- a/tests/test_ci_contract.py
+++ b/tests/test_ci_contract.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from scripts import ci_contract
+from scripts import ci_contract, pre_push_gate
 
 
 def test_ci_contract_is_valid_and_profiles_are_non_empty() -> None:
@@ -143,12 +143,33 @@ def test_workflow_calls_group_entrypoint_instead_of_inline_command_copy() -> Non
         "python-tests",
         "migrated-stack",
         "dependency-audit",
+        "frontend-dependency-audit",
+        "python-dependency-audit",
+        "critical-smoke",
+        "workflow-config",
+        "image-contract",
+        "deployment-contract",
         "container-contract",
     ):
         assert f"scripts/ci_contract.py run-group {group}" in workflow
     assert "npm run typecheck" not in workflow
     assert "npm run e2e:ci" not in workflow
     assert "scripts/run_pytest.py backend/tests" not in workflow
+
+
+def test_workflow_uses_lockfile_download_cache_without_audit_installation() -> None:
+    root = Path(__file__).parents[1]
+    workflow = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    audit_start = workflow.index("  dependency-audit:")
+    audit_end = workflow.index("  critical-smoke:", audit_start)
+    audit_job = workflow[audit_start:audit_end]
+
+    assert "NPM_CONFIG_CACHE" not in workflow
+    assert "cache: npm" in workflow
+    assert "cache-dependency-path: frontend/package-lock.json" in workflow
+    assert "node_modules" not in workflow
+    assert "npm ci" not in audit_job
+    assert "run-group frontend-dependency-audit" in audit_job
 
 
 def test_workflow_keeps_four_way_smoke_and_python_shards_independent() -> None:
@@ -168,11 +189,298 @@ def test_workflow_keeps_four_way_smoke_and_python_shards_independent() -> None:
         == 2
     )
     assert (
-        "  frontend-smoke:\n    name: Frontend smoke (${{ matrix.shard }}/4)\n    if:" in workflow
+        "  frontend-smoke:\n    name: Frontend smoke (${{ matrix.shard }}/4)\n    needs: scope-router\n    if:"
+        in workflow
     )
-    assert "  migrated-stack:\n    name: Migrated PostgreSQL stack\n    if:" in workflow
+    assert (
+        "  migrated-stack:\n    name: Migrated PostgreSQL stack\n    needs: scope-router\n    if:"
+        in workflow
+    )
 
 
 def test_cross_stack_profile_includes_delivery_policy_gates() -> None:
     groups = set(ci_contract.PROFILE_GROUPS["cross-stack"])
     assert {"policy", "workflow-config", "deployment-contract"} <= groups
+
+
+@pytest.mark.parametrize(
+    ("paths", "profile", "required_groups", "forbidden_groups"),
+    [
+        (
+            ["docs/release-flow.md", "codex-backlog/tasks/140-scope.md"],
+            "documentation",
+            {"quality", "workflow-config"},
+            {
+                "frontend-e2e",
+                "python-tests",
+                "migrated-stack",
+                "dependency-audit",
+                "container-contract",
+            },
+        ),
+        (
+            ["security/README.md"],
+            "documentation",
+            {"quality", "workflow-config"},
+            {"container-contract", "dependency-audit", "frontend-e2e", "python-tests"},
+        ),
+        (
+            ["frontend/src/App.tsx"],
+            "frontend",
+            {"frontend-checks", "frontend-e2e", "critical-smoke"},
+            {"python-tests", "migrated-stack", "dependency-audit", "container-contract"},
+        ),
+        (
+            ["backend/fitminiapp_api/services/example.py"],
+            "backend",
+            {"python-tests", "critical-smoke"},
+            {
+                "frontend-checks",
+                "frontend-e2e",
+                "migrated-stack",
+                "dependency-audit",
+                "container-contract",
+            },
+        ),
+        (
+            ["backend/fitminiapp_api/schemas/example.py"],
+            "cross-stack",
+            {
+                "frontend-e2e",
+                "python-tests",
+                "migrated-stack",
+                "dependency-audit",
+                "container-contract",
+            },
+            set(),
+        ),
+        (
+            ["backend/alembic/versions/0040_feature.py"],
+            "migration",
+            {"python-tests", "migrated-stack", "critical-smoke", "deployment-contract"},
+            {"frontend-e2e", "dependency-audit", "container-contract"},
+        ),
+        (
+            ["frontend/package-lock.json"],
+            "frontend",
+            {"frontend-dependency-audit"},
+            {"python-dependency-audit", "container-contract"},
+        ),
+        (
+            ["backend/requirements-runtime.txt"],
+            "backend",
+            {"python-dependency-audit", "container-contract"},
+            {"frontend-e2e", "migrated-stack"},
+        ),
+        (
+            [".github/workflows/ci.yml"],
+            "workflow-platform",
+            {"policy", "workflow-config", "image-contract", "deployment-contract"},
+            {
+                "frontend-e2e",
+                "python-tests",
+                "migrated-stack",
+                "dependency-audit",
+                "container-contract",
+            },
+        ),
+        (
+            ["bot/.dockerignore"],
+            "cross-stack",
+            {"container-contract", "frontend-e2e", "python-tests", "migrated-stack"},
+            set(),
+        ),
+        (
+            [".trivyignore.yaml"],
+            "workflow-platform",
+            {"container-contract", "workflow-config", "image-contract", "deployment-contract"},
+            {"frontend-e2e", "python-tests", "migrated-stack"},
+        ),
+        (
+            ["scripts/ci_contract.py"],
+            "cross-stack",
+            {
+                "frontend-e2e",
+                "python-tests",
+                "migrated-stack",
+                "dependency-audit",
+                "container-contract",
+            },
+            set(),
+        ),
+        (
+            ["unknown/build-input.bin"],
+            "cross-stack",
+            {
+                "frontend-e2e",
+                "python-tests",
+                "migrated-stack",
+                "dependency-audit",
+                "container-contract",
+            },
+            set(),
+        ),
+    ],
+)
+def test_scope_router_is_conservative_and_profile_specific(
+    paths: list[str],
+    profile: str,
+    required_groups: set[str],
+    forbidden_groups: set[str],
+) -> None:
+    decision = ci_contract.classify_scope(paths)
+
+    assert decision["profile"] == profile
+    groups = set(decision["required_groups"])
+    assert required_groups <= groups
+    assert not forbidden_groups & groups
+
+
+def test_scope_router_preserves_dot_prefixed_workflow_paths() -> None:
+    decision = ci_contract.classify_scope(["./.github/workflows/ci.yml"])
+
+    assert decision["paths"] == [".github/workflows/ci.yml"]
+    assert decision["profile"] == "workflow-platform"
+
+
+def test_scope_router_writes_machine_readable_outputs(tmp_path: Path) -> None:
+    destination = tmp_path / "github-output"
+    decision = ci_contract.classify_scope(["frontend/package.json"])
+
+    ci_contract.write_router_outputs(decision, destination)
+
+    output = destination.read_text(encoding="utf-8")
+    assert "profile=frontend" in output
+    assert "run_frontend_dependency_audit=true" in output
+    assert 'required_jobs=["' in output
+
+
+def test_repository_router_uses_exact_pull_request_diff(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        ci_contract,
+        "_git_changed_paths",
+        lambda root, base_sha, head_sha: ["backend/fitminiapp_api/main.py"],
+    )
+
+    decision = ci_contract.route_repository(
+        tmp_path,
+        event="pull_request",
+        base_sha="base",
+        head_sha="head",
+    )
+
+    assert decision["profile"] == "backend"
+    assert decision["base_sha"] == "base"
+    assert decision["head_sha"] == "head"
+
+
+def test_scheduled_and_manual_routes_use_full_regression_profile() -> None:
+    for event in ("schedule", "workflow_dispatch"):
+        decision = ci_contract.route_repository(Path.cwd(), event=event)
+        assert decision["profile"] == "cross-stack"
+        assert set(decision["required_groups"]) == set(ci_contract.PROFILE_GROUPS["cross-stack"])
+        assert decision["outputs"]["run_full_dependency_audit"] is True
+
+
+def test_push_route_keeps_merge_provenance_and_container_delivery() -> None:
+    decision = ci_contract.route_repository(Path.cwd(), event="push")
+
+    assert decision["required_jobs"] == ["containers", "merge-provenance", "scope-router"]
+    assert decision["outputs"]["run_merge_provenance"] is True
+    assert decision["outputs"]["run_containers"] is True
+
+
+def test_expected_result_set_rejects_missing_or_skipped_required_jobs() -> None:
+    expected = ["scope-router", "quality"]
+    ci_contract.verify_results(expected, {"scope-router": "success", "quality": "success"})
+
+    with pytest.raises(ci_contract.CIContractError, match="did not succeed"):
+        ci_contract.verify_results(expected, {"scope-router": "success"})
+    with pytest.raises(ci_contract.CIContractError, match="did not succeed"):
+        ci_contract.verify_results(expected, {"scope-router": "success", "quality": "skipped"})
+    with pytest.raises(ci_contract.CIContractError, match="outside the router result set"):
+        ci_contract.verify_results(
+            expected,
+            {"scope-router": "success", "quality": "success", "policy": "success"},
+        )
+
+
+def test_transient_dependency_failure_retries_with_bounded_backoff(
+    monkeypatch, tmp_path: Path
+) -> None:
+    calls = 0
+    sleeps: list[int] = []
+    command = ci_contract.CommandSpec(
+        name="audit",
+        argv=("audit",),
+        retry_on_transient=True,
+        retry_max_attempts=3,
+        retry_delays_seconds=(2, 10),
+    )
+
+    def fake_run(argv, **kwargs):
+        nonlocal calls
+        calls += 1
+        return SimpleNamespace(returncode=1, stdout="HTTP 503", stderr="")
+
+    monkeypatch.setattr(ci_contract.subprocess, "run", fake_run)
+    monkeypatch.setattr(ci_contract.time, "sleep", sleeps.append)
+
+    with pytest.raises(ci_contract.CIContractError, match="BLOCKED_INFRASTRUCTURE"):
+        ci_contract._run_command(command, argv=command.argv, cwd=tmp_path, env={}, group="audit")
+
+    assert calls == 3
+    assert sleeps == [2, 10]
+
+
+def test_dependency_vulnerability_failure_is_not_retried(monkeypatch, tmp_path: Path) -> None:
+    calls = 0
+    command = ci_contract.CommandSpec(
+        name="audit",
+        argv=("audit",),
+        retry_on_transient=True,
+        retry_max_attempts=3,
+        retry_delays_seconds=(2, 10),
+    )
+
+    def fake_run(argv, **kwargs):
+        nonlocal calls
+        calls += 1
+        return SimpleNamespace(returncode=1, stdout="high severity vulnerability", stderr="")
+
+    monkeypatch.setattr(ci_contract.subprocess, "run", fake_run)
+
+    with pytest.raises(ci_contract.CIContractError, match="failed at audit"):
+        ci_contract._run_command(command, argv=command.argv, cwd=tmp_path, env={}, group="audit")
+
+    assert calls == 1
+    assert not ci_contract._is_transient_failure("CWE-500: high severity vulnerability")
+    assert not ci_contract._is_transient_failure("npm error CWE-500: high severity vulnerability")
+    assert ci_contract._is_transient_failure("npm error code E503")
+
+
+def test_workflow_routes_scope_cancels_only_pull_request_runs() -> None:
+    root = Path(__file__).parents[1]
+    workflow = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    deploy = (root / ".github" / "workflows" / "deploy.yml").read_text(encoding="utf-8")
+
+    assert "scripts/ci_contract.py route" in workflow
+    assert "cancel-in-progress: ${{ github.event_name == 'pull_request' }}" in workflow
+    assert "schedule:" in workflow
+    assert "workflow_dispatch:" in workflow
+    assert 'test "$TARGET_REF" = refs/heads/master' in workflow
+    assert "group: production" in deploy
+    assert "cancel-in-progress: false" in deploy
+
+
+def test_local_gate_and_ci_router_share_the_same_decision() -> None:
+    fixtures = [
+        ["frontend/src/App.tsx"],
+        ["backend/fitminiapp_api/schemas/example.py"],
+        [".github/workflows/ci.yml"],
+        ["docs/release-flow.md"],
+        ["unknown/input.bin"],
+    ]
+
+    for paths in fixtures:
+        assert pre_push_gate.classify_scope(paths) == ci_contract.classify_scope(paths)


### PR DESCRIPTION
## Summary
- add a shared scope-aware CI router with conservative frontend, backend, migration, workflow and cross-stack profiles
- keep exact expected job/result sets in sync between GitHub Actions and the local pre-push gate
- harden npm download caching, dependency audits, bounded transient retries, critical import smoke and container contract coverage
- document the routing, cache and timing contract

## Validation
- local delivery gate: `PRE_PUSH_CI_PASS`
- 906 Python tests passed, 1 skipped
- 233 frontend E2E tests passed, 4 skipped
- 96 frontend unit files / 462 tests passed
- migrated PostgreSQL stack, dependency audits, policy and deployment/image/container contracts passed
- base `5e07b408ceb33b7e5d239ed046c2fdaf85333fe0`, head `94aaa2cd588a79f3dbb5db25c162df6c5eadf87a`

Task 140