### PR TITLE
[Task 90A] Fix AI Coach beta navigation layout

### DIFF
--- a/frontend/src/pages/miniapp/MiniAppPage.tsx
+++ b/frontend/src/pages/miniapp/MiniAppPage.tsx
@@ -448,7 +448,12 @@ export default function MiniAppPage() {
                   </section>
                 )}
 
-                <nav className="profile-settings-nav" aria-label="Разделы профиля">
+                <nav
+                  className={`profile-settings-nav${
+                    aiCoachStatus.data?.ui_enabled ? ' profile-settings-nav--ai-enabled' : ''
+                  }`}
+                  aria-label="Разделы профиля"
+                >
                   <a
                     href="#profile-personal"
                     onClick={() => openProfileSection('profile-personal')}

--- a/frontend/src/styles/design-v2.css
+++ b/frontend/src/styles/design-v2.css
@@ -8454,6 +8454,14 @@ body.public-shell-mode:has(.public-shell.public-shell--design-v2) {
     border-bottom: 0;
   }
 
+  .profile-settings-nav--ai-enabled a:nth-last-child(-n + 2) {
+    border-bottom: 0;
+  }
+
+  .profile-settings-nav--ai-enabled a:last-child {
+    grid-column: auto;
+  }
+
   .app-section--profile .profile-primary-card,
   .app-section--profile .training-preferences-card {
     padding: var(--v2-space-4);

--- a/frontend/tests/e2e/ai-coach-ui.spec.ts
+++ b/frontend/tests/e2e/ai-coach-ui.spec.ts
@@ -80,6 +80,22 @@ async function openAiCoachSurface(
   await expect(page.getByRole('heading', { name: 'Профиль и настройки' })).toBeVisible();
   await expect(page.locator('#profile-ai-coach')).toHaveAttribute('open');
   await expect(page.getByTestId('ai-coach-experience')).toBeVisible();
+
+  if (viewport.width <= 640) {
+    const securityLink = page.getByRole('link', { name: 'Доступ и безопасность', exact: true });
+    const aiCoachLink = page.getByRole('link', { name: 'AI Coach beta', exact: true });
+    const [securityBox, aiCoachBox] = await Promise.all([
+      securityLink.boundingBox(),
+      aiCoachLink.boundingBox(),
+    ]);
+
+    if (!securityBox || !aiCoachBox) {
+      throw new Error('Profile settings navigation links are not measurable');
+    }
+
+    expect(Math.abs(aiCoachBox.y - securityBox.y)).toBeLessThan(1);
+    expect(aiCoachBox.x).toBeGreaterThan(securityBox.x);
+  }
 }
 
 test('AI Coach internal beta keeps honest states and responsive boundaries', async ({


### PR DESCRIPTION
## Summary

- Keep the AI Coach beta entry in the right cell of the final mobile navigation row, opposite Access and security.
- Preserve the existing five-entry layout when the beta is disabled.
- Add a responsive e2e assertion for the mobile geometry.

## Verification

- 
pm run typecheck`n- 
pm run build`n- 
pm run lint`n- 
pm run e2e:ci -- tests/e2e/ai-coach-ui.spec.ts (1 passed)
- 
pm run e2e:ci -- tests/e2e/profile-settings-simplification.spec.ts (4 passed)

env change required: no