### PR TITLE
[Task 83] Fix report trainer handoff visibility

### DIFF
--- a/frontend/src/pages/reports/ProgressReportPage.tsx
+++ b/frontend/src/pages/reports/ProgressReportPage.tsx
@@ -940,14 +940,14 @@ export default function ProgressReportPage() {
         </section>
       )}
 
-      {handoffId === null && auth?.user && !clientId && (
+      {handoffId === null && auth?.user?.trainer && !clientId && (
         <ReportHandoffPanel
           dateFrom={applied.dateFrom}
           dateTo={applied.dateTo}
           loading={displayFetching}
           period={applied.period}
           report={displayReport}
-          trainer={auth.user?.trainer ?? null}
+          trainer={auth.user.trainer}
         />
       )}
 

--- a/frontend/src/styles/design-v2.css
+++ b/frontend/src/styles/design-v2.css
@@ -83,6 +83,10 @@ body:has(.app-shell--design-v2) {
   gap: 12px;
 }
 
+.progress-report-custom > .ui-field {
+  align-self: start;
+}
+
 .progress-report-custom .ui-button {
   min-height: 44px;
 }

--- a/frontend/tests/e2e/progress-report.spec.ts
+++ b/frontend/tests/e2e/progress-report.spec.ts
@@ -36,6 +36,38 @@ async function installReportApi(page: Page, state: ReportState = 'full') {
   );
 }
 
+test('keeps custom date fields aligned while validation is visible', async ({ page }) => {
+  await installPlatformApi(page, { browserSession: true });
+  await installReportApi(page);
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto('/app/report?period=days_30');
+
+  await page.getByRole('tab', { name: 'Свой период' }).click();
+  const dateFrom = page.locator('#report-date-from');
+  const dateTo = page.locator('#report-date-to');
+  await expect(dateFrom).toBeVisible();
+  await expect(dateTo).toBeVisible();
+  await expect(page.getByText('Укажите обе даты.', { exact: true })).toBeVisible();
+
+  const [fromBox, toBox] = await Promise.all([dateFrom.boundingBox(), dateTo.boundingBox()]);
+  expect(fromBox).not.toBeNull();
+  expect(toBox).not.toBeNull();
+  expect(Math.abs(fromBox!.y - toBox!.y)).toBeLessThanOrEqual(1);
+  expect(Math.abs(fromBox!.height - toBox!.height)).toBeLessThanOrEqual(1);
+});
+
+test('hides trainer handoff section when the client has no assigned trainer', async ({ page }) => {
+  await installPlatformApi(page, { browserSession: true });
+  await installReportApi(page);
+  await page.goto('/app/report?period=days_30');
+
+  await expect(page.getByRole('heading', { name: 'Факты за период' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Отправить отчёт текущему тренеру' })).toHaveCount(
+    0,
+  );
+  await expect(page.getByText('Нет доступного текущего тренера', { exact: true })).toHaveCount(0);
+});
+
 test('full report keeps a mobile-first preview and creates a valid light print document', async ({
   page,
 }) => {


### PR DESCRIPTION
## Changes
- Align the custom report date fields while the shared validation message is visible.
- Hide the trainer handoff section when the authenticated client has no assigned trainer.
- Add focused E2E regression coverage for both behaviors.

## Verification
- npm run build
- npm run test -- --run tests/unit/pages/ProgressReportPage.test.tsx
- Focused progress-report E2E tests for alignment and trainer visibility
- Targeted Prettier check and git diff --check

No migrations or configuration changes.