### PR TITLE
fix: render private Allure reports with runtime styles

### DIFF
--- a/deploy/allure-report-origin/Caddyfile
+++ b/deploy/allure-report-origin/Caddyfile
@@ -9,7 +9,10 @@
 		Cache-Control "private, no-store"
 		X-Content-Type-Options "nosniff"
 		Referrer-Policy "no-referrer"
-		Content-Security-Policy "default-src 'self'; base-uri 'none'; frame-ancestors 'none'"
+		# Allure 2.43 injects its application stylesheet at runtime and contains
+		# a small inline bootstrap script in index.html. Keep the report isolated
+		# while allowing those report-local assets.
+		Content-Security-Policy "default-src 'self'; base-uri 'none'; frame-ancestors 'none'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'"
 	}
 	@unsupported not method GET HEAD
 	@private path /.publish.lock /.publish.lock/* /.staging /.staging/* /metadata /metadata/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,7 +222,10 @@ services:
                 Strict-Transport-Security "max-age=31536000; includeSubDomains"
                 X-Content-Type-Options "nosniff"
                 Referrer-Policy "no-referrer"
-                Content-Security-Policy "default-src 'self'; base-uri 'none'; frame-ancestors 'none'"
+                # Allure 2.43 injects its application stylesheet at runtime and
+                # contains a small inline bootstrap script in index.html. Keep
+                # the report isolated while allowing those report-local assets.
+                Content-Security-Policy "default-src 'self'; base-uri 'none'; frame-ancestors 'none'; object-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'"
             }
 
             basic_auth argon2id {

--- a/tests/test_scheduled_regression.py
+++ b/tests/test_scheduled_regression.py
@@ -136,7 +136,15 @@ def test_private_report_origin_uses_isolated_caddy_and_dedicated_tunnel() -> Non
     assert "reverse_proxy allure-report-origin:8080" in public_caddy_block
     assert "file_server" in caddy
     assert "browse" not in caddy
+    allure_csp = (
+        "Content-Security-Policy \"default-src 'self'; base-uri 'none'; "
+        "frame-ancestors 'none'; object-src 'none'; script-src 'self' 'unsafe-inline'; "
+        "style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; "
+        "font-src 'self' data:; connect-src 'self'\""
+    )
     assert 'Cache-Control "private, no-store"' in caddy
+    assert allure_csp in caddy
+    assert allure_csp in public_caddy_block
     assert 'respond @private "Not Found" 404' in caddy
     assert "/.publish.lock" in caddy
     assert "@unsupported not method GET HEAD" in caddy


### PR DESCRIPTION
## Что исправлено\n\n- разрешены report-local inline bootstrap scripts и runtime styles, которые генерирует Allure 2.43;\n- CSP синхронизирован во внешнем Allure Caddy и isolated origin;\n- сохранены Basic Auth, same-origin fetch и запрет object/frame embedding;\n- добавлена регрессия конфигурации.\n\n## Проверки\n\n- 20 passed, 3 skipped — 	ests/test_scheduled_regression.py;\n- Caddy alidate — Valid configuration.\n\nFixes broken unstyled Allure report rendering under the private hostname.