### PR TITLE
[Task 107] fix: accept bootstrapped empty Allure metadata

### DIFF
--- a/scripts/allure_report_origin.py
+++ b/scripts/allure_report_origin.py
@@ -314,7 +314,11 @@ def _load_state(root: Path) -> tuple[list[dict[str, object]], list[str]]:
     if not state_path.is_file():
         if root.exists():
             children = list(root.iterdir())
-            if any(child.name not in {".publish.lock", ".staging"} for child in children):
+            for child in children:
+                if child.name in {".publish.lock", ".staging"}:
+                    continue
+                if child.name == "metadata" and child.is_dir() and not any(child.iterdir()):
+                    continue
                 raise ReportOriginError("report index is missing while storage is not empty")
             staging = root / ".staging"
             if staging.is_dir() and any(staging.iterdir()):

--- a/tests/test_scheduled_regression.py
+++ b/tests/test_scheduled_regression.py
@@ -293,6 +293,24 @@ def _origin_payload(header: dict[str, object], *, symlink: bool = False) -> io.B
     return output
 
 
+def test_origin_accepts_bootstrapped_empty_metadata_directory(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(allure_report_origin, "_available_bytes", lambda path: 10 * 1024**3)
+    root = tmp_path / "reports"
+    (root / "metadata").mkdir(parents=True)
+    report_bytes = len(b"<!doctype html><title>synthetic</title>\n") + len(b"trace-safe\n")
+    header = _origin_header(report_bytes=report_bytes)
+
+    response = allure_report_origin.handle_request(
+        _origin_payload(header),
+        io.BytesIO(),
+        root=root,
+        now=datetime(2026, 9, 7, 2, 0, tzinfo=UTC),
+    )
+
+    assert response["status"] == "published"
+    assert (root / "metadata" / "index.json").is_file()
+
+
 def test_origin_publishes_atomically_and_retries_cleanup_queue(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(allure_report_origin, "_available_bytes", lambda path: 10 * 1024**3)
     root = tmp_path / "reports"


### PR DESCRIPTION
## Что исправлено\n\nПервый scheduled Allure publisher отклонял публикацию на чистом VPS, если bootstrap заранее создавал пустой /srv/yfc-allure-reports/metadata. Теперь пустой каталог metadata считается допустимым начальным состоянием; неожиданные файлы и каталоги по-прежнему отклоняются.\n\n## Проверки\n\n- 19 passed, 3 skipped: tests/test_scheduled_regression.py\n- Ruff check/format\n- pre-commit\n- git diff --check\n\nFixes the first-publication failure for Task 107.