### PR TITLE
[Task 107] fix: retain decrypted Allure manifest

### DIFF
--- a/scripts/allure_bundle.py
+++ b/scripts/allure_bundle.py
@@ -296,6 +296,12 @@ def decrypt_bundle(
                     shutil.copyfileobj(stream, destination)
             if manifest["file_count"] != file_count or manifest["source_bytes"] != total_bytes:
                 raise AllureBundleError("bundle manifest does not match archive contents")
+        manifest_path = staging_output / "manifest.json"
+        manifest_path.write_text(
+            json.dumps(manifest, ensure_ascii=False, sort_keys=True) + "\n",
+            encoding="utf-8",
+            newline="\n",
+        )
         if output.exists():
             output.rmdir()
         staging_output.replace(output)

--- a/tests/test_scheduled_regression.py
+++ b/tests/test_scheduled_regression.py
@@ -740,6 +740,17 @@ def test_bundle_round_trip_is_encrypted_and_traversal_safe(tmp_path: Path, monke
     extracted = tmp_path / "extracted"
     opened = allure_bundle.decrypt_bundle(source=encrypted, output=extracted)
     assert opened["suite"] == "python-tests"
+    assert json.loads((extracted / "manifest.json").read_text(encoding="utf-8")) == {
+        key: manifest[key]
+        for key in (
+            "browser",
+            "created_at",
+            "file_count",
+            "schema_version",
+            "source_bytes",
+            "suite",
+        )
+    }
     assert (extracted / "result.json").read_text(encoding="utf-8") == '{"status":"passed"}\n'
 
 


### PR DESCRIPTION
## Что исправлено\n\nСохраняем проверенный manifest.json в распакованном Allure bundle. Агрегатор использует этот manifest для обнаружения bundle; без него все текущие bundle считались отсутствующими, и daily report становился incomplete.\n\n## Проверка\n\n- 19 passed, 3 skipped: tests/test_scheduled_regression.py\n- Ruff check/format и pre-commit passed\n- git diff --check passed