### PR TITLE
[Task 144] Block invalid Hermes review deliveries

### DIFF
--- a/backend/fitminiapp_api/services/news_editorial.py
+++ b/backend/fitminiapp_api/services/news_editorial.py
@@ -114,7 +114,7 @@ def review_delivery_blockers(
             for warning in draft.warnings
             if isinstance(warning, str) and warning
         )
-    if review.artifact is None:
+    if is_hermes_draft and review.artifact is None:
         blockers.append("preview_artifact_unavailable")
     if is_hermes_draft and (review.image is None or not review.image.image_data):
         blockers.append("preview_image_missing")

--- a/backend/fitminiapp_api/services/news_editorial.py
+++ b/backend/fitminiapp_api/services/news_editorial.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Literal
 
+from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
 
 from fitminiapp_api.core.config import settings
@@ -90,6 +91,34 @@ class ReviewArtifact:
     transport: Literal["message", "photo"] | None
     visible_length: int | None
     limit: int | None
+
+
+HERMES_SUBMISSION_MARKER = "hermes_narrow_intake"
+PREVIEW_OPERATIONAL_BLOCKERS = frozenset({"publishing_disabled", "channel_rights_missing"})
+
+
+def review_delivery_blockers(
+    draft: NewsDraftRevision,
+    review: ReviewArtifact,
+) -> tuple[str, ...]:
+    """Return blockers that make an owner Telegram delivery unsafe or misleading."""
+
+    is_hermes_draft = draft.evidence_metadata.get("submitted_by") == HERMES_SUBMISSION_MARKER
+    blockers: list[str] = []
+    if is_hermes_draft:
+        blockers.extend(
+            blocker for blocker in review.blockers if blocker not in PREVIEW_OPERATIONAL_BLOCKERS
+        )
+        blockers.extend(
+            f"unresolved_warning:{warning}"
+            for warning in draft.warnings
+            if isinstance(warning, str) and warning
+        )
+    if review.artifact is None:
+        blockers.append("preview_artifact_unavailable")
+    if is_hermes_draft and (review.image is None or not review.image.image_data):
+        blockers.append("preview_image_missing")
+    return tuple(dict.fromkeys(blockers))
 
 
 def editorial_actor_ref(telegram_user_id: int) -> str:
@@ -532,7 +561,13 @@ def enqueue_review_deliveries(db: Session, admin_telegram_user_ids: set[int]) ->
                 .filter(
                     NewsReviewDelivery.draft_id == draft.id,
                     NewsReviewDelivery.delivery_round == cluster.delivery_round,
-                    NewsReviewDelivery.status.in_({"queued", "processing"}),
+                    or_(
+                        NewsReviewDelivery.status.in_({"queued", "processing"}),
+                        and_(
+                            NewsReviewDelivery.status == "failed",
+                            NewsReviewDelivery.last_error_code == "preview_delivery_blocked",
+                        ),
+                    ),
                 )
                 .first()
                 is not None

--- a/backend/fitminiapp_api/services/news_worker.py
+++ b/backend/fitminiapp_api/services/news_worker.py
@@ -28,6 +28,7 @@ from fitminiapp_api.services.news_editorial import (
     editorial_actor_ref,
     enqueue_review_deliveries,
     prune_news_editorial,
+    review_delivery_blockers,
     review_message,
 )
 from fitminiapp_api.services.news_freshness import is_current_month_publication
@@ -394,6 +395,45 @@ def _claim_deliveries() -> list[int]:
         return result
 
 
