### PR TITLE
[Task 148] Silence legacy news review backlog

### DIFF
--- a/backend/fitminiapp_api/services/news_editorial.py
+++ b/backend/fitminiapp_api/services/news_editorial.py
@@ -95,6 +95,13 @@ class ReviewArtifact:
 
 HERMES_SUBMISSION_MARKER = "hermes_narrow_intake"
 PREVIEW_OPERATIONAL_BLOCKERS = frozenset({"publishing_disabled", "channel_rights_missing"})
+LEGACY_REVIEW_DELIVERY_DISABLED = "legacy_review_delivery_disabled"
+
+
+def is_hermes_origin_draft(draft: NewsDraftRevision) -> bool:
+    """Return whether a revision came through the canonical Hermes intake marker."""
+
+    return draft.evidence_metadata.get("submitted_by") == HERMES_SUBMISSION_MARKER
 
 
 def review_delivery_blockers(
@@ -103,7 +110,7 @@ def review_delivery_blockers(
 ) -> tuple[str, ...]:
     """Return blockers that make an owner Telegram delivery unsafe or misleading."""
 
-    is_hermes_draft = draft.evidence_metadata.get("submitted_by") == HERMES_SUBMISSION_MARKER
+    is_hermes_draft = is_hermes_origin_draft(draft)
     blockers: list[str] = []
     if is_hermes_draft:
         blockers.extend(
@@ -456,13 +463,26 @@ def moderate_draft(
             outcome = "limit_reached"
         else:
             revoke_active_decisions(db, cluster.id, reason="editorial_regenerate")
-            transition_news_cluster(
-                db,
-                cluster,
-                "candidate",
-                reason_code="owner_regenerate",
-                actor_ref=actor_ref,
-            )
+            if is_hermes_origin_draft(draft):
+                # There is no Hermes text-generation request contract in YFC. Re-queue the
+                # accepted immutable revision instead of routing it through legacy candidate
+                # generation, which is intentionally disabled in Hermes production.
+                cluster.delivery_round += 1
+                transition_news_cluster(
+                    db,
+                    cluster,
+                    "draft_ready",
+                    reason_code="owner_regenerate_hermes_revision",
+                    actor_ref=actor_ref,
+                )
+            else:
+                transition_news_cluster(
+                    db,
+                    cluster,
+                    "candidate",
+                    reason_code="owner_regenerate",
+                    actor_ref=actor_ref,
+                )
             cluster.deferred_until = None
             result_status = "queued"
     db.add(
@@ -488,8 +508,14 @@ def moderate_draft(
 
 def enqueue_review_deliveries(db: Session, admin_telegram_user_ids: set[int]) -> int:
     now = utcnow()
+    legacy_source_fetch_enabled = settings.news_legacy_source_fetch_enabled
+    if not legacy_source_fetch_enabled:
+        cancel_legacy_review_deliveries(db)
     image_pending = db.query(NewsCluster).filter(NewsCluster.status == "image_pending").all()
     for cluster in image_pending:
+        draft = latest_draft(db, cluster)
+        if not legacy_source_fetch_enabled and (draft is None or not is_hermes_origin_draft(draft)):
+            continue
         transition_news_cluster(
             db,
             cluster,
@@ -506,6 +532,9 @@ def enqueue_review_deliveries(db: Session, admin_telegram_user_ids: set[int]) ->
         .all()
     )
     for cluster in deferred:
+        draft = latest_draft(db, cluster)
+        if not legacy_source_fetch_enabled and (draft is None or not is_hermes_origin_draft(draft)):
+            continue
         transition_news_cluster(
             db,
             cluster,
@@ -523,6 +552,9 @@ def enqueue_review_deliveries(db: Session, admin_telegram_user_ids: set[int]) ->
     for cluster in clusters:
         draft = latest_draft(db, cluster)
         if draft is None:
+            continue
+        if not legacy_source_fetch_enabled and not is_hermes_origin_draft(draft):
+            _cancel_pending_deliveries(db, draft.id)
             continue
         if not source_metadata_is_current_month(draft.evidence_metadata, now=now):
             _cancel_pending_deliveries(db, draft.id)
@@ -621,6 +653,36 @@ def enqueue_review_deliveries(db: Session, admin_telegram_user_ids: set[int]) ->
             )
     db.flush()
     return created
+
+
+def cancel_legacy_review_deliveries(db: Session) -> int:
+    """Cancel queued/processing legacy deliveries while source acquisition is disabled."""
+
+    if settings.news_legacy_source_fetch_enabled:
+        return 0
+    rows = (
+        db.query(NewsReviewDelivery)
+        .filter(NewsReviewDelivery.status.in_({"queued", "processing"}))
+        .all()
+    )
+    if not rows:
+        return 0
+    draft_ids = {row.draft_id for row in rows}
+    drafts = {
+        draft.id: draft
+        for draft in db.query(NewsDraftRevision).filter(NewsDraftRevision.id.in_(draft_ids)).all()
+    }
+    cancelled = 0
+    for delivery in rows:
+        draft = drafts.get(delivery.draft_id)
+        if draft is None or is_hermes_origin_draft(draft):
+            continue
+        delivery.status = "cancelled"
+        delivery.processing_started_at = None
+        delivery.next_attempt_at = None
+        delivery.last_error_code = LEGACY_REVIEW_DELIVERY_DISABLED
+        cancelled += 1
+    return cancelled
 
 
 def compose_review_artifact(

--- a/backend/fitminiapp_api/services/news_worker.py
+++ b/backend/fitminiapp_api/services/news_worker.py
@@ -24,9 +24,12 @@ from fitminiapp_api.models.news import (
 from fitminiapp_api.services.audit import record_audit_event
 from fitminiapp_api.services.news_drafts import create_draft_revision
 from fitminiapp_api.services.news_editorial import (
+    LEGACY_REVIEW_DELIVERY_DISABLED,
+    cancel_legacy_review_deliveries,
     compose_review_artifact,
     editorial_actor_ref,
     enqueue_review_deliveries,
+    is_hermes_origin_draft,
     prune_news_editorial,
     review_delivery_blockers,
     review_message,
@@ -446,6 +449,9 @@ async def deliver_review_queue(
         editorial_actor_ref(telegram_id): telegram_id
         for telegram_id in settings.admin_telegram_id_set
     }
+    if not settings.news_legacy_source_fetch_enabled:
+        with get_session_context() as db:
+            cancel_legacy_review_deliveries(db)
     delivered = 0
     for delivery_id in _claim_deliveries():
         with get_session_context() as db:
@@ -464,6 +470,12 @@ async def deliver_review_queue(
             ):
                 delivery.status = "cancelled"
                 delivery.processing_started_at = None
+                continue
+            if not settings.news_legacy_source_fetch_enabled and not is_hermes_origin_draft(draft):
+                delivery.status = "cancelled"
+                delivery.processing_started_at = None
+                delivery.next_attempt_at = None
+                delivery.last_error_code = LEGACY_REVIEW_DELIVERY_DISABLED
                 continue
             review = compose_review_artifact(db, draft, channel_ready=channel_ready)
             delivery_blockers = review_delivery_blockers(draft, review)

--- a/backend/tests/test_news_publishing.py
+++ b/backend/tests/test_news_publishing.py
@@ -31,6 +31,7 @@ from fitminiapp_api.services.news_editorial import (
     compose_review_artifact,
     edit_text_revision,
     enqueue_review_deliveries,
+    moderate_draft,
     review_message,
 )
 from fitminiapp_api.services.news_images import (
@@ -1404,6 +1405,275 @@ def test_legacy_source_fetch_flag_preserves_downstream_pipeline(monkeypatch) -> 
     )
 
     assert calls == ["publish", "images", "enqueue", "deliver"]
+
+
+def test_legacy_draft_ready_stays_silent_when_legacy_fetch_is_disabled(monkeypatch) -> None:
+    cluster_id = _source_and_candidate(external_id="legacy-draft-ready-silent")
+    draft_id, _ = _draft(cluster_id)
+    monkeypatch.setattr(settings, "news_legacy_source_fetch_enabled", False)
+
+    with get_session_context() as db:
+        cluster = db.get(NewsCluster, cluster_id)
+        assert cluster is not None
+        cluster.status = "draft_ready"
+
+        assert enqueue_review_deliveries(db, {7001}) == 0
+        assert cluster.status == "draft_ready"
+        assert db.get(NewsDraftRevision, draft_id) is not None
+        assert db.query(NewsReviewDelivery).count() == 0
+
+
+def test_expired_legacy_deferred_stays_silent_when_legacy_fetch_is_disabled(monkeypatch) -> None:
+    cluster_id = _source_and_candidate(external_id="legacy-deferred-silent")
+    draft_id, _ = _draft(cluster_id)
+    monkeypatch.setattr(settings, "news_legacy_source_fetch_enabled", False)
+
+    with get_session_context() as db:
+        cluster = db.get(NewsCluster, cluster_id)
+        assert cluster is not None
+        cluster.status = "deferred"
+        cluster.deferred_until = utcnow() - timedelta(seconds=1)
+
+        assert enqueue_review_deliveries(db, {7001}) == 0
+        assert cluster.status == "deferred"
+        assert cluster.deferred_until is not None
+        assert db.get(NewsDraftRevision, draft_id) is not None
+        assert db.query(NewsReviewDelivery).count() == 0
+
+
+def test_legacy_publication_failed_does_not_create_owner_delivery_when_disabled(
+    monkeypatch,
+) -> None:
+    cluster_id = _source_and_candidate(external_id="legacy-publication-failed-silent")
+    draft_id, _ = _draft(cluster_id)
+    monkeypatch.setattr(settings, "news_legacy_source_fetch_enabled", False)
+
+    with get_session_context() as db:
+        cluster = db.get(NewsCluster, cluster_id)
+        assert cluster is not None
+        cluster.status = "publication_failed"
+
+        assert enqueue_review_deliveries(db, {7001}) == 0
+        assert cluster.status == "publication_failed"
+        assert db.get(NewsDraftRevision, draft_id) is not None
+        assert db.query(NewsReviewDelivery).count() == 0
+
+
+def test_legacy_awaiting_review_does_not_get_preview_upgrade_when_disabled(monkeypatch) -> None:
+    cluster_id = _source_and_candidate(external_id="legacy-awaiting-review-silent")
+    draft_id, _ = _draft(cluster_id)
+    monkeypatch.setattr(settings, "news_legacy_source_fetch_enabled", False)
+
+    with get_session_context() as db:
+        cluster = db.get(NewsCluster, cluster_id)
+        assert cluster is not None
+        cluster.status = "awaiting_review"
+        delivery_round = cluster.delivery_round
+
+        assert enqueue_review_deliveries(db, {7001}) == 0
+        assert cluster.status == "awaiting_review"
+        assert cluster.delivery_round == delivery_round
+        assert db.query(NewsReviewDelivery).count() == 0
+        assert (
+            db.query(AuditEvent)
+            .filter_by(action="news.preview_upgrade_queued", resource_id=draft_id)
+            .count()
+            == 0
+        )
+
+
+@pytest.mark.parametrize("delivery_status", ["queued", "processing"])
+def test_pending_legacy_delivery_is_cancelled_before_telegram_send(
+    monkeypatch, delivery_status
+) -> None:
+    cluster_id = _source_and_candidate(external_id="legacy-queued-cancel")
+    draft_id, _ = _draft(cluster_id)
+    monkeypatch.setattr(settings, "news_legacy_source_fetch_enabled", True)
+    monkeypatch.setattr(settings, "admin_telegram_user_ids", "7001")
+    with get_session_context() as db:
+        assert enqueue_review_deliveries(db, {7001}) == 1
+        delivery = db.query(NewsReviewDelivery).one()
+        delivery.status = delivery_status
+        delivery.processing_started_at = utcnow() if delivery_status == "processing" else None
+
+    monkeypatch.setattr(settings, "news_legacy_source_fetch_enabled", False)
+    calls: list[str] = []
+
+    async def unexpected_send(*_args, **_kwargs):
+        calls.append("telegram")
+        raise AssertionError("legacy delivery must be cancelled before Telegram send")
+
+    async def deliver() -> int:
+        async with httpx.AsyncClient() as client:
+            return await deliver_review_queue(
+                client,
+                unexpected_send,
+                unexpected_send,
+                channel_ready=True,
+            )
+
+    assert asyncio.run(deliver()) == 0
+    assert calls == []
+    with get_session_context() as db:
+        delivery = db.query(NewsReviewDelivery).one()
+        assert delivery.draft_id == draft_id
+        assert delivery.status == "cancelled"
+        assert delivery.processing_started_at is None
+        assert delivery.next_attempt_at is None
+        assert delivery.last_error_code == "legacy_review_delivery_disabled"
+
+
+def test_hermes_draft_reaches_telegram_when_legacy_fetch_is_disabled(monkeypatch) -> None:
+    cluster_id = _source_and_candidate(external_id="hermes-downstream-enabled")
+    draft_id, _ = _draft(cluster_id)
+    monkeypatch.setattr(settings, "news_legacy_source_fetch_enabled", False)
+    monkeypatch.setattr(settings, "news_image_provider", "disabled")
+    monkeypatch.setattr(settings, "admin_telegram_user_ids", "7001")
+    with get_session_context() as db:
+        cluster = db.get(NewsCluster, cluster_id)
+        draft = db.get(NewsDraftRevision, draft_id)
+        assert cluster is not None and draft is not None
+        draft.evidence_metadata = {
+            **draft.evidence_metadata,
+            "submitted_by": "hermes_narrow_intake",
+        }
+        draft.warnings = []
+        asyncio.run(create_image_revision(db, cluster, draft, client=None))
+        assert enqueue_review_deliveries(db, {7001}) == 1
+
+    preview_calls: list[int] = []
+    control_calls: list[int] = []
+
+    async def send_preview(_client, chat_id, *_args, **_kwargs):
+        preview_calls.append(chat_id)
+        return SimpleNamespace(message_id=611, message_date=utcnow())
+
+    async def send_control(_client, chat_id, *_args, **_kwargs):
+        control_calls.append(chat_id)
+        return 612
+
+    async def deliver() -> int:
+        async with httpx.AsyncClient() as client:
+            return await deliver_review_queue(
+                client,
+                send_control,
+                send_preview,
+                channel_ready=True,
+            )
+
+    assert asyncio.run(deliver()) == 1
+    assert preview_calls == [7001]
+    assert control_calls == [7001]
+    with get_session_context() as db:
+        delivery = db.query(NewsReviewDelivery).one()
+        assert delivery.status == "sent"
+        assert db.get(NewsDraftRevision, draft_id).evidence_metadata["submitted_by"] == (
+            "hermes_narrow_intake"
+        )
+
+
+def test_owner_edited_hermes_revision_keeps_delivery_eligibility(monkeypatch) -> None:
+    cluster_id = _source_and_candidate(external_id="hermes-owner-edit-marker")
+    draft_id, _ = _draft(cluster_id)
+    monkeypatch.setattr(settings, "news_legacy_source_fetch_enabled", False)
+    monkeypatch.setattr(settings, "news_image_provider", "disabled")
+    with get_session_context() as db:
+        cluster = db.get(NewsCluster, cluster_id)
+        draft = db.get(NewsDraftRevision, draft_id)
+        assert cluster is not None and draft is not None
+        draft.evidence_metadata = {
+            **draft.evidence_metadata,
+            "submitted_by": "hermes_narrow_intake",
+        }
+        draft.warnings = []
+        asyncio.run(create_image_revision(db, cluster, draft, client=None))
+        cluster.status = "awaiting_review"
+        result = edit_text_revision(
+            db,
+            draft_id=draft.id,
+            expected_image_revision=cluster.current_image_revision,
+            admin_telegram_user_id=7001,
+            draft_text=draft.draft_text,
+        )
+        assert result.status == "queued"
+        edited = (
+            db.query(NewsDraftRevision)
+            .filter(NewsDraftRevision.cluster_id == cluster.id)
+            .order_by(NewsDraftRevision.revision.desc())
+            .first()
+        )
+        assert edited is not None and edited.id != draft.id
+        assert edited.evidence_metadata["submitted_by"] == "hermes_narrow_intake"
+        asyncio.run(create_image_revision(db, cluster, edited, client=None))
+        assert enqueue_review_deliveries(db, {7001}) == 1
+
+
+def test_hermes_regenerate_requeues_revision_without_legacy_candidate_generation(
+    monkeypatch,
+) -> None:
+    cluster_id = _source_and_candidate(external_id="hermes-regenerate-disabled-legacy")
+    draft_id, _ = _draft(cluster_id)
+    monkeypatch.setattr(settings, "news_ingestion_enabled", True)
+    monkeypatch.setattr(settings, "news_legacy_source_fetch_enabled", False)
+    monkeypatch.setattr(settings, "news_image_provider", "disabled")
+    monkeypatch.setattr(settings, "admin_telegram_user_ids", "7001")
+    with get_session_context() as db:
+        cluster = db.get(NewsCluster, cluster_id)
+        draft = db.get(NewsDraftRevision, draft_id)
+        assert cluster is not None and draft is not None
+        draft.evidence_metadata = {
+            **draft.evidence_metadata,
+            "submitted_by": "hermes_narrow_intake",
+        }
+        draft.warnings = []
+        asyncio.run(create_image_revision(db, cluster, draft, client=None))
+        assert enqueue_review_deliveries(db, {7001}) == 1
+        result = moderate_draft(
+            db,
+            draft_id=draft.id,
+            admin_telegram_user_id=7001,
+            action="regenerate",
+        )
+        assert result.status == "queued"
+        assert result.cluster_status == "draft_ready"
+        assert cluster.status == "draft_ready"
+        assert cluster.delivery_round == 1
+        assert db.query(NewsReviewDelivery).one().status == "cancelled"
+
+    async def unexpected_candidate_generation(*_args, **_kwargs):
+        raise AssertionError("Hermes regeneration must not call legacy candidate generation")
+
+    monkeypatch.setattr(news_worker, "generate_candidate_drafts", unexpected_candidate_generation)
+    preview_calls: list[int] = []
+    control_calls: list[int] = []
+
+    async def send_preview(_client, chat_id, *_args, **_kwargs):
+        preview_calls.append(chat_id)
+        return SimpleNamespace(message_id=621, message_date=utcnow())
+
+    async def send_control(_client, chat_id, *_args, **_kwargs):
+        control_calls.append(chat_id)
+        return 622
+
+    async def unused_publication(*_args, **_kwargs):
+        raise AssertionError("publication is not part of Hermes regenerate review flow")
+
+    asyncio.run(
+        run_news_pipeline_once(
+            send_message=send_control,
+            send_preview=send_preview,
+            send_publication=unused_publication,
+            publication_ready=False,
+            fetch_sources=True,
+        )
+    )
+    assert preview_calls == [7001]
+    assert control_calls == [7001]
+    with get_session_context() as db:
+        cluster = db.get(NewsCluster, cluster_id)
+        assert cluster is not None and cluster.status == "awaiting_review"
+        deliveries = db.query(NewsReviewDelivery).order_by(NewsReviewDelivery.id).all()
+        assert [delivery.status for delivery in deliveries] == ["cancelled", "sent"]
 
 
 def test_hermes_fallback_draft_is_not_delivered_or_requeued(monkeypatch) -> None:

--- a/docs/telegram-news-editorial-automation.md
+++ b/docs/telegram-news-editorial-automation.md
@@ -23,6 +23,14 @@ production-конфигурации Hermes оно нормализуется в 
 ручное редактирование/подтверждение, планирование и управление публикацией продолжают работать.
 Его нельзя реализовывать изменением `NEWS_INGESTION_ENABLED`.
 
+При `NEWS_LEGACY_SOURCE_FETCH_ENABLED=false` в review downstream допускаются только revisions с
+canonical marker `evidence_metadata["submitted_by"] == "hermes_narrow_intake"`. Уже сохранённые
+legacy drafts и clusters не удаляются и не переводятся обратно из `deferred`; queued/processing
+legacy `NewsReviewDelivery` безопасно отменяются до Telegram send, а новые legacy delivery и
+preview upgrade не создаются. Hermes owner-edited revisions сохраняют marker и продолжают
+проходить review flow. Действие «Перегенерировать текст» для Hermes повторно ставит принятую
+immutable revision в review flow и не включает legacy candidate generation.
+
 После production release целевые значения для разделения контуров такие:
 
 ```text


### PR DESCRIPTION
## Что изменено\n- при NEWS_LEGACY_SOURCE_FETCH_ENABLED=false review delivery разрешена только для evidence_metadata.submitted_by=hermes_narrow_intake; legacy backlog сохраняется и становится silent\n- queued/processing legacy NewsReviewDelivery fail-safe отменяются до Telegram send\n- Hermes owner-edited revisions сохраняют marker\n- Hermes regenerate requeues the accepted revision без legacy candidate generation\n\n## Проверки\n- targeted news regressions: 9 passed\n- full news suite: 82 passed\n- exact pre-push gate: 962 passed, 1 skipped; critical smoke passed\n- migrations/config/provider/HMAC/Telegram credentials не менялись\n\nCloses Task 148.