### PR TITLE
[Task 107] feat: publish Allure through Caddy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,11 @@ ALLURE_REPORT_ORIGIN_GID=1501
 ALLURE_REPORT_ORIGIN_MEMORY_LIMIT=64m
 ALLURE_CLOUDFLARED_MEMORY_LIMIT=64m
 ALLURE_CLOUDFLARED_TUNNEL_TOKEN=
+# Optional direct HTTPS publication through the existing public Caddy. Keep
+# empty when the Cloudflare Tunnel/Access transport is selected instead.
+ALLURE_PUBLIC_HOSTNAME=
+ALLURE_BASIC_AUTH_USER=
+ALLURE_BASIC_AUTH_HASH=
 
 # Blue/green deployment safety envelope. Production values must be confirmed from measured host
 # headroom before the owner-approved bootstrap/rollout; these local examples are not capacity proof.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,6 +182,11 @@ services:
       # Optional for backward compatibility. When set, Caddy serves the same
       # backend on the public landing hostname as well as the app hostname.
       LANDING_DOMAIN: ${LANDING_DOMAIN:-}
+      # Optional private Allure hostname. The route is emitted only when the
+      # hostname is configured and requires a pre-hashed password.
+      ALLURE_PUBLIC_HOSTNAME: ${ALLURE_PUBLIC_HOSTNAME:-}
+      ALLURE_BASIC_AUTH_USER: ${ALLURE_BASIC_AUTH_USER:-}
+      ALLURE_BASIC_AUTH_HASH: ${ALLURE_BASIC_AUTH_HASH:-}
     entrypoint:
       - /bin/sh
       - -ec
@@ -192,6 +197,42 @@ services:
             SITE_ADDRESSES="$${APP_DOMAIN}, $${LANDING_CANONICAL}, www.$${LANDING_CANONICAL}"
         else
             SITE_ADDRESSES="$${APP_DOMAIN}"
+        fi
+        ALLURE_SITE=""
+        if [ -n "$${ALLURE_PUBLIC_HOSTNAME}" ]; then
+            : "$${ALLURE_BASIC_AUTH_USER:?ALLURE_BASIC_AUTH_USER is required when ALLURE_PUBLIC_HOSTNAME is set}"
+            : "$${ALLURE_BASIC_AUTH_HASH:?ALLURE_BASIC_AUTH_HASH is required when ALLURE_PUBLIC_HOSTNAME is set}"
+            case "$${ALLURE_PUBLIC_HOSTNAME}" in
+                *[!A-Za-z0-9.-]*)
+                    echo "ALLURE_PUBLIC_HOSTNAME must be a DNS hostname" >&2
+                    exit 1
+                    ;;
+            esac
+            case "$${ALLURE_BASIC_AUTH_USER}" in
+                *[!A-Za-z0-9._-]*)
+                    echo "ALLURE_BASIC_AUTH_USER contains unsupported characters" >&2
+                    exit 1
+                    ;;
+            esac
+            ALLURE_SITE="$$(cat <<ALLURE_CADDY_EOF
+        $${ALLURE_PUBLIC_HOSTNAME} {
+            encode zstd gzip
+
+            header {
+                Strict-Transport-Security "max-age=31536000; includeSubDomains"
+                X-Content-Type-Options "nosniff"
+                Referrer-Policy "no-referrer"
+                Content-Security-Policy "default-src 'self'; base-uri 'none'; frame-ancestors 'none'"
+            }
+
+            basic_auth {
+                $${ALLURE_BASIC_AUTH_USER} $${ALLURE_BASIC_AUTH_HASH}
+            }
+
+            reverse_proxy allure-report-origin:8080
+        }
+        ALLURE_CADDY_EOF
+        )"
         fi
         cat > /etc/caddy/Caddyfile <<EOF
         $${SITE_ADDRESSES} {
@@ -205,6 +246,8 @@ services:
 
             reverse_proxy edge:8080
         }
+
+        $${ALLURE_SITE}
         EOF
         exec caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
     depends_on:
@@ -220,6 +263,7 @@ services:
     networks:
       proxy_net:
         ipv4_address: 172.28.0.10
+      allure_reports:
 
   cloudflared:
     image: ${CLOUDFLARED_IMAGE:-cloudflare/cloudflared:latest}

--- a/docs/scheduled-regression-allure.md
+++ b/docs/scheduled-regression-allure.md
@@ -173,6 +173,29 @@ traversal, symlink, hardlink, device и превышение size limit, рас�
 Итоговый DNS diff содержит только CNAME Tunnel; прямого DNS/IP bypass нет. Это не является
 подтверждением внешнего применения: DNS, Tunnel и Access остаются owner-gated.
 