+def _mark_review_delivery_blocked(
+    delivery_id: int,
+    *,
+    draft_id: str,
+    text_revision: int,
+    image_revision: int,
+    attempt_count: int,
+    blockers: tuple[str, ...],
+) -> None:
+    with get_session_context() as db:
+        delivery = db.get(NewsReviewDelivery, delivery_id)
+        if delivery is None or delivery.status != "processing":
+            return
+        delivery.status = "failed"
+        delivery.processing_started_at = None
+        delivery.last_error_code = "preview_delivery_blocked"
+        record_audit_event(
+            db,
+            action="news.preview_delivery_blocked",
+            resource_type="news_draft_revision",
+            resource_id=draft_id,
+            details={
+                "blockers": list(blockers),
+                "delivery_id": delivery_id,
+                "text_revision": text_revision,
+                "image_revision": image_revision,
+            },
+        )
+    logger.warning(
+        "news_review_delivery_blocked",
+        extra={
+            "pipeline_stage": "owner_delivery",
+            "reason": "preview_not_deliverable",
+            "blockers": ",".join(blockers),
+            "attempt_count": attempt_count,
+        },
+    )
+
+
 async def deliver_review_queue(
     client: httpx.AsyncClient,
     send_message: Callable[..., Awaitable[int | None]],
@@ -426,7 +466,9 @@ async def deliver_review_queue(
                 delivery.processing_started_at = None
                 continue
             review = compose_review_artifact(db, draft, channel_ready=channel_ready)
-            message, _, markup = review_message(db, draft, channel_ready=channel_ready)
+            delivery_blockers = review_delivery_blockers(draft, review)
+            if not delivery_blockers:
+                message, _, markup = review_message(db, draft, channel_ready=channel_ready)
             image_data = review.image.image_data if review.image is not None else None
             preview_message_id = delivery.telegram_message_id
             artifact = review.artifact
@@ -436,6 +478,16 @@ async def deliver_review_queue(
             image_revision = cluster.current_image_revision
             attempt_count = delivery.attempt_count
             queue_age = max(0, round((utcnow() - delivery.created_at).total_seconds()))
+        if delivery_blockers:
+            _mark_review_delivery_blocked(
+                delivery_id,
+                draft_id=draft_resource_id,
+                text_revision=text_revision,
+                image_revision=image_revision,
+                attempt_count=attempt_count,
+                blockers=delivery_blockers,
+            )
+            continue
         try:
             if artifact is not None and preview_message_id is None:
                 preview_result = await send_preview(

--- a/backend/tests/test_news_publishing.py
+++ b/backend/tests/test_news_publishing.py
@@ -1406,6 +1406,151 @@ def test_legacy_source_fetch_flag_preserves_downstream_pipeline(monkeypatch) -> 
     assert calls == ["publish", "images", "enqueue", "deliver"]
 
 
+def test_hermes_fallback_draft_is_not_delivered_or_requeued(monkeypatch) -> None:
+    cluster_id = _source_and_candidate(external_id="hermes-fallback-delivery")
+    draft_id, _ = _draft(cluster_id)
+    monkeypatch.setattr(settings, "news_image_provider", "disabled")
+    monkeypatch.setattr(settings, "news_publication_enabled", True)
+    monkeypatch.setattr(settings, "news_channel_id", -1001234567890)
+    monkeypatch.setattr(settings, "news_channel_username", "yfc_test_news")
+    monkeypatch.setattr(settings, "admin_telegram_user_ids", "7001")
+    with get_session_context() as db:
+        cluster = db.get(NewsCluster, cluster_id)
+        draft = db.get(NewsDraftRevision, draft_id)
+        assert cluster is not None and draft is not None
+        draft.evidence_metadata = {
+            **draft.evidence_metadata,
+            "submitted_by": "hermes_narrow_intake",
+        }
+        draft.warnings = [
+            "deterministic_fallback_requires_editor",
+            "provider_response_too_large",
+        ]
+        asyncio.run(create_image_revision(db, cluster, draft, client=None))
+        assert enqueue_review_deliveries(db, {7001}) == 1
+
+    preview_calls: list[int] = []
+    control_calls: list[int] = []
+
+    async def send_preview(_client, chat_id, *_args, **_kwargs):
+        preview_calls.append(chat_id)
+        return SimpleNamespace(message_id=601, message_date=utcnow())
+
+    async def send_control(_client, chat_id, *_args, **_kwargs):
+        control_calls.append(chat_id)
+        return 602
+
+    async def deliver() -> int:
+        async with httpx.AsyncClient() as client:
+            return await deliver_review_queue(
+                client,
+                send_control,
+                send_preview,
+                channel_ready=True,
+            )
+
+    delivered = asyncio.run(deliver())
+    assert delivered == 0
+    assert preview_calls == []
+    assert control_calls == []
+    with get_session_context() as db:
+        delivery = db.query(NewsReviewDelivery).one()
+        assert delivery.status == "failed"
+        assert delivery.last_error_code == "preview_delivery_blocked"
+        event = db.query(AuditEvent).filter_by(action="news.preview_delivery_blocked").one()
+        assert (
+            "unresolved_warning:deterministic_fallback_requires_editor" in event.details["blockers"]
+        )
+        assert "unresolved_warning:provider_response_too_large" in event.details["blockers"]
+        assert enqueue_review_deliveries(db, {7001}) == 0
+
+
+def test_overlong_preview_never_sends_control_card_without_artifact(monkeypatch) -> None:
+    cluster_id = _source_and_candidate(external_id="overlong-delivery-guard")
+    draft_id, _ = _draft(cluster_id)
+    monkeypatch.setattr(settings, "news_image_provider", "disabled")
+    monkeypatch.setattr(settings, "news_publication_enabled", True)
+    monkeypatch.setattr(settings, "news_channel_id", -1001234567890)
+    monkeypatch.setattr(settings, "admin_telegram_user_ids", "7001")
+    with get_session_context() as db:
+        cluster = db.get(NewsCluster, cluster_id)
+        draft = db.get(NewsDraftRevision, draft_id)
+        assert cluster is not None and draft is not None
+        draft.evidence_metadata = {
+            **draft.evidence_metadata,
+            "submitted_by": "hermes_narrow_intake",
+            "editorial_fields": {
+                "headline": "Тест",
+                "summary": "Я" * 1009,
+                "why_it_matters": "",
+            },
+        }
+        draft.warnings = []
+        asyncio.run(create_image_revision(db, cluster, draft, client=None))
+        assert enqueue_review_deliveries(db, {7001}) == 1
+
+    preview_calls: list[int] = []
+    control_calls: list[int] = []
+
+    async def send_preview(_client, chat_id, *_args, **_kwargs):
+        preview_calls.append(chat_id)
+        return SimpleNamespace(message_id=603, message_date=utcnow())
+
+    async def send_control(_client, chat_id, *_args, **_kwargs):
+        control_calls.append(chat_id)
+        return 604
+
+    async def deliver() -> int:
+        async with httpx.AsyncClient() as client:
+            return await deliver_review_queue(
+                client,
+                send_control,
+                send_preview,
+                channel_ready=True,
+            )
+
+    delivered = asyncio.run(deliver())
+    assert delivered == 0
+    assert preview_calls == []
+    assert control_calls == []
+    with get_session_context() as db:
+        delivery = db.query(NewsReviewDelivery).one()
+        assert delivery.last_error_code == "preview_delivery_blocked"
+
+
+def test_hermes_without_image_is_not_delivered_as_text_only(monkeypatch) -> None:
+    cluster_id = _source_and_candidate(external_id="hermes-image-required")
+    draft_id, _ = _draft(cluster_id)
+    monkeypatch.setattr(settings, "news_publication_enabled", True)
+    monkeypatch.setattr(settings, "news_channel_id", -1001234567890)
+    monkeypatch.setattr(settings, "admin_telegram_user_ids", "7001")
+    with get_session_context() as db:
+        draft = db.get(NewsDraftRevision, draft_id)
+        assert draft is not None
+        draft.evidence_metadata = {
+            **draft.evidence_metadata,
+            "submitted_by": "hermes_narrow_intake",
+        }
+        assert enqueue_review_deliveries(db, {7001}) == 1
+
+    async def unexpected_send(*_args, **_kwargs):
+        raise AssertionError("Hermes delivery requires an image preview")
+
+    async def deliver() -> int:
+        async with httpx.AsyncClient() as client:
+            return await deliver_review_queue(
+                client,
+                unexpected_send,
+                unexpected_send,
+                channel_ready=True,
+            )
+
+    assert asyncio.run(deliver()) == 0
+    with get_session_context() as db:
+        delivery = db.query(NewsReviewDelivery).one()
+        assert delivery.last_error_code == "preview_delivery_blocked"
+
+
 def test_over_limit_photo_control_card_shows_measurement_and_recovery_actions(
     monkeypatch,
 ) -> None:

--- a/backend/tests/test_news_publishing.py
+++ b/backend/tests/test_news_publishing.py
@@ -1551,6 +1551,58 @@ def test_hermes_without_image_is_not_delivered_as_text_only(monkeypatch) -> None
         assert delivery.last_error_code == "preview_delivery_blocked"
 
 
+def test_legacy_overlong_preview_keeps_recovery_control_card(monkeypatch) -> None:
+    cluster_id = _source_and_candidate(external_id="legacy-overlong-delivery")
+    draft_id, _ = _draft(cluster_id)
+    monkeypatch.setattr(settings, "news_image_provider", "disabled")
+    monkeypatch.setattr(settings, "news_publication_enabled", True)
+    monkeypatch.setattr(settings, "news_channel_id", -1001234567890)
+    monkeypatch.setattr(settings, "news_channel_username", "yfc_test_news")
+    monkeypatch.setattr(settings, "admin_telegram_user_ids", "7001")
+    with get_session_context() as db:
+        cluster = db.get(NewsCluster, cluster_id)
+        draft = db.get(NewsDraftRevision, draft_id)
+        assert cluster is not None and draft is not None
+        metadata = dict(draft.evidence_metadata)
+        metadata["editorial_fields"] = {
+            "headline": "Тест",
+            "summary": "Я" * 1009,
+            "why_it_matters": "",
+        }
+        draft.evidence_metadata = metadata
+        draft.warnings = []
+        asyncio.run(create_image_revision(db, cluster, draft, client=None))
+        assert enqueue_review_deliveries(db, {7001}) == 1
+
+    preview_calls: list[int] = []
+    control_calls: list[dict[str, object]] = []
+
+    async def send_preview(_client, chat_id, *_args, **_kwargs):
+        preview_calls.append(chat_id)
+        raise AssertionError("legacy overlong delivery must keep the control-card path")
+
+    async def send_control(_client, chat_id, text, *, reply_markup):
+        control_calls.append({"chat_id": chat_id, "text": text, "reply_markup": reply_markup})
+        return 605
+
+    async def deliver() -> int:
+        async with httpx.AsyncClient() as client:
+            return await deliver_review_queue(
+                client,
+                send_control,
+                send_preview,
+                channel_ready=True,
+            )
+
+    assert asyncio.run(deliver()) == 1
+    assert preview_calls == []
+    assert len(control_calls) == 1
+    assert "Точный preview: недоступен" in control_calls[0]["text"]
+    with get_session_context() as db:
+        delivery = db.query(NewsReviewDelivery).one()
+        assert delivery.status == "sent"
+
+
 def test_over_limit_photo_control_card_shows_measurement_and_recovery_actions(
     monkeypatch,
 ) -> None:

--- a/docs/telegram-news-editorial-automation.md
+++ b/docs/telegram-news-editorial-automation.md
@@ -101,6 +101,15 @@ draft и transient retry; paid/cloud fallback, новые credentials и provide
 публикацию. YFC по-прежнему применяет `manual_required`, Gate B/C и остаётся единственным
 publisher.
 
+YFC имеет дополнительный final delivery gate: Hermes draft не отправляется владельцу в Telegram,
+пока не собраны exact image и rendered caption и не сняты content/publication blockers. Fallback-
+заглушки, unresolved provider warnings, переполненный caption и отсутствие artifact не создают
+ни preview, ни управляющую карточку. Заблокированная попытка фиксируется как bounded failure и
+не повторяется для той же text/image revision; новая попытка появляется только после новой
+ревизии текста или изображения. Операционные состояния `publishing_disabled` и
+`channel_rights_missing` не меняют требование наличия image+text preview и не считаются
+содержательным fallback.
+
 ## Taxonomy and policy
 
 `NewsCluster` stores versioned independent fields:


### PR DESCRIPTION
## Summary
- block Hermes review delivery unless exact image artifact and valid editorial content are present
- suppress control cards for invalid/fallback/oversized/text-only Hermes revisions and bound same-revision retries
- add regression coverage and operational documentation

## Verification
- local PRE_PUSH_CI_PASS: quality, python-tests, critical-smoke
- 948 passed, 1 skipped
- independent review: APPROVED

Task: 144