### PR TITLE
[Task 107] fix: make Allure publisher Python 3.10 compatible

### DIFF
--- a/scripts/allure_report_origin.py
+++ b/scripts/allure_report_origin.py
@@ -16,7 +16,7 @@ import tempfile
 import uuid
 from collections.abc import Mapping, Sequence
 from contextlib import contextmanager, suppress
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path, PurePosixPath
 from typing import BinaryIO, Final
 from zoneinfo import ZoneInfo
@@ -44,6 +44,12 @@ _CONTROL_CHARACTERS = re.compile(r"[\u0000-\u001f\u007f]")
 
 class ReportOriginError(RuntimeError):
     """The isolated report origin rejected an unsafe or inconsistent request."""
+
+
+_ORIGIN_ERRORS: Final = (ReportOriginError, OSError)
+_MAIN_ERRORS: Final = (ReportOriginError, OSError, ValueError)
+# The publisher runs with the VPS system Python 3.10, where datetime.UTC is unavailable.
+_UTC: Final = timezone.utc  # noqa: UP017
 
 
 def _safe_segment(value: object, *, field: str) -> str:
@@ -117,7 +123,7 @@ def _parse_timestamp(value: object) -> datetime:
         raise ReportOriginError("report timestamp is invalid") from error
     if parsed.tzinfo is None:
         raise ReportOriginError("report timestamp must include a timezone")
-    return parsed.astimezone(UTC)
+    return parsed.astimezone(_UTC)
 
 
 def _local_date(value: object) -> date:
@@ -663,10 +669,10 @@ def _handle_request_unlocked(
     root = root.resolve()
     root.mkdir(parents=True, exist_ok=True)
     os.chmod(root, 0o750)
-    moment = now or datetime.now(UTC)
+    moment = now or datetime.now(_UTC)
     if moment.tzinfo is None:
         raise ReportOriginError("publication timestamp must include a timezone")
-    moment = moment.astimezone(UTC)
+    moment = moment.astimezone(_UTC)
     magic = source.read(len(PROTOCOL_MAGIC))
     if magic != PROTOCOL_MAGIC:
         raise ReportOriginError("unsupported publication protocol")
@@ -771,7 +777,7 @@ def _handle_request_unlocked(
         )
         destination.flush()
         return response
-    except ReportOriginError, OSError:
+    except _ORIGIN_ERRORS:
         if installed and not metadata_committed:
             shutil.rmtree(final_root, ignore_errors=True)
         raise
@@ -853,7 +859,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         handle_request(sys.stdin.buffer, sys.stdout.buffer, root=args.root)
         return 0
-    except ReportOriginError, OSError, ValueError:
+    except _MAIN_ERRORS:
         try:
             sys.stdout.write(
                 json.dumps({"status": "error", "error": "publication rejected"}) + "\n"

--- a/tests/test_scheduled_regression.py
+++ b/tests/test_scheduled_regression.py
@@ -1,6 +1,8 @@
+import ast
 import io
 import json
 import shutil
+import subprocess
 import tarfile
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
@@ -147,6 +149,43 @@ def test_private_report_origin_uses_isolated_caddy_and_dedicated_tunnel() -> Non
     assert not (root / "deploy" / "allure-report-worker").exists()
     assert "testIgnore: ['**/mobile-ui-regression.spec.ts']" in cross_browser
     assert '--run-id "${GITHUB_RUN_ID}-attempt-${GITHUB_RUN_ATTEMPT}"' in workflow
+
+
+def test_publisher_scripts_parse_on_vps_python_310() -> None:
+    root = Path(__file__).parents[1]
+    for relative in (
+        Path("scripts") / "allure_report_origin.py",
+        Path("deploy") / "allure-report-origin" / "publisher.py",
+    ):
+        source = (root / relative).read_text(encoding="utf-8")
+        ast.parse(source, filename=str(root / relative), feature_version=(3, 10))
+
+
+def test_publisher_imports_on_python_310_when_available() -> None:
+    python310 = shutil.which("python3.10")
+    if python310 is None:
+        pytest.skip("python3.10 is unavailable in the local test environment")
+
+    root = Path(__file__).parents[1]
+    result = subprocess.run(
+        [
+            python310,
+            "-c",
+            (
+                "import sys\n"
+                "sys.path.insert(0, 'scripts')\n"
+                "import allure_report_origin\n"
+                "sys.path.insert(0, 'deploy/allure-report-origin')\n"
+                "import publisher\n"
+            ),
+        ],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 def test_origin_rejects_noncanonical_state_paths() -> None:


### PR DESCRIPTION
Исправляет запуск изолированного Allure publisher на VPS с системным Python 3.10.

Изменения:
- заменены Python 3.14-only comma exception clauses на совместимые tuple aliases;
- добавлена регрессионная проверка парсинга publisher-скриптов с feature_version=(3, 10).

Проверки:
- pytest tests/test_scheduled_regression.py -q: 18 passed, 2 skipped;
- Ruff check: passed;
- py_compile: passed;
- pre-commit: passed.