### PR TITLE
[Task 107] fix: configure Caddy Argon2id auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ ALLURE_CLOUDFLARED_TUNNEL_TOKEN=
 # empty when the Cloudflare Tunnel/Access transport is selected instead.
 ALLURE_PUBLIC_HOSTNAME=
 ALLURE_BASIC_AUTH_USER=
+# Generate this value with: caddy hash-password --algorithm argon2id
 ALLURE_BASIC_AUTH_HASH=
 
 # Blue/green deployment safety envelope. Production values must be confirmed from measured host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,7 +225,7 @@ services:
                 Content-Security-Policy "default-src 'self'; base-uri 'none'; frame-ancestors 'none'"
             }
 
-            basic_auth {
+            basic_auth argon2id {
                 $${ALLURE_BASIC_AUTH_USER} $${ALLURE_BASIC_AUTH_HASH}
             }
 

--- a/docs/scheduled-regression-allure.md
+++ b/docs/scheduled-regression-allure.md
@@ -178,16 +178,16 @@ traversal, symlink, hardlink, device и превышение size limit, рас�
 Если Cloudflare Tunnel/Access не используется, тот же report origin можно публиковать через
 уже работающий `caddy` на VPS. В этом варианте authoritative DNS остаётся у текущего DNS-
 провайдера, а `allure.your-fitness-coach.ru` получает A/AAAA на VPS. Публичный Caddy принимает
-только HTTPS, требует `basic_auth` и проксирует запросы в `allure-report-origin:8080` через
+только HTTPS, требует `basic_auth argon2id` и проксирует запросы в `allure-report-origin:8080` через
 внутреннюю сеть `allure_reports`. Host port для origin по-прежнему не открывается.
 
 Для варианта Caddy в production `.env` задаются только:
 
     ALLURE_PUBLIC_HOSTNAME=allure.your-fitness-coach.ru
     ALLURE_BASIC_AUTH_USER=<owner-login>
-    ALLURE_BASIC_AUTH_HASH=<argon2id-or-bcrypt-hash>
+    ALLURE_BASIC_AUTH_HASH=<argon2id-hash>
 
-`ALLURE_BASIC_AUTH_HASH` получают командой `caddy hash-password`; plaintext-пароль не хранится
+`ALLURE_BASIC_AUTH_HASH` получают командой `caddy hash-password --algorithm argon2id`; plaintext-пароль не хранится
 в репозитории и не передаётся publisher-пользователю. Пустой hostname отключает маршрут, а
 заданный hostname без user/hash приводит к fail-closed ошибке запуска Caddy. Cloudflare token
 и `cloudflared-allure` для этой схемы не нужны.

--- a/tests/test_scheduled_regression.py
+++ b/tests/test_scheduled_regression.py
@@ -130,7 +130,7 @@ def test_private_report_origin_uses_isolated_caddy_and_dedicated_tunnel() -> Non
     assert "ALLURE_PUBLIC_HOSTNAME: ${ALLURE_PUBLIC_HOSTNAME:-}" in public_caddy_block
     assert "ALLURE_BASIC_AUTH_HASH: ${ALLURE_BASIC_AUTH_HASH:-}" in public_caddy_block
     assert "allure_reports:" in public_caddy_block
-    assert "basic_auth" in public_caddy_block
+    assert "basic_auth argon2id {" in public_caddy_block
     assert "reverse_proxy allure-report-origin:8080" in public_caddy_block
     assert "file_server" in caddy
     assert "browse" not in caddy


### PR DESCRIPTION
## Исправление
- явно указать `argon2id` в директиве Caddy `basic_auth`;
- оставить production hash в `.env` без раскрытия в Git;
- добавить регрессионную проверку и уточнить инструкцию генерации hash.

## Причина
Caddy по умолчанию использует `bcrypt`, поэтому Argon2id hash синтаксически принимался, но пароль всегда отклонялся с `401`.

## Проверки
- `24 passed, 2 skipped`;
- `docker compose --env-file .env.example --profile direct-https --profile allure-reports config --quiet`;
- pre-commit hooks passed.