+### Альтернатива: direct HTTPS через существующий Caddy
+
+Если Cloudflare Tunnel/Access не используется, тот же report origin можно публиковать через
+уже работающий `caddy` на VPS. В этом варианте authoritative DNS остаётся у текущего DNS-
+провайдера, а `allure.your-fitness-coach.ru` получает A/AAAA на VPS. Публичный Caddy принимает
+только HTTPS, требует `basic_auth` и проксирует запросы в `allure-report-origin:8080` через
+внутреннюю сеть `allure_reports`. Host port для origin по-прежнему не открывается.
+
+Для варианта Caddy в production `.env` задаются только:
+
+    ALLURE_PUBLIC_HOSTNAME=allure.your-fitness-coach.ru
+    ALLURE_BASIC_AUTH_USER=<owner-login>
+    ALLURE_BASIC_AUTH_HASH=<argon2id-or-bcrypt-hash>
+
+`ALLURE_BASIC_AUTH_HASH` получают командой `caddy hash-password`; plaintext-пароль не хранится
+в репозитории и не передаётся publisher-пользователю. Пустой hostname отключает маршрут, а
+заданный hostname без user/hash приводит к fail-closed ошибке запуска Caddy. Cloudflare token
+и `cloudflared-allure` для этой схемы не нужны.
+
+Этот вариант не скрывает IP VPS и не даёт Cloudflare Access/WAF/DDoS-защиту. Доступ к origin
+остаётся только через публичный Caddy с HTTPS и Basic Auth; direct `:8080`, directory listing,
+write methods и служебные пути origin не публикуются.
+
 ## GitHub names и least privilege
 
 Новые/используемые GitHub Actions secrets (значения не приводятся):

--- a/tests/test_scheduled_regression.py
+++ b/tests/test_scheduled_regression.py
@@ -118,6 +118,7 @@ def test_private_report_origin_uses_isolated_caddy_and_dedicated_tunnel() -> Non
     action = (root / ".github" / "actions" / "upload-allure-results" / "action.yml").read_text(
         encoding="utf-8"
     )
+    public_caddy_block = compose.split("  caddy:\n", 1)[1].split("\n  cloudflared:\n", 1)[0]
     origin_block = compose.split("  allure-report-origin:\n", 1)[1].split("\n  worker:\n", 1)[0]
 
     assert 'profiles: ["allure-reports"]' in origin_block
@@ -126,6 +127,11 @@ def test_private_report_origin_uses_isolated_caddy_and_dedicated_tunnel() -> Non
     assert "\n    ports:" not in origin_block
     assert "allure_reports:\n    internal: true" in compose
     assert "TUNNEL_TOKEN: ${ALLURE_CLOUDFLARED_TUNNEL_TOKEN:-}" in compose
+    assert "ALLURE_PUBLIC_HOSTNAME: ${ALLURE_PUBLIC_HOSTNAME:-}" in public_caddy_block
+    assert "ALLURE_BASIC_AUTH_HASH: ${ALLURE_BASIC_AUTH_HASH:-}" in public_caddy_block
+    assert "allure_reports:" in public_caddy_block
+    assert "basic_auth" in public_caddy_block
+    assert "reverse_proxy allure-report-origin:8080" in public_caddy_block
     assert "file_server" in caddy
     assert "browse" not in caddy
     assert 'Cache-Control "private, no-store"' in caddy


### PR DESCRIPTION
## Что изменено
- добавлен безопасный прямой HTTPS-маршрут `allure` через публичный Caddy;
- Allure origin подключён только к внутренней сети `allure_reports`;
- Basic Auth включается fail-closed только при заданных `ALLURE_PUBLIC_HOSTNAME`, `ALLURE_BASIC_AUTH_USER` и `ALLURE_BASIC_AUTH_HASH`;
- добавлены `.env.example`, эксплуатационная инструкция и регрессионные проверки.

## Проверки
- `24 passed, 2 skipped`;
- `docker compose --env-file .env.example --profile direct-https --profile allure-reports config --quiet`;
- проверена валидация сгенерированного Caddy-конфига и отказ при отсутствии hash.

## Production notes
После merge deploy workflow доставит конфигурацию. На VPS нужно будет запустить только `allure-report-origin` и пересоздать публичный `caddy` с профилями `allure-reports` и `direct-https`, затем проверить `401` без авторизации и доступ после входа. Production credentials в Git не добавлялись.