### PR TITLE
[Task 149] News review batches for Hermes editorial intake

### DIFF
--- a/backend/fitminiapp_api/services/news_editorial.py
+++ b/backend/fitminiapp_api/services/news_editorial.py
@@ -26,7 +26,7 @@ from fitminiapp_api.models.news import (
 from fitminiapp_api.services.audit import record_audit_event
 from fitminiapp_api.services.news_content import parse_editorial_content
 from fitminiapp_api.services.news_drafts import quality_warnings
-from fitminiapp_api.services.news_freshness import source_metadata_is_current_month
+from fitminiapp_api.services.news_freshness import source_metadata_is_fresh
 from fitminiapp_api.services.news_images import create_uploaded_image_revision, current_image
 from fitminiapp_api.services.news_ingestion import utcnow
 from fitminiapp_api.services.news_publication import (
@@ -96,6 +96,12 @@ class ReviewArtifact:
 HERMES_SUBMISSION_MARKER = "hermes_narrow_intake"
 PREVIEW_OPERATIONAL_BLOCKERS = frozenset({"publishing_disabled", "channel_rights_missing"})
 LEGACY_REVIEW_DELIVERY_DISABLED = "legacy_review_delivery_disabled"
+MANUAL_REVIEW_ALLOWED_WARNINGS = frozenset({"medical_prescription_language"})
+MANUAL_REVIEW_ALLOWED_CONTENT_BLOCKERS = frozenset(
+    {
+        "prohibited_medical_or_aas_language",
+    }
+)
 
 
 def is_hermes_origin_draft(draft: NewsDraftRevision) -> bool:
@@ -114,12 +120,20 @@ def review_delivery_blockers(
     blockers: list[str] = []
     if is_hermes_draft:
         blockers.extend(
-            blocker for blocker in review.blockers if blocker not in PREVIEW_OPERATIONAL_BLOCKERS
+            blocker
+            for blocker in review.blockers
+            if blocker not in PREVIEW_OPERATIONAL_BLOCKERS
+            and blocker != "unresolved_warning:medical_prescription_language"
+            and blocker not in MANUAL_REVIEW_ALLOWED_CONTENT_BLOCKERS
         )
         blockers.extend(
             f"unresolved_warning:{warning}"
             for warning in draft.warnings
-            if isinstance(warning, str) and warning
+            if (
+                isinstance(warning, str)
+                and warning
+                and warning not in MANUAL_REVIEW_ALLOWED_WARNINGS
+            )
         )
     if is_hermes_draft and review.artifact is None:
         blockers.append("preview_artifact_unavailable")
@@ -556,7 +570,7 @@ def enqueue_review_deliveries(db: Session, admin_telegram_user_ids: set[int]) ->
         if not legacy_source_fetch_enabled and not is_hermes_origin_draft(draft):
             _cancel_pending_deliveries(db, draft.id)
             continue
-        if not source_metadata_is_current_month(draft.evidence_metadata, now=now):
+        if not source_metadata_is_fresh(draft.evidence_metadata, now=now):
             _cancel_pending_deliveries(db, draft.id)
             transition_news_cluster(
                 db,

--- a/backend/fitminiapp_api/services/news_freshness.py
+++ b/backend/fitminiapp_api/services/news_freshness.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
 
+FRESHNESS_WINDOW_DAYS = 60
+FRESHNESS_WINDOW = timedelta(days=FRESHNESS_WINDOW_DAYS)
+
 
 def _as_utc_naive(value: datetime) -> datetime:
     if value.tzinfo is None:
@@ -20,29 +23,42 @@ def parse_source_published_at(value: object) -> datetime | None:
     return _as_utc_naive(parsed)
 
 
-def is_current_month_publication(
+def is_fresh_publication(
     published_at: datetime | None,
     *,
     now: datetime,
 ) -> bool:
-    """Return whether a source date is inside the current or previous calendar month.
+    """Return whether a source date is inside the inclusive 60-day freshness window.
 
-    The legacy function name is kept because it is part of the existing news pipeline
-    contract. The accepted freshness window now intentionally spans two calendar months.
+    Naive datetimes are the existing UTC-naive storage format. Future-dated and missing
+    source dates fail closed.
     """
     if published_at is None:
         return False
     current = _as_utc_naive(now)
     published = _as_utc_naive(published_at)
-    current_month_start = current.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-    previous_month_start = (current_month_start - timedelta(days=1)).replace(
-        day=1,
-        hour=0,
-        minute=0,
-        second=0,
-        microsecond=0,
+    return current - FRESHNESS_WINDOW <= published <= current
+
+
+def source_metadata_is_fresh(
+    metadata: Mapping[str, object],
+    *,
+    now: datetime,
+) -> bool:
+    return is_fresh_publication(
+        parse_source_published_at(metadata.get("source_published_at")),
+        now=now,
     )
-    return previous_month_start <= published <= current
+
+
+def is_current_month_publication(
+    published_at: datetime | None,
+    *,
+    now: datetime,
+) -> bool:
+    """Backward-compatible name for the 60-day freshness check."""
+
+    return is_fresh_publication(published_at, now=now)
 
 
 def source_metadata_is_current_month(
@@ -50,7 +66,6 @@ def source_metadata_is_current_month(
     *,
     now: datetime,
 ) -> bool:
-    return is_current_month_publication(
-        parse_source_published_at(metadata.get("source_published_at")),
-        now=now,
-    )
+    """Backward-compatible name for :func:`source_metadata_is_fresh`."""
+
+    return source_metadata_is_fresh(metadata, now=now)

--- a/backend/fitminiapp_api/services/news_hermes.py
+++ b/backend/fitminiapp_api/services/news_hermes.py
@@ -281,6 +281,7 @@ def accept_hermes_submission(
         [parsed],
         candidate_threshold=settings.news_candidate_score_threshold,
         fetched_at=current,
+        allow_sensitive_manual_review=True,
     )
     if counts["rejected"]:
         raise HermesIntakeError("source_packet_rejected")

--- a/backend/fitminiapp_api/services/news_ingestion.py
+++ b/backend/fitminiapp_api/services/news_ingestion.py
@@ -20,7 +20,7 @@ from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from fitminiapp_api.models.news import NewsCluster, NewsItem, NewsSource
-from fitminiapp_api.services.news_freshness import is_current_month_publication
+from fitminiapp_api.services.news_freshness import is_fresh_publication
 from fitminiapp_api.services.news_state import transition_news_cluster
 from fitminiapp_api.services.news_taxonomy import (
     classify_editorial_text,
@@ -820,7 +820,10 @@ def score_candidate(
     supporting_source_count: int,
     uncertain_duplicate: bool,
     now: datetime,
+    allow_sensitive_manual_review: bool = False,
 ) -> tuple[int, str, list[str], list[str]]:
+    """Score a source item; Hermes may retain sensitive topics for owner review only."""
+
     text = f"{item.title} {item.summary}"
     topic = _topic(text)
     reasons = [f"source_quality:{SOURCE_QUALITY[source.source_type]}"]
@@ -837,10 +840,10 @@ def score_candidate(
         if any(keyword in normalized_text for keyword in keywords):
             score += 10
             reasons.append(f"priority:{priority}")
-    current_month = is_current_month_publication(item.published_at, now=now)
-    if current_month:
+    fresh = is_fresh_publication(item.published_at, now=now)
+    if fresh:
         score += 15
-        reasons.append("freshness:current_month")
+        reasons.append("freshness:60_days")
     else:
         risks.append("source_not_current_month")
         reasons.append("freshness_gate_failed")
@@ -858,10 +861,14 @@ def score_candidate(
         score -= 10
     prohibited = prohibited_flags(text)
     risks.extend(f"prohibited_{flag}" for flag in prohibited)
-    if prohibited:
+    # Only the authenticated Hermes intake opts into sensitive-topic recall. Legacy source
+    # acquisition keeps the strict rejection path, while publication gates remain unchanged.
+    if prohibited and not allow_sensitive_manual_review:
         score = 0
         reasons.append("prohibited_topic")
-    if not current_month or topic == "other":
+    elif prohibited:
+        reasons.append("sensitive_topic_manual_review")
+    if not fresh or topic == "other":
         score = 0
     return max(0, min(100, score)), topic, reasons, list(dict.fromkeys(risks))
 
@@ -902,6 +909,7 @@ def ingest_items(
     *,
     candidate_threshold: int,
     fetched_at: datetime | None = None,
+    allow_sensitive_manual_review: bool = False,
 ) -> dict[str, int]:
     current = fetched_at or utcnow()
     counts = {
@@ -1029,6 +1037,7 @@ def ingest_items(
             supporting_source_count=max(0, len(representative_items) - 1),
             uncertain_duplicate=uncertain,
             now=current,
+            allow_sensitive_manual_review=allow_sensitive_manual_review,
         )
         classification = classify_editorial_text(
             primary.title,
@@ -1069,9 +1078,10 @@ def ingest_items(
             counts["clustered"] += 1
             continue
         prohibited = any(flag.startswith("prohibited_") for flag in risks)
-        current_month = "source_not_current_month" not in risks
+        hard_prohibited = prohibited and not allow_sensitive_manual_review
+        fresh = "source_not_current_month" not in risks
         broad_recall_candidate = (
-            current_month
+            fresh
             and source.source_type
             in {"primary_research", "systematic_review", "official_organization", "yfc"}
             and topic == "other"
@@ -1083,9 +1093,9 @@ def ingest_items(
                     for marker in ESPORTS_PHYSICAL_CONTEXT
                 )
             )
-            and not prohibited
+            and not hard_prohibited
         )
-        discovery_eligible = not prohibited and (
+        discovery_eligible = not hard_prohibited and (
             score >= candidate_threshold or broad_recall_candidate
         )
         cluster.discovery_eligible = discovery_eligible
@@ -1096,12 +1106,17 @@ def ingest_items(
                     if score >= candidate_threshold
                     else "broad_source_recall",
                     *classification.classification_reasons,
-                    *(["source_not_current_month"] if not current_month else []),
-                    *(["prohibited_content"] if prohibited else []),
+                    *(["source_not_current_month"] if not fresh else []),
+                    *(["prohibited_content"] if hard_prohibited else []),
+                    *(
+                        ["sensitive_topic_manual_review"]
+                        if prohibited and allow_sensitive_manual_review
+                        else []
+                    ),
                 ]
             )
         )
-        if prohibited:
+        if hard_prohibited:
             transition_news_cluster(
                 db,
                 cluster,

--- a/backend/fitminiapp_api/services/news_publication.py
+++ b/backend/fitminiapp_api/services/news_publication.py
@@ -30,7 +30,7 @@ from fitminiapp_api.services.news_content import (
     EditorialContent,
     editorial_content_from_metadata,
 )
-from fitminiapp_api.services.news_freshness import source_metadata_is_current_month
+from fitminiapp_api.services.news_freshness import source_metadata_is_fresh
 from fitminiapp_api.services.news_images import current_image
 from fitminiapp_api.services.news_ingestion import utcnow
 from fitminiapp_api.services.news_state import transition_news_cluster
@@ -371,7 +371,7 @@ def publication_quality_blockers(
     )
     if not isinstance(draft.evidence_metadata.get("source_published_at"), str):
         blockers.append("source_date_missing")
-    elif not source_metadata_is_current_month(draft.evidence_metadata, now=utcnow()):
+    elif not source_metadata_is_fresh(draft.evidence_metadata, now=utcnow()):
         blockers.append("source_not_current_month")
     if content is not None and draft.evidence_metadata.get("topic") == "research":
         research_context = f"{content.summary} {content.why_it_matters}".casefold()
@@ -531,7 +531,7 @@ def approve_publication(
     if schedule is None:
         return ApprovalResult(status="schedule_invalid")
     scheduled_for_utc, local_date = schedule
-    if not source_metadata_is_current_month(
+    if not source_metadata_is_fresh(
         draft.evidence_metadata,
         now=scheduled_for_utc,
     ):
@@ -681,7 +681,7 @@ def claim_due_publications(db: Session, *, limit: int = 5) -> list[str]:
     for row in candidates:
         cluster = db.get(NewsCluster, row.cluster_id)
         draft = db.get(NewsDraftRevision, row.text_revision_id)
-        if draft is None or not source_metadata_is_current_month(
+        if draft is None or not source_metadata_is_fresh(
             draft.evidence_metadata,
             now=now,
         ):

--- a/backend/fitminiapp_api/services/news_rescore.py
+++ b/backend/fitminiapp_api/services/news_rescore.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from sqlalchemy.orm import Session
 
 from fitminiapp_api.models.news import NewsCluster, NewsItem, NewsSource
-from fitminiapp_api.services.news_freshness import is_current_month_publication
+from fitminiapp_api.services.news_freshness import is_fresh_publication
 from fitminiapp_api.services.news_ingestion import latest_items_by_source, score_candidate, utcnow
 from fitminiapp_api.services.news_state import transition_news_cluster
 
@@ -32,7 +32,7 @@ def rescore_freshness_blocked_clusters(
         if "source_not_current_month" not in previous_risks:
             continue
         primary = db.get(NewsItem, cluster.primary_item_id)
-        if primary is None or not is_current_month_publication(primary.published_at, now=current):
+        if primary is None or not is_fresh_publication(primary.published_at, now=current):
             continue
         source = db.get(NewsSource, primary.source_id)
         if source is None:

--- a/backend/fitminiapp_api/services/news_review_schedule.py
+++ b/backend/fitminiapp_api/services/news_review_schedule.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+NEWS_REVIEW_TIMEZONE = ZoneInfo("Europe/Moscow")
+NEWS_REVIEW_BATCH_SIZE = 5
+NEWS_REVIEW_SLOT_WINDOW = timedelta(minutes=15)
+NEWS_REVIEW_SLOT_STARTS = (time(hour=8), time(hour=13), time(hour=18))
+
+
+@dataclass(frozen=True)
+class NewsReviewSlot:
+    key: str
+    local_start: datetime
+    local_end: datetime
+
+
+def _as_utc_aware(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _local_slot_start(day: date, slot_time: time) -> datetime:
+    return datetime.combine(day, slot_time, tzinfo=NEWS_REVIEW_TIMEZONE)
+
+
+def current_news_review_slot(now: datetime) -> NewsReviewSlot | None:
+    """Return the active 15-minute owner-review dispatch window, if any."""
+
+    local_now = _as_utc_aware(now).astimezone(NEWS_REVIEW_TIMEZONE)
+    for slot_time in NEWS_REVIEW_SLOT_STARTS:
+        local_start = _local_slot_start(local_now.date(), slot_time)
+        local_end = local_start + NEWS_REVIEW_SLOT_WINDOW
+        if local_start <= local_now < local_end:
+            return NewsReviewSlot(
+                key=local_start.isoformat(),
+                local_start=local_start,
+                local_end=local_end,
+            )
+    return None

--- a/backend/fitminiapp_api/services/news_worker.py
+++ b/backend/fitminiapp_api/services/news_worker.py
@@ -6,11 +6,12 @@ import hmac
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from time import monotonic
 from typing import Protocol
 
 import httpx
+from sqlalchemy import func
 
 from fitminiapp_api.core.config import settings
 from fitminiapp_api.db.session import get_session_context
@@ -34,7 +35,7 @@ from fitminiapp_api.services.news_editorial import (
     review_delivery_blockers,
     review_message,
 )
-from fitminiapp_api.services.news_freshness import is_current_month_publication
+from fitminiapp_api.services.news_freshness import is_fresh_publication
 from fitminiapp_api.services.news_images import create_image_revision
 from fitminiapp_api.services.news_ingestion import (
     SafeNewsFetcher,
@@ -47,6 +48,10 @@ from fitminiapp_api.services.news_publication import (
     mark_publication_failed,
     mark_publication_succeeded,
     publication_payload,
+)
+from fitminiapp_api.services.news_review_schedule import (
+    NEWS_REVIEW_BATCH_SIZE,
+    NewsReviewSlot,
 )
 from fitminiapp_api.services.news_state import transition_news_cluster
 from fitminiapp_api.services.notifications import safe_delivery_error
@@ -278,7 +283,7 @@ async def generate_candidate_drafts(
             if cluster is None:
                 continue
             primary = db.get(NewsItem, cluster.primary_item_id)
-            if primary is None or not is_current_month_publication(
+            if primary is None or not is_fresh_publication(
                 primary.published_at,
                 now=utcnow(),
             ):
@@ -363,7 +368,11 @@ async def generate_pending_images(client: httpx.AsyncClient) -> int:
     return generated
 
 
-def _claim_deliveries() -> list[int]:
+def _claim_deliveries(
+    *,
+    draft_limit: int | None = None,
+    review_slot: NewsReviewSlot | None = None,
+) -> list[int]:
     now = utcnow()
     stale_before = now - PROCESSING_TTL
     with get_session_context() as db:
@@ -378,17 +387,62 @@ def _claim_deliveries() -> list[int]:
             },
             synchronize_session=False,
         )
-        rows = (
-            db.query(NewsReviewDelivery)
-            .filter(
-                NewsReviewDelivery.status == "queued",
-                NewsReviewDelivery.next_attempt_at <= now,
-            )
-            .order_by(NewsReviewDelivery.next_attempt_at.asc(), NewsReviewDelivery.id.asc())
-            .limit(MAX_DELIVERIES_PER_CYCLE)
-            .with_for_update(skip_locked=True)
-            .all()
+        eligible = db.query(NewsReviewDelivery).filter(
+            NewsReviewDelivery.status == "queued",
+            NewsReviewDelivery.next_attempt_at <= now,
         )
+        effective_draft_limit = draft_limit
+        if review_slot is not None:
+            slot_start_utc = review_slot.local_start.astimezone(UTC).replace(tzinfo=None)
+            sent_drafts_in_slot = (
+                db.query(NewsReviewDelivery.draft_id)
+                .filter(
+                    NewsReviewDelivery.status == "sent",
+                    NewsReviewDelivery.sent_at.is_not(None),
+                    NewsReviewDelivery.sent_at >= slot_start_utc,
+                )
+                .distinct()
+            )
+            eligible = eligible.filter(~NewsReviewDelivery.draft_id.in_(sent_drafts_in_slot))
+            remaining_batch_size = max(0, NEWS_REVIEW_BATCH_SIZE - sent_drafts_in_slot.count())
+            effective_draft_limit = (
+                remaining_batch_size
+                if effective_draft_limit is None
+                else min(effective_draft_limit, remaining_batch_size)
+            )
+        if effective_draft_limit is None:
+            rows = (
+                eligible.order_by(
+                    NewsReviewDelivery.next_attempt_at.asc(), NewsReviewDelivery.id.asc()
+                )
+                .limit(MAX_DELIVERIES_PER_CYCLE)
+                .with_for_update(skip_locked=True)
+                .all()
+            )
+        else:
+            selected_drafts = (
+                eligible.with_entities(
+                    NewsReviewDelivery.draft_id,
+                    func.min(NewsReviewDelivery.next_attempt_at).label("next_attempt_at"),
+                    func.min(NewsReviewDelivery.id).label("delivery_id"),
+                )
+                .group_by(NewsReviewDelivery.draft_id)
+                .order_by(
+                    func.min(NewsReviewDelivery.next_attempt_at).asc(),
+                    func.min(NewsReviewDelivery.id).asc(),
+                )
+                .limit(effective_draft_limit)
+                .all()
+            )
+            draft_ids = [row[0] for row in selected_drafts]
+            rows = (
+                eligible.filter(NewsReviewDelivery.draft_id.in_(draft_ids))
+                .order_by(NewsReviewDelivery.next_attempt_at.asc(), NewsReviewDelivery.id.asc())
+                .with_for_update(skip_locked=True)
+                .all()
+                if draft_ids
+                else []
+            )
         result = []
         for row in rows:
             row.status = "processing"
@@ -444,6 +498,7 @@ async def deliver_review_queue(
     channel_ready: bool,
     *,
     cycle_stats: NewsCycleStats | None = None,
+    review_slot: NewsReviewSlot | None = None,
 ) -> int:
     recipient_ids = {
         editorial_actor_ref(telegram_id): telegram_id
@@ -453,7 +508,10 @@ async def deliver_review_queue(
         with get_session_context() as db:
             cancel_legacy_review_deliveries(db)
     delivered = 0
-    for delivery_id in _claim_deliveries():
+    for delivery_id in _claim_deliveries(
+        draft_limit=NEWS_REVIEW_BATCH_SIZE if review_slot is not None else None,
+        review_slot=review_slot,
+    ):
         with get_session_context() as db:
             delivery = db.get(NewsReviewDelivery, delivery_id)
             if delivery is None or delivery.status != "processing":
@@ -702,9 +760,12 @@ async def run_news_pipeline_once(
     send_publication: Callable[..., Awaitable[PublicationResult]],
     publication_ready: bool,
     fetch_sources: bool,
+    review_delivery_due: bool = True,
+    review_slot: NewsReviewSlot | None = None,
 ) -> NewsCycleStats:
     started = monotonic()
     cycle_stats = NewsCycleStats()
+    delivered = 0
     legacy_source_fetch_enabled = settings.news_legacy_source_fetch_enabled
     with get_session_context() as db:
         prune_news_editorial(db, retention_days=settings.news_retention_days)
@@ -733,13 +794,15 @@ async def run_news_pipeline_once(
         await generate_pending_images(client)
         with get_session_context() as db:
             enqueue_review_deliveries(db, settings.admin_telegram_id_set)
-        delivered = await deliver_review_queue(
-            client,
-            send_message,
-            send_preview,
-            publication_ready,
-            cycle_stats=cycle_stats,
-        )
+        if review_delivery_due:
+            delivered = await deliver_review_queue(
+                client,
+                send_message,
+                send_preview,
+                publication_ready,
+                cycle_stats=cycle_stats,
+                review_slot=review_slot,
+            )
     if (legacy_source_fetch_enabled and fetch_sources) or any(
         (
             cycle_stats.drafts_created,

--- a/backend/fitminiapp_api/services/worker.py
+++ b/backend/fitminiapp_api/services/worker.py
@@ -29,6 +29,8 @@ from fitminiapp_api.models.weekly_digest import WeeklyDigestDelivery
 from fitminiapp_api.services.account_exports import prune_account_exports
 from fitminiapp_api.services.audit import prune_audit_events
 from fitminiapp_api.services.bot_support import prune_support_cases
+from fitminiapp_api.services.news_ingestion import utcnow
+from fitminiapp_api.services.news_review_schedule import current_news_review_slot
 from fitminiapp_api.services.news_worker import run_news_pipeline_once
 from fitminiapp_api.services.notifications import (
     MAX_DELIVERY_ATTEMPTS,
@@ -810,6 +812,7 @@ async def run_until_stopped(
 ) -> None:
     next_reminder_sync = 0.0
     next_news_sync = 0.0
+    last_news_review_slot_key: str | None = None
     WORKER_HEARTBEAT_PATH.touch()
     while not stop_requested.is_set():
         current = monotonic()
@@ -821,6 +824,10 @@ async def run_until_stopped(
             next_reminder_sync = current + settings.reminder_sync_seconds
         if settings.news_ingestion_enabled:
             should_fetch_news = current >= next_news_sync
+            review_slot = current_news_review_slot(utcnow())
+            review_delivery_due = (
+                review_slot is not None and review_slot.key != last_news_review_slot_key
+            )
             try:
                 await run_news_pipeline_once(
                     send_message=send_telegram_message,
@@ -828,6 +835,8 @@ async def run_until_stopped(
                     send_publication=send_telegram_publication,
                     publication_ready=news_publication_ready,
                     fetch_sources=should_fetch_news,
+                    review_delivery_due=review_delivery_due,
+                    review_slot=review_slot,
                 )
             except Exception as exc:
                 logger.error(
@@ -837,6 +846,9 @@ async def run_until_stopped(
                         "reason": type(exc).__name__,
                     },
                 )
+            else:
+                if review_delivery_due and review_slot is not None:
+                    last_news_review_slot_key = review_slot.key
             if should_fetch_news:
                 next_news_sync = current + settings.news_ingestion_cycle_seconds
         WORKER_HEARTBEAT_PATH.touch()

--- a/backend/tests/test_news_editorial.py
+++ b/backend/tests/test_news_editorial.py
@@ -35,7 +35,7 @@ from fitminiapp_api.services.news_editorial import (
     prune_news_editorial,
     review_message,
 )
-from fitminiapp_api.services.news_freshness import is_current_month_publication
+from fitminiapp_api.services.news_freshness import is_fresh_publication
 from fitminiapp_api.services.news_ingestion import (
     ParsedNewsItem,
     SafeNewsFetcher,
@@ -423,18 +423,18 @@ def test_json_feed_parser_accepts_documented_metadata() -> None:
 def test_freshness_window_rejects_older_missing_and_future_dates() -> None:
     now = datetime(2026, 8, 26, 12, 0, 0)
 
-    assert is_current_month_publication(datetime(2026, 7, 1), now=now)
-    assert is_current_month_publication(datetime(2026, 8, 1), now=now)
-    assert is_current_month_publication(now, now=now)
-    assert not is_current_month_publication(datetime(2026, 6, 30, 23, 59, 59), now=now)
-    assert not is_current_month_publication(None, now=now)
-    assert not is_current_month_publication(datetime(2026, 8, 26, 12, 0, 1), now=now)
+    assert is_fresh_publication(now - timedelta(days=60), now=now)
+    assert is_fresh_publication(datetime(2026, 8, 1), now=now)
+    assert is_fresh_publication(now, now=now)
+    assert not is_fresh_publication(now - timedelta(days=61), now=now)
+    assert not is_fresh_publication(None, now=now)
+    assert not is_fresh_publication(datetime(2026, 8, 26, 12, 0, 1), now=now)
 
 
 def test_ingestion_hard_gates_source_outside_freshness_window() -> None:
     _create_source()
     current = datetime(2026, 8, 26, 12, 0, 0)
-    stale = replace(_parsed(), published_at=datetime(2026, 6, 30, 23, 59, 59))
+    stale = replace(_parsed(), published_at=current - timedelta(days=61))
 
     with get_session_context() as db:
         source = db.get(NewsSource, "journal-one")
@@ -542,15 +542,7 @@ def test_stale_draft_is_not_enqueued_for_owner_review(monkeypatch) -> None:
         cluster = db.get(NewsCluster, cluster_id)
         assert cluster is not None
         draft = asyncio.run(create_draft_revision(db, cluster))
-        current_month_start = utcnow().replace(
-            day=1,
-            hour=0,
-            minute=0,
-            second=0,
-            microsecond=0,
-        )
-        previous_month_start = (current_month_start - timedelta(days=1)).replace(day=1)
-        stale = previous_month_start - timedelta(seconds=1)
+        stale = utcnow() - timedelta(days=61)
         draft.evidence_metadata = {
             **draft.evidence_metadata,
             "source_published_at": stale.isoformat(),

--- a/backend/tests/test_news_freshness_window.py
+++ b/backend/tests/test_news_freshness_window.py
@@ -1,35 +1,36 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
-from fitminiapp_api.services.news_freshness import is_current_month_publication
+from fitminiapp_api.services.news_freshness import (
+    FRESHNESS_WINDOW_DAYS,
+    is_fresh_publication,
+)
 
 
-def test_freshness_window_accepts_current_and_previous_calendar_month() -> None:
+def test_freshness_window_accepts_exactly_60_days() -> None:
     now = datetime(2026, 8, 30, 12, 0, 0)
+    lower_bound = now - timedelta(days=FRESHNESS_WINDOW_DAYS)
 
-    assert is_current_month_publication(datetime(2026, 7, 1, 0, 0, 0), now=now)
-    assert is_current_month_publication(datetime(2026, 7, 31, 23, 59, 59), now=now)
-    assert is_current_month_publication(datetime(2026, 8, 1, 0, 0, 0), now=now)
-    assert is_current_month_publication(now, now=now)
+    assert is_fresh_publication(lower_bound, now=now)
+    assert is_fresh_publication(datetime(2026, 7, 31, 23, 59, 59), now=now)
+    assert is_fresh_publication(datetime(2026, 8, 1, 0, 0, 0), now=now)
+    assert is_fresh_publication(now, now=now)
+    assert not is_fresh_publication(lower_bound - timedelta(microseconds=1), now=now)
 
 
 def test_freshness_window_rejects_older_missing_and_future_dates() -> None:
     now = datetime(2026, 8, 30, 12, 0, 0)
 
-    assert not is_current_month_publication(datetime(2026, 6, 30, 23, 59, 59), now=now)
-    assert not is_current_month_publication(None, now=now)
-    assert not is_current_month_publication(datetime(2026, 8, 30, 12, 0, 1), now=now)
+    assert not is_fresh_publication(now - timedelta(days=61), now=now)
+    assert not is_fresh_publication(None, now=now)
+    assert not is_fresh_publication(datetime(2026, 8, 30, 12, 0, 1), now=now)
 
 
 def test_freshness_window_handles_year_boundary_and_timezone() -> None:
     now = datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)
+    lower_bound = now - timedelta(days=FRESHNESS_WINDOW_DAYS)
 
-    assert is_current_month_publication(
-        datetime(2025, 12, 1, 0, 0, 0, tzinfo=UTC),
-        now=now,
-    )
-    assert not is_current_month_publication(
-        datetime(2025, 11, 30, 23, 59, 59, tzinfo=UTC),
-        now=now,
-    )
+    assert is_fresh_publication(lower_bound, now=now)
+    assert is_fresh_publication(datetime(2025, 12, 1, 0, 0, 0, tzinfo=UTC), now=now)
+    assert not is_fresh_publication(lower_bound - timedelta(seconds=1), now=now)

--- a/backend/tests/test_news_hermes.py
+++ b/backend/tests/test_news_hermes.py
@@ -267,3 +267,96 @@ def test_hermes_image_pending_downstream_survives_disabled_legacy_fetch(
         assert cluster.current_image_revision == 1
         delivery = db.query(NewsReviewDelivery).one()
         assert delivery.status == "sent"
+
+
+def test_hermes_sensitive_source_reaches_full_owner_card(client, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "hermes_intake_enabled", True)
+    monkeypatch.setattr(settings, "hermes_intake_key_id", "hermes-test")
+    monkeypatch.setattr(
+        settings,
+        "hermes_intake_shared_secret",
+        SecretStr("test-hermes-shared-secret-that-is-long-enough"),
+    )
+    monkeypatch.setattr(settings, "news_ingestion_enabled", True)
+    monkeypatch.setattr(settings, "news_legacy_source_fetch_enabled", False)
+    monkeypatch.setattr(settings, "news_image_provider", "disabled")
+    monkeypatch.setattr(settings, "admin_telegram_user_ids", "7001")
+
+    with get_session_context() as db:
+        db.add(
+            NewsSource(
+                id="journal-one",
+                name="Journal One",
+                source_type="primary_research",
+                fetch_kind="rss",
+                feed_url="https://example.com/feed",
+                language="en",
+                enabled=True,
+            )
+        )
+
+    payload = _payload()
+    payload["idempotency_key"] = "hermes-sensitive-idempotency"
+    payload["request_nonce"] = "hermes-sensitive-nonce"
+    payload["source"]["title"] = "Исследование дозировки пептида для спорта"
+    payload["source"]["summary"] = (
+        "Фармакологическая работа рассмотрела дозировку пептида и ограничения "
+        "результатов для самостоятельной интерпретации."
+    )
+    payload["draft"]["headline"] = "Исследование пептида: контекст результатов"
+    payload["draft"]["summary"] = (
+        "Работа описывает дозировку пептида и ограничения результатов без "
+        "индивидуального назначения."
+    )
+    payload["source"]["content_hash"] = _canonical_source_hash(
+        title=payload["source"]["title"],
+        summary=payload["source"]["summary"],
+        canonical_url=payload["source"]["canonical_url"],
+        published_at=datetime.fromisoformat(payload["source"]["published_at"]),
+    )
+    body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
+    intake = client.post(
+        "/api/v1/hermes/editorial/intake",
+        content=body,
+        headers=_signed_headers(body),
+    )
+    assert intake.status_code == 200, intake.text
+    assert intake.json()["status"] == "accepted"
+    assert intake.json()["publication_policy"] == "manual_required"
+
+    preview_calls: list[int] = []
+    control_calls: list[int] = []
+
+    async def send_preview(_client, chat_id, *_args, **_kwargs):
+        preview_calls.append(chat_id)
+        return SimpleNamespace(message_id=511, message_date=datetime.now(UTC))
+
+    async def send_control(_client, chat_id, *_args, **_kwargs):
+        control_calls.append(chat_id)
+        return 512
+
+    async def send_publication(*_args, **_kwargs):
+        raise AssertionError("manual-sensitive intake must not publish automatically")
+
+    asyncio.run(
+        run_news_pipeline_once(
+            send_message=send_control,
+            send_preview=send_preview,
+            send_publication=send_publication,
+            publication_ready=True,
+            fetch_sources=True,
+        )
+    )
+
+    assert preview_calls == [7001]
+    assert control_calls == [7001]
+    with get_session_context() as db:
+        submission = db.query(HermesEditorialSubmission).one()
+        draft = db.get(NewsDraftRevision, submission.draft_id)
+        cluster = db.get(NewsCluster, submission.cluster_id)
+        delivery = db.query(NewsReviewDelivery).one()
+        assert draft is not None and cluster is not None
+        assert "medical_prescription_language" in draft.warnings
+        assert any(flag.startswith("prohibited_") for flag in cluster.risk_flags)
+        assert cluster.status == "awaiting_review"
+        assert delivery.status == "sent"

--- a/backend/tests/test_news_publishing.py
+++ b/backend/tests/test_news_publishing.py
@@ -57,6 +57,7 @@ from fitminiapp_api.services.news_publication import (
     reconcile_uncertain_publication,
     retry_uncertain_publication,
 )
+from fitminiapp_api.services.news_review_schedule import current_news_review_slot
 from fitminiapp_api.services.news_sources import apply_source_allowlist, parse_source_allowlist
 from fitminiapp_api.services.news_worker import (
     NewsCycleStats,
@@ -185,15 +186,7 @@ def test_review_artifact_blocks_source_outside_freshness_window() -> None:
     with get_session_context() as db:
         draft = db.get(NewsDraftRevision, draft_id)
         assert draft is not None
-        current_month_start = utcnow().replace(
-            day=1,
-            hour=0,
-            minute=0,
-            second=0,
-            microsecond=0,
-        )
-        previous_month_start = (current_month_start - timedelta(days=1)).replace(day=1)
-        stale = previous_month_start - timedelta(seconds=1)
+        stale = utcnow() - timedelta(days=61)
         draft.evidence_metadata = {
             **draft.evidence_metadata,
             "source_published_at": stale.isoformat(),
@@ -217,7 +210,7 @@ def test_scheduling_cannot_cross_source_freshness_window(monkeypatch) -> None:
         enqueue_review_deliveries(db, {7001})
         draft.evidence_metadata = {
             **draft.evidence_metadata,
-            "source_published_at": "2026-07-04T00:00:00",
+            "source_published_at": "2026-06-28T12:00:00",
         }
 
         result = approve_publication(
@@ -250,7 +243,7 @@ def test_queued_publication_is_failed_after_freshness_window_rollover(monkeypatc
         enqueue_review_deliveries(db, {7001})
         draft.evidence_metadata = {
             **draft.evidence_metadata,
-            "source_published_at": "2026-07-04T00:00:00",
+            "source_published_at": "2026-06-30T00:00:00",
         }
         approved = approve_publication(
             db,
@@ -1355,6 +1348,168 @@ def test_successful_pipeline_fetches_scores_drafts_and_delivers_for_approval(
         event = db.query(AuditEvent).filter_by(action="news.preview_created").one()
         assert event.details["preview_message_id"] == 301
         assert event.details["control_message_id"] == 302
+
+
+def test_scheduled_review_delivery_sends_at_most_five_distinct_drafts(monkeypatch) -> None:
+    definitions = parse_source_allowlist(
+        [
+            {
+                "id": "batch-journal",
+                "name": "Batch Journal",
+                "type": "primary_research",
+                "fetch_kind": "rss",
+                "url": "https://batch-journal.example/feed",
+                "language": "en",
+                "enabled": True,
+                "fetch_interval_minutes": 60,
+                "trust_notes": "Primary publisher",
+                "licensing_notes": "Metadata and short excerpt only",
+            }
+        ]
+    )
+    titles = (
+        "Resistance training changed measured strength outcome",
+        "Dietary protein review changed nutrition context",
+        "Sleep duration cohort reported recovery associations",
+        "Cardio interval study measured endurance outcome",
+        "Mobility exercise study reported flexibility outcome",
+        "Creatine supplement trial measured performance outcome",
+    )
+    with get_session_context() as db:
+        apply_source_allowlist(db, definitions)
+        source = db.get(NewsSource, "batch-journal")
+        assert source is not None
+        for index, title in enumerate(titles):
+            counts = ingest_items(
+                db,
+                source,
+                [
+                    ParsedNewsItem(
+                        external_id=f"batch-{index}",
+                        canonical_url=f"https://batch-journal.example/batch-{index}",
+                        primary_url=f"https://batch-journal.example/batch-{index}",
+                        title=title,
+                        summary=f"A controlled study reported the {title.lower()}.",
+                        publisher="Batch Journal",
+                        published_at=utcnow(),
+                        doi=f"10.1000/batch-{index}",
+                    )
+                ],
+                candidate_threshold=55,
+            )
+            assert counts["candidate"] == 1
+            item = db.query(NewsItem).filter(NewsItem.external_id == f"batch-{index}").one()
+            assert item.cluster_id is not None
+            cluster = db.get(NewsCluster, item.cluster_id)
+            assert cluster is not None
+            draft = asyncio.run(create_draft_revision(db, cluster))
+            draft.evidence_metadata = {
+                **draft.evidence_metadata,
+                "submitted_by": "hermes_narrow_intake",
+            }
+            draft.warnings = []
+            asyncio.run(create_image_revision(db, cluster, draft, client=None))
+        assert enqueue_review_deliveries(db, {7001}) == len(titles)
+
+    monkeypatch.setattr(settings, "news_legacy_source_fetch_enabled", False)
+    monkeypatch.setattr(settings, "news_image_provider", "disabled")
+    monkeypatch.setattr(settings, "news_publication_enabled", True)
+    monkeypatch.setattr(settings, "news_channel_id", -1001234567890)
+    monkeypatch.setattr(settings, "news_channel_username", "yfc_test_news")
+    monkeypatch.setattr(settings, "admin_telegram_user_ids", "7001")
+    slot = current_news_review_slot(datetime(2026, 9, 8, 5, 5, 0, tzinfo=UTC))
+    assert slot is not None
+    preview_calls: list[int] = []
+    control_calls: list[int] = []
+
+    async def send_preview(_client, chat_id, *_args, **_kwargs):
+        preview_calls.append(chat_id)
+        return SimpleNamespace(message_id=700 + len(preview_calls), message_date=utcnow())
+
+    async def send_control(_client, chat_id, *_args, **_kwargs):
+        control_calls.append(chat_id)
+        return 800 + len(control_calls)
+
+    async def deliver() -> int:
+        async with httpx.AsyncClient() as client:
+            return await deliver_review_queue(
+                client,
+                send_control,
+                send_preview,
+                channel_ready=True,
+                review_slot=slot,
+            )
+
+    assert asyncio.run(deliver()) == 5
+    assert len(preview_calls) == 5
+    assert len(control_calls) == 5
+    with get_session_context() as db:
+        statuses = [
+            row.status for row in db.query(NewsReviewDelivery).order_by(NewsReviewDelivery.id)
+        ]
+        assert statuses.count("sent") == 5
+        assert statuses.count("queued") == 1
+
+    assert asyncio.run(deliver()) == 0
+    assert len(preview_calls) == 5
+    assert len(control_calls) == 5
+    with get_session_context() as db:
+        assert (
+            db.query(NewsReviewDelivery).filter(NewsReviewDelivery.status == "queued").count() == 1
+        )
+
+
+def test_sensitive_hermes_warning_reaches_owner_card_but_not_publish_button(monkeypatch) -> None:
+    cluster_id = _source_and_candidate(external_id="hermes-sensitive-card")
+    draft_id, _ = _draft(cluster_id)
+    monkeypatch.setattr(settings, "news_legacy_source_fetch_enabled", False)
+    monkeypatch.setattr(settings, "news_image_provider", "disabled")
+    monkeypatch.setattr(settings, "news_publication_enabled", True)
+    monkeypatch.setattr(settings, "news_channel_id", -1001234567890)
+    monkeypatch.setattr(settings, "news_channel_username", "yfc_test_news")
+    monkeypatch.setattr(settings, "admin_telegram_user_ids", "7001")
+    with get_session_context() as db:
+        cluster = db.get(NewsCluster, cluster_id)
+        draft = db.get(NewsDraftRevision, draft_id)
+        assert cluster is not None and draft is not None
+        draft.evidence_metadata = {
+            **draft.evidence_metadata,
+            "submitted_by": "hermes_narrow_intake",
+        }
+        draft.warnings = ["medical_prescription_language"]
+        asyncio.run(create_image_revision(db, cluster, draft, client=None))
+        assert enqueue_review_deliveries(db, {7001}) == 1
+
+    control_calls: list[dict[str, object]] = []
+
+    async def send_preview(_client, _chat_id, *_args, **_kwargs):
+        return SimpleNamespace(message_id=631, message_date=utcnow())
+
+    async def send_control(_client, _chat_id, text, *, reply_markup):
+        control_calls.append({"text": text, "reply_markup": reply_markup})
+        return 632
+
+    async def deliver() -> int:
+        async with httpx.AsyncClient() as client:
+            return await deliver_review_queue(
+                client,
+                send_control,
+                send_preview,
+                channel_ready=True,
+            )
+
+    assert asyncio.run(deliver()) == 1
+    assert len(control_calls) == 1
+    callback_values = [
+        button["callback_data"]
+        for row in control_calls[0]["reply_markup"]["inline_keyboard"]
+        for button in row
+        if "callback_data" in button
+    ]
+    assert "medical_prescription_language" in control_calls[0]["text"]
+    assert not any(value.startswith("newsp:p:") for value in callback_values)
+    with get_session_context() as db:
+        assert db.query(NewsReviewDelivery).one().status == "sent"
 
 
 def test_legacy_source_fetch_flag_preserves_downstream_pipeline(monkeypatch) -> None:

--- a/backend/tests/test_news_review_schedule.py
+++ b/backend/tests/test_news_review_schedule.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from fitminiapp_api.services.news_review_schedule import (
+    NEWS_REVIEW_BATCH_SIZE,
+    current_news_review_slot,
+)
+
+
+def test_review_schedule_exposes_three_moscow_windows_and_batch_size() -> None:
+    assert NEWS_REVIEW_BATCH_SIZE == 5
+
+    first = current_news_review_slot(datetime(2026, 9, 8, 5, 0, 0, tzinfo=UTC))
+    second = current_news_review_slot(datetime(2026, 9, 8, 10, 14, 59, tzinfo=UTC))
+    third = current_news_review_slot(datetime(2026, 9, 8, 15, 0, 0, tzinfo=UTC))
+
+    assert first is not None
+    assert first.key == "2026-09-08T08:00:00+03:00"
+    assert second is not None
+    assert second.key == "2026-09-08T13:00:00+03:00"
+    assert third is not None
+    assert third.key == "2026-09-08T18:00:00+03:00"
+
+
+def test_review_schedule_has_a_bounded_grace_window() -> None:
+    start = datetime(2026, 9, 8, 5, 0, 0, tzinfo=UTC)
+
+    assert current_news_review_slot(start) is not None
+    assert current_news_review_slot(start + timedelta(minutes=14, seconds=59)) is not None
+    assert current_news_review_slot(start + timedelta(minutes=15)) is None
+    assert current_news_review_slot(start - timedelta(seconds=1)) is None
+
+
+def test_review_schedule_treats_naive_datetimes_as_utc_storage_values() -> None:
+    slot = current_news_review_slot(datetime(2026, 9, 8, 5, 5, 0))
+
+    assert slot is not None
+    assert slot.local_start.isoformat() == "2026-09-08T08:00:00+03:00"

--- a/backend/tests/test_worker_delivery.py
+++ b/backend/tests/test_worker_delivery.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from itertools import pairwise
 from pathlib import Path
 from time import monotonic
@@ -17,6 +17,7 @@ from fitminiapp_api.models.program import ProgramTemplate, UserProgram, UserWork
 from fitminiapp_api.models.user import User, UserProfile
 from fitminiapp_api.services import notifications as notification_service
 from fitminiapp_api.services import worker
+from fitminiapp_api.services.news_review_schedule import current_news_review_slot
 from fitminiapp_api.services.notifications import (
     NOTIFICATION_FALLBACK,
     NotificationDeliveryError,
@@ -657,6 +658,46 @@ def test_worker_finishes_current_cycle_before_graceful_stop(
     asyncio.run(scenario())
 
     assert events == ["cycle:True"]
+
+
+def test_worker_dispatches_news_review_once_per_active_slot(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    events: list[dict[str, object]] = []
+
+    async def scenario() -> None:
+        stop_requested = asyncio.Event()
+        iterations = 0
+        slot = current_news_review_slot(datetime(2026, 9, 8, 5, 5, tzinfo=UTC))
+        assert slot is not None
+
+        async def run_once(*, sync_reminders: bool) -> None:
+            del sync_reminders
+            nonlocal iterations
+            iterations += 1
+            if iterations == 2:
+                stop_requested.set()
+
+        async def run_news_pipeline_once(**kwargs) -> None:
+            events.append(kwargs)
+
+        monkeypatch.setattr(worker, "run_once", run_once)
+        monkeypatch.setattr(worker, "run_news_pipeline_once", run_news_pipeline_once)
+        monkeypatch.setattr(worker, "current_news_review_slot", lambda _now: slot)
+        monkeypatch.setattr(worker, "WORKER_HEARTBEAT_PATH", tmp_path / "worker-heartbeat")
+        monkeypatch.setattr(worker.settings, "weekly_digest_enabled", False)
+        monkeypatch.setattr(worker.settings, "news_ingestion_enabled", True)
+
+        await worker.run_until_stopped(
+            stop_requested,
+            news_publication_ready=False,
+        )
+
+    asyncio.run(scenario())
+
+    assert len(events) == 2
+    assert [event["review_delivery_due"] for event in events] == [True, False]
+    assert events[0]["review_slot"] is events[1]["review_slot"]
 
 
 def test_worker_heartbeat_refreshes_during_long_async_cycle(

--- a/docs/telegram-news-editorial-automation.md
+++ b/docs/telegram-news-editorial-automation.md
@@ -31,6 +31,22 @@ preview upgrade не создаются. Hermes owner-edited revisions сохр�
 проходить review flow. Действие «Перегенерировать текст» для Hermes повторно ставит принятую
 immutable revision в review flow и не включает legacy candidate generation.
 
+Для editorial intake действует rolling-окно свежести в 60 дней: границы включаются, будущие и
+неизвестные даты отклоняются. Это product/discovery heuristic, а не медицинская норма. Owner-
+карточки отправляются из очереди пачками до 5 различных drafts в окнах 08:00, 13:00 и 18:00
+по `Europe/Moscow`; если доступно меньше пяти, отправляется доступное количество без filler.
+Пятнадцатиминутное окно допускает обычный polling worker и не меняет расписание самого Hermes.
+Очередь, изображения и другие downstream-этапы продолжают обрабатываться между слотами, но новые
+Telegram review cards вне этих окон не отправляются.
+
+Hermes может передавать владельцу полноценный exact preview и управляющую карточку для тем,
+которые требуют ручного решения: AAS/фармакология/пептиды/БАДы и дозировки. Такие карточки не
+включаются в autopublish: `NEWS_AUTO_PUBLISH_LOW_RISK` остаётся `false`, а существующие
+publication quality gates сохраняют право скрыть кнопку публикации до редактирования текста.
+Это расширяет только ручной editorial recall; отсутствие exact image/caption, malformed provider
+response, fallback-заглушка, неподтверждённые числа и другие технические blockers по-прежнему
+fail-closed и не отправляются владельцу как будто это готовая новость.
+
 После production release целевые значения для разделения контуров такие:
 
 ```text
@@ -110,13 +126,15 @@ draft и transient retry; paid/cloud fallback, новые credentials и provide
 publisher.
 
 YFC имеет дополнительный final delivery gate: Hermes draft не отправляется владельцу в Telegram,
-пока не собраны exact image и rendered caption и не сняты content/publication blockers. Fallback-
-заглушки, unresolved provider warnings, переполненный caption и отсутствие artifact не создают
-ни preview, ни управляющую карточку. Заблокированная попытка фиксируется как bounded failure и
-не повторяется для той же text/image revision; новая попытка появляется только после новой
-ревизии текста или изображения. Операционные состояния `publishing_disabled` и
-`channel_rights_missing` не меняют требование наличия image+text preview и не считаются
-содержательным fallback.
+пока не собраны exact image и rendered caption и не сняты технические delivery blockers.
+Fallback-заглушки, unresolved provider warnings, переполненный caption и отсутствие artifact не
+создают ни preview, ни управляющую карточку. Разрешённые для owner review sensitive warnings
+могут оставаться publication blockers: они показываются в полноценной карточке, но скрывают
+кнопку публикации до ручного решения/редактирования. Заблокированная техническая попытка
+фиксируется как bounded failure и не повторяется для той же text/image revision; новая попытка
+появляется только после новой ревизии текста или изображения. Операционные состояния
+`publishing_disabled` и `channel_rights_missing` не меняют требование наличия image+text preview и
+не считаются содержательным fallback.
 
 ## Taxonomy and policy
 
@@ -134,12 +152,13 @@ food, medicine and peptides.  Research is a `content_type` and never replaces th
 Unknown or ambiguous classification goes to manual review; it is not silently promoted to a safe
 topic or auto-publication.
 
-Discovery recall and publication eligibility are separate.  A primary/official current item with
-semantic topic evidence can remain a discovery candidate even when the legacy coarse topic scorer
-does not match.  Unsafe/prescriptive content still hard-blocks.  Existing counters distinguish
-`duplicate`, `stale`, `below_threshold`, `rejected`, `candidate` and `eligible`; source fetch
-failures remain visible on `NewsSource` as error code/time/consecutive count and are not reported as
-“no news”.
+Recall discovery и eligibility публикации разделены. Primary/official fresh item с семантическими
+признаками темы может остаться discovery candidate, даже если legacy coarse topic scorer не дал
+совпадения. Чувствительный/предписывающий Hermes-контент сохраняется для owner review, а
+publication quality gates по-прежнему блокируют unsafe или технически невалидный output. Счётчики
+различают `duplicate`, `stale`, `below_threshold`, `rejected`, `candidate` и `eligible`; ошибки
+загрузки источников остаются видимыми в `NewsSource` с code/time/consecutive count и не
+отчитываются как «новостей нет».
 
 The server-side policy is:
 
@@ -147,12 +166,14 @@ The server-side policy is:
 blocked | manual_required | auto_eligible
 ```
 
-Sensitive medical/pharmacology, peptides, AAS/SARMs, dosage/cycle/protocol, individualized
-recommendations, pregnancy/minors/chronic disease/symptoms, interactions, recalls/contamination,
-preliminary or conflicting evidence and any ambiguity are at least `manual_required`.  Prompt
-injection, unsupported numbers and explicit unsafe/guaranteed claims are blocked.  `auto_eligible`
-also requires the owner-controlled `NEWS_AUTO_PUBLISH_LOW_RISK=true`, valid source provenance,
-quality checks, an exact snapshot and an active kill-switch.  The committed default is false.
+Чувствительные medical/pharmacology, peptides, AAS/SARMs, dosage/cycle/protocol,
+индивидуальные рекомендации, pregnancy/minors/chronic disease/symptoms, interactions,
+recalls/contamination, preliminary или conflicting evidence и любая неоднозначность имеют как
+минимум `manual_required`; Hermes intake может доставить их владельцу как полноценный preview для
+ручного решения. Prompt injection, unsupported numbers и явные unsafe/guaranteed claims по-прежнему
+заблокированы для delivery или publication. `auto_eligible` дополнительно требует
+owner-controlled `NEWS_AUTO_PUBLISH_LOW_RISK=true`, valid source provenance, quality checks, exact
+snapshot и active kill-switch. Committed default — `false`.
 
 The deterministic style checklist checks template/AI meta language, fake personal voice, clickbait,
 invented quotes, excessive exclamation and mechanical repetition.  It does not use an AI detector,


### PR DESCRIPTION
## What changed
- Use a rolling inclusive 60-day source window and up to 5 review cards in the 08:00/13:00/18:00 Europe/Moscow slots.
- Keep legacy acquisition OFF behavior fail-safe: legacy backlog is retained but no new/repeated Telegram review delivery is created; queued/processing legacy deliveries are cancelled before send.
- Keep Hermes-origin drafts (including owner-edited revisions) fully eligible for manual Telegram review, including sensitive topics; auto-publish remains unchanged.
- Keep Hermes regenerate independent from legacy candidate generation.

## Safety
- No migration, purge, source/provider/Groq/HMAC/scheduler/Telegram credential/publication-contract changes.
- Production .env change required: no; existing runtime flags remain the contract.

## Verification
- Exact-head pre-push gate: quality, full Python profile (1016 passed, 1 skipped), critical import smoke.
- No production data was modified locally.