### PR TITLE
[Task 149R] Harden Hermes freshness and deployment recovery

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,7 +100,17 @@ jobs:
         id: migration
         run: |
           set -Eeuo pipefail
-          ACTIVE_REVISION="$(ssh -o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -p "$PROD_PORT" "$PROD_USER@$PROD_HOST" "set -Eeuo pipefail
+          ACTIVE_REVISION=""
+          for attempt in 1 2 3; do
+            if ACTIVE_REVISION="$(ssh \
+              -o BatchMode=yes \
+              -o IdentitiesOnly=yes \
+              -o StrictHostKeyChecking=yes \
+              -o ConnectTimeout=10 \
+              -o ConnectionAttempts=1 \
+              -p "$PROD_PORT" \
+              "$PROD_USER@$PROD_HOST" \
+              "set -Eeuo pipefail
             marker='$PROD_PATH/.artifacts/operations/deployments/last-successful-revision'
             if [ -f \"\$marker\" ]; then
               cat \"\$marker\"
@@ -141,7 +151,17 @@ jobs:
             bot_revision=\$(docker image inspect --format '{{index .Config.Labels \"org.opencontainers.image.revision\"}}' \"\$bot_image\")
             test \"\$backend_revision\" = \"\$bot_revision\"
             printf '%s\\n' \"\$backend_revision\"
-          ")"
+          ")"; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "Unable to read active production revision after 3 SSH attempts" >&2
+              exit 1
+            fi
+            delay=$((attempt * 5))
+            echo "Active revision SSH read attempt $attempt failed; retrying in $delay seconds" >&2
+            sleep "$delay"
+          done
           if [[ ! "$ACTIVE_REVISION" =~ ^[0-9a-f]{40}$ ]]; then
             echo "Production active revision is missing or not a full lowercase SHA" >&2
             exit 1
@@ -178,6 +198,7 @@ jobs:
         run: |
           set -Eeuo pipefail
           scp -o BatchMode=yes -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -P "$PROD_PORT" \
+            -o ConnectTimeout=10 -o ConnectionAttempts=1 \
             "${{ steps.bundle.outputs.name }}" \
             "$PROD_USER@$PROD_HOST:/tmp/${{ steps.bundle.outputs.name }}"
 
@@ -198,6 +219,8 @@ jobs:
             -o BatchMode=yes \
             -o IdentitiesOnly=yes \
             -o StrictHostKeyChecking=yes \
+            -o ConnectTimeout=10 \
+            -o ConnectionAttempts=1 \
             -p "$PROD_PORT" \
             "$PROD_USER@$PROD_HOST" \
             "set -Eeuo pipefail

--- a/backend/fitminiapp_api/api/v1/hermes.py
+++ b/backend/fitminiapp_api/api/v1/hermes.py
@@ -23,6 +23,7 @@ _CLIENT_ERROR_CODES = {
     "source_packet_invalid",
     "source_content_hash_mismatch",
     "source_packet_rejected",
+    "source_publication_not_fresh",
     "source_item_missing",
     "cluster_missing",
     "draft_schema_invalid",
@@ -52,7 +53,7 @@ def _intake_http_error(error: HermesIntakeError) -> HTTPException:
     if error.code in _CONFLICT_CODES:
         return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=error.code)
     if error.code in _CLIENT_ERROR_CODES:
-        return HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=error.code)
+        return HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=error.code)
     return HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="intake_failed")
 
 

--- a/backend/fitminiapp_api/services/news_hermes.py
+++ b/backend/fitminiapp_api/services/news_hermes.py
@@ -33,6 +33,7 @@ from fitminiapp_api.services.news_drafts import (
     quality_warnings,
     render_draft,
 )
+from fitminiapp_api.services.news_freshness import is_fresh_publication
 from fitminiapp_api.services.news_growth import article_candidate_handoff
 from fitminiapp_api.services.news_ingestion import (
     ParsedNewsItem,
@@ -237,6 +238,8 @@ def accept_hermes_submission(
     )
     if recent_count >= settings.hermes_intake_rate_limit_per_minute:
         raise HermesIntakeError("rate_limited")
+    if not is_fresh_publication(payload.source.published_at, now=current):
+        raise HermesIntakeError("source_publication_not_fresh")
 
     source = db.get(NewsSource, payload.source.source_id)
     if source is None or not source.enabled:

--- a/backend/tests/test_deployment_smoke.py
+++ b/backend/tests/test_deployment_smoke.py
@@ -48,6 +48,13 @@ def test_deployment_smoke_separates_compatible_preflight_from_release_contract()
             final_url=f"{BASE_URL}/api/v1/me",
             headers={"cache-control": "no-store"},
         ),
+        "/api/v1/auth/refresh": HttpResponse(
+            status=401,
+            body=b'{"detail":"Not authenticated"}',
+            content_type="application/json",
+            final_url=f"{BASE_URL}/api/v1/auth/refresh",
+            headers={"cache-control": "no-store"},
+        ),
         "/app": _response("/app", body=HTML, content_type="text/html"),
         "/app/report?period=days_30": _response(
             "/app/report?period=days_30", body=HTML, content_type="text/html"
@@ -66,9 +73,25 @@ def test_deployment_smoke_separates_compatible_preflight_from_release_contract()
 
     requested_paths: list[str] = []
 
-    def read(_base_url: str, path: str, *, timeout: float) -> HttpResponse:
+    def read(
+        _base_url: str,
+        path: str,
+        *,
+        timeout: float,
+        method: str = "GET",
+        body: bytes | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> HttpResponse:
         assert timeout == 3
         requested_paths.append(path)
+        if path == "/api/v1/auth/refresh":
+            assert method == "POST"
+            assert body == b"{}"
+            assert headers == {"Accept": "application/json", "Content-Type": "application/json"}
+        else:
+            assert method == "GET"
+            assert body is None
+            assert headers is None
         return responses[path]
 
     assert (

--- a/backend/tests/test_news_hermes.py
+++ b/backend/tests/test_news_hermes.py
@@ -5,6 +5,7 @@ import time
 from datetime import UTC, datetime
 from types import SimpleNamespace
 
+import pytest
 from pydantic import SecretStr
 
 from fitminiapp_api.core.config import settings
@@ -13,10 +14,11 @@ from fitminiapp_api.models.news import (
     HermesEditorialSubmission,
     NewsCluster,
     NewsDraftRevision,
+    NewsItem,
     NewsReviewDelivery,
     NewsSource,
 )
-from fitminiapp_api.services import news_worker
+from fitminiapp_api.services import news_hermes, news_worker
 from fitminiapp_api.services.news_hermes import _canonical_source_hash, hermes_signature
 from fitminiapp_api.services.news_worker import run_news_pipeline_once
 
@@ -78,6 +80,18 @@ def _signed_headers(body: bytes) -> dict[str, str]:
     }
 
 
+def _set_published_at(payload: dict, published_at: datetime | None) -> None:
+    source = payload["source"]
+    assert isinstance(source, dict)
+    source["published_at"] = published_at.isoformat() if published_at else None
+    source["content_hash"] = _canonical_source_hash(
+        title=source["title"],
+        summary=source["summary"],
+        canonical_url=source["canonical_url"],
+        published_at=published_at,
+    )
+
+
 def test_signed_hermes_intake_creates_preview_and_is_idempotent(client, monkeypatch) -> None:
     monkeypatch.setattr(settings, "hermes_intake_enabled", True)
     monkeypatch.setattr(settings, "hermes_intake_key_id", "hermes-test")
@@ -116,8 +130,18 @@ def test_signed_hermes_intake_creates_preview_and_is_idempotent(client, monkeypa
         assert db.query(HermesEditorialSubmission).count() == 1
 
 
-def test_signed_hermes_intake_preserves_missing_source_publication_date(
-    client, monkeypatch
+@pytest.mark.parametrize(
+    ("published_at", "expected_status"),
+    [
+        (None, 422),
+        (datetime(2026, 8, 30, 12, 0, 1), 422),
+        (datetime(2026, 6, 30, 11, 59, 59), 422),
+        (datetime(2026, 7, 1, 12, 0, 0), 200),
+        (datetime(2026, 8, 29, 12, 0, 0), 200),
+    ],
+)
+def test_signed_hermes_intake_enforces_source_freshness_before_ingestion(
+    client, monkeypatch, published_at: datetime | None, expected_status: int
 ) -> None:
     monkeypatch.setattr(settings, "hermes_intake_enabled", True)
     monkeypatch.setattr(settings, "hermes_intake_key_id", "hermes-test")
@@ -126,6 +150,8 @@ def test_signed_hermes_intake_preserves_missing_source_publication_date(
         "hermes_intake_shared_secret",
         SecretStr("test-hermes-shared-secret-that-is-long-enough"),
     )
+    fixed_now = datetime(2026, 8, 30, 12, 0, 0)
+    monkeypatch.setattr(news_hermes, "utcnow", lambda: fixed_now)
     with get_session_context() as db:
         db.add(
             NewsSource(
@@ -140,16 +166,15 @@ def test_signed_hermes_intake_preserves_missing_source_publication_date(
         )
 
     payload = _payload()
-    payload["idempotency_key"] = "hermes-test-missing-published-at"
+    payload["idempotency_key"] = f"hermes-test-freshness-{expected_status}"
     payload["request_nonce"] = "hermes-test-nonce-1"
-    payload["source"]["published_at"] = None
-    payload["source"]["content_hash"] = _canonical_source_hash(
-        title=payload["source"]["title"],
-        summary=payload["source"]["summary"],
-        canonical_url=payload["source"]["canonical_url"],
-        published_at=None,
-    )
+    _set_published_at(payload, published_at)
     body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
+
+    with get_session_context() as db:
+        before_submissions = db.query(HermesEditorialSubmission).count()
+        before_items = db.query(NewsItem).count()
+        before_drafts = db.query(NewsDraftRevision).count()
 
     response = client.post(
         "/api/v1/hermes/editorial/intake",
@@ -157,13 +182,15 @@ def test_signed_hermes_intake_preserves_missing_source_publication_date(
         headers=_signed_headers(body),
     )
 
-    assert response.status_code == 200, response.text
-    assert response.json()["status"] == "accepted"
+    assert response.status_code == expected_status, response.text
     with get_session_context() as db:
-        submission = db.query(HermesEditorialSubmission).one()
-        draft = db.get(NewsDraftRevision, submission.draft_id)
-        assert draft is not None
-        assert draft.evidence_metadata["source_published_at"] is None
+        if expected_status == 422:
+            assert response.json()["detail"] == "source_publication_not_fresh"
+            assert db.query(HermesEditorialSubmission).count() == before_submissions
+            assert db.query(NewsItem).count() == before_items
+            assert db.query(NewsDraftRevision).count() == before_drafts
+        else:
+            assert response.json()["status"] == "accepted"
 
 
 def test_hermes_intake_rejects_bad_signature_without_source_processing(client, monkeypatch) -> None:

--- a/scripts/check_deployment.py
+++ b/scripts/check_deployment.py
@@ -21,10 +21,23 @@ class HttpResponse:
     headers: dict[str, str]
 
 
-def _read(base_url: str, path: str, *, timeout: float) -> HttpResponse:
+def _read(
+    base_url: str,
+    path: str,
+    *,
+    timeout: float,
+    method: str = "GET",
+    body: bytes | None = None,
+    headers: dict[str, str] | None = None,
+) -> HttpResponse:
+    request_headers = {"User-Agent": "fitminiapp-deployment-check/2"}
+    if headers:
+        request_headers.update(headers)
     request = urllib.request.Request(
         urljoin(base_url.rstrip("/") + "/", path.lstrip("/")),
-        headers={"User-Agent": "fitminiapp-deployment-check/2"},
+        data=body,
+        method=method,
+        headers=request_headers,
     )
     try:
         response = urllib.request.urlopen(request, timeout=timeout)
@@ -73,6 +86,7 @@ def check_deployment(
     timeout: float,
     expected_environment: str | None = None,
     require_progress_report_shell: bool = False,
+    check_refresh_boundary: bool = True,
     read=None,
 ) -> str:
     reader = read or _read
@@ -126,6 +140,21 @@ def check_deployment(
         raise RuntimeError(
             f"authenticated boundary returned {auth_boundary.status}, expected anonymous 401"
         )
+
+    if check_refresh_boundary:
+        auth_refresh = reader(
+            base_url,
+            "/api/v1/auth/refresh",
+            timeout=timeout,
+            method="POST",
+            body=b"{}",
+            headers={"Accept": "application/json", "Content-Type": "application/json"},
+        )
+        _expect_same_origin(base_url, auth_refresh, "browser auth refresh boundary")
+        if auth_refresh.status != 401:
+            raise RuntimeError(
+                f"browser auth refresh boundary returned {auth_refresh.status}, expected anonymous 401"
+            )
 
     app = reader(base_url, "/app", timeout=timeout)
     _expect_same_origin(base_url, app, "application shell")

--- a/scripts/continuous_deployment_probe.py
+++ b/scripts/continuous_deployment_probe.py
@@ -16,6 +16,11 @@ else:
     from check_deployment import _first_versioned_asset, _read, check_deployment
 
 
+# The anonymous refresh endpoint is limited to 10 requests per minute. Seven
+# seconds keeps the continuous probe below that limit even with a sliding window.
+AUTH_REFRESH_PROBE_INTERVAL_SECONDS = 7.0
+
+
 @dataclass
 class ProbeReport:
     started_at: float
@@ -86,16 +91,23 @@ def run_probe(
     report.requests += 1
     report.compatibility_asset = _first_versioned_asset(initial_document.body)
     on_started()
+    next_refresh_boundary_at = started
 
     while True:
         sample_started = clock()
+        check_refresh_boundary = sample_started >= next_refresh_boundary_at
+        if check_refresh_boundary:
+            next_refresh_boundary_at = sample_started + max(
+                interval, AUTH_REFRESH_PROBE_INTERVAL_SECONDS
+            )
         try:
             check_deployment(
                 base_url,
                 timeout=timeout,
                 expected_environment=expected_environment,
+                check_refresh_boundary=check_refresh_boundary,
             )
-            report.requests += 8
+            report.requests += 8 + int(check_refresh_boundary)
             if compatibility_required():
                 old_asset = _read(base_url, report.compatibility_asset, timeout=timeout)
                 report.requests += 1

--- a/scripts/zero_downtime_deploy.py
+++ b/scripts/zero_downtime_deploy.py
@@ -329,6 +329,68 @@ def _image_digest(image: str, expected_revision: str) -> str:
     return digest
 
 
+def _image_digest_from_exact_revision_tag(
+    image: str,
+    *,
+    configured_image: str,
+    expected_revision: str,
+) -> str:
+    """Resolve a legacy image by its exact immutable revision tag.
+
+    Older single-slot images may not retain the OCI revision label after a Docker
+    reclaim.  The fallback still requires the running image ID to expose the exact
+    revision tag and a repository digest; a mutable tag or an unrelated digest is
+    never accepted as provenance.
+    """
+    if not re.fullmatch(r"sha256:[0-9a-f]{64}", image):
+        raise DeploymentError(f"legacy image reference {image!r} is not an immutable image ID")
+    if not re.fullmatch(rf".+:{re.escape(expected_revision)}", configured_image):
+        raise DeploymentError(
+            f"legacy service image {configured_image!r} is not an exact revision tag"
+        )
+    result = _run(
+        [
+            "docker",
+            "image",
+            "inspect",
+            "--format",
+            '{{json .RepoDigests}}|{{json .RepoTags}}|{{index .Config.Labels "org.opencontainers.image.revision"}}',
+            image,
+        ],
+        capture=True,
+    ).stdout.strip()
+    digests_json, separator, remainder = result.partition("|")
+    tags_json, tags_separator, revision = remainder.partition("|")
+    if not separator or not tags_separator or revision not in {"", "<no value>"}:
+        raise DeploymentError(
+            f"legacy image {image} has an unexpected OCI revision label {revision!r}"
+        )
+    try:
+        digests = json.loads(digests_json)
+        tags = json.loads(tags_json)
+    except json.JSONDecodeError as exc:
+        raise DeploymentError(f"legacy image {image} returned invalid Docker metadata") from exc
+    if not isinstance(digests, list) or not digests:
+        raise DeploymentError(f"legacy image {image} has no immutable repository digest")
+    if not isinstance(tags, list) or configured_image not in tags:
+        raise DeploymentError(
+            f"legacy image {image} is not tagged with its configured exact revision image"
+        )
+    repository = configured_image.rsplit(":", 1)[0]
+    matching = [
+        value
+        for value in digests
+        if isinstance(value, str)
+        and value.startswith(repository + "@sha256:")
+        and re.fullmatch(r".+@sha256:[0-9a-f]{64}", value)
+    ]
+    if not matching:
+        raise DeploymentError(
+            f"legacy image {image} has no immutable digest for repository {repository!r}"
+        )
+    return matching[0]
+
+
 def _capacity() -> dict[str, int]:
     memory_kib = 0
     meminfo = Path("/proc/meminfo")
@@ -1252,6 +1314,34 @@ def _legacy_running_image(service: str) -> str:
     return image
 
 
+def _legacy_configured_image(service: str) -> str:
+    container_id = _compose("ps", "-q", service, capture=True).stdout.strip()
+    if not container_id or not _service_is_running(service):
+        raise DeploymentError(f"single-slot rollout requires running legacy service {service}")
+    image = _run(
+        ["docker", "inspect", "--format", "{{.Config.Image}}", container_id],
+        capture=True,
+    ).stdout.strip()
+    if not image:
+        raise DeploymentError(f"legacy service {service} has no configured image reference")
+    return image
+
+
+def _legacy_image_digest(service: str, expected_revision: str) -> str:
+    image = _legacy_running_image(service)
+    try:
+        return _image_digest(image, expected_revision)
+    except DeploymentError as exc:
+        if not re.search(r"revision (?:''|'<no value>') does not match ", str(exc)):
+            raise
+    configured_image = _legacy_configured_image(service)
+    return _image_digest_from_exact_revision_tag(
+        image,
+        configured_image=configured_image,
+        expected_revision=expected_revision,
+    )
+
+
 def _stop_legacy_services(config: DeployConfig) -> None:
     for service, timeout in (
         ("worker", config.worker_drain_seconds),
@@ -1407,9 +1497,9 @@ def single_slot_deploy(config: DeployConfig) -> Evidence:
 
     try:
         with _stage(evidence, "single_slot_legacy_provenance"):
-            old_backend = _image_digest(_legacy_running_image("backend"), active_revision)
-            old_bot = _image_digest(_legacy_running_image("bot"), active_revision)
-            old_worker = _image_digest(_legacy_running_image("worker"), active_revision)
+            old_backend = _legacy_image_digest("backend", active_revision)
+            old_bot = _legacy_image_digest("bot", active_revision)
+            old_worker = _legacy_image_digest("worker", active_revision)
             if old_worker != old_backend:
                 raise DeploymentError(
                     "legacy backend and worker do not use the same verified image digest"

--- a/tests/test_check_deployment.py
+++ b/tests/test_check_deployment.py
@@ -41,6 +41,13 @@ def _fake_read(config: dict[str, object]):
             final_url=f"{base_url}/api/v1/me",
             headers={"cache-control": "no-store"},
         ),
+        "/api/v1/auth/refresh": check_deployment.HttpResponse(
+            status=401,
+            body=b'{"detail":"Not authenticated"}',
+            content_type="application/json",
+            final_url=f"{base_url}/api/v1/auth/refresh",
+            headers={"cache-control": "no-store"},
+        ),
         "/app": response("/app", html, "text/html; charset=utf-8"),
         "/login": response("/login", html, "text/html; charset=utf-8"),
         "/app?tgWebAppPlatform=android": response(
@@ -54,8 +61,24 @@ def _fake_read(config: dict[str, object]):
         ),
     }
 
-    def read(_base_url: str, path: str, *, timeout: float) -> check_deployment.HttpResponse:
+    def read(
+        _base_url: str,
+        path: str,
+        *,
+        timeout: float,
+        method: str = "GET",
+        body: bytes | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> check_deployment.HttpResponse:
         assert timeout == 10.0
+        if path == "/api/v1/auth/refresh":
+            assert method == "POST"
+            assert body == b"{}"
+            assert headers == {"Accept": "application/json", "Content-Type": "application/json"}
+        else:
+            assert method == "GET"
+            assert body is None
+            assert headers is None
         return responses[path]
 
     return read
@@ -85,6 +108,48 @@ def test_production_smoke_requires_safe_environment_and_auth_flags(
 
     assert check_deployment.main() == 0
     assert "Environment reported by API: prod" in capsys.readouterr().out
+
+
+def test_deployment_check_can_skip_rate_limited_refresh_boundary() -> None:
+    read = _fake_read(
+        {
+            "app_env": "prod",
+            "enable_dev_auth": False,
+            "enable_web_auth": True,
+            "enable_email_auth": False,
+        }
+    )
+
+    def no_refresh(
+        base_url: str,
+        path: str,
+        *,
+        timeout: float,
+        method: str = "GET",
+        body: bytes | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> check_deployment.HttpResponse:
+        if path == "/api/v1/auth/refresh":
+            pytest.fail("rate-limited refresh boundary should be skipped")
+        return read(
+            base_url,
+            path,
+            timeout=timeout,
+            method=method,
+            body=body,
+            headers=headers,
+        )
+
+    assert (
+        check_deployment.check_deployment(
+            "https://app.example.test",
+            timeout=10.0,
+            expected_environment="prod",
+            check_refresh_boundary=False,
+            read=no_refresh,
+        )
+        == "prod"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_continuous_deployment_probe.py
+++ b/tests/test_continuous_deployment_probe.py
@@ -80,3 +80,37 @@ def test_probe_classifies_broken_old_asset(monkeypatch) -> None:
 
     assert report.failure_count == 1
     assert report.failures["asset_mismatch"] == 1
+
+
+def test_probe_throttles_the_rate_limited_refresh_boundary(monkeypatch) -> None:
+    clock = FakeClock()
+    refresh_boundary_checks: list[bool] = []
+
+    def read(_base_url: str, path: str, *, timeout: float) -> HttpResponse:
+        del timeout
+        if path == "/app":
+            return _response(
+                path, body=b'<div id="root"></div><script src="/assets/a-old.js"></script>'
+            )
+        return _response(path, body=b"old asset")
+
+    def check(_base_url: str, **kwargs: object) -> str:
+        refresh_boundary_checks.append(bool(kwargs["check_refresh_boundary"]))
+        return "prod"
+
+    monkeypatch.setattr(probe, "_read", read)
+    monkeypatch.setattr(probe, "check_deployment", check)
+
+    report = probe.run_probe(
+        "https://app.example.test",
+        duration=8,
+        interval=1,
+        timeout=1,
+        expected_environment="prod",
+        clock=clock,
+        sleeper=clock.sleep,
+    )
+
+    assert report.failure_count == 0
+    assert refresh_boundary_checks == [True, False, False, False, False, False, False, True, False]
+    assert report.requests == 1 + sum(8 + int(value) for value in refresh_boundary_checks) + 9

--- a/tests/test_release_safeguards.py
+++ b/tests/test_release_safeguards.py
@@ -108,6 +108,16 @@ def test_deploy_recovers_legacy_revision_before_migration_and_rollout() -> None:
     assert 'install -d -m 700 \\"\\$(dirname \\"\\$active_marker\\")\\"' in deploy
 
 
+def test_deploy_bounds_transient_production_ssh_failures() -> None:
+    deploy = _sources()["deploy"]
+
+    assert "for attempt in 1 2 3; do" in deploy
+    assert "ConnectTimeout=10" in deploy
+    assert "ConnectionAttempts=1" in deploy
+    assert "Unable to read active production revision after 3 SSH attempts" in deploy
+    assert 'sleep "$delay"' in deploy
+
+
 def test_delivery_contract_is_master_only_and_approval_gated() -> None:
     sources = _sources()
     controller = sources["controller"]

--- a/tests/test_zero_downtime_deploy.py
+++ b/tests/test_zero_downtime_deploy.py
@@ -163,6 +163,61 @@ def test_persist_application_image_refs_rejects_non_immutable_values(
         )
 
 
+def test_legacy_image_digest_accepts_exact_tag_when_oci_label_is_missing(monkeypatch) -> None:
+    image_id = "sha256:" + "c" * 64
+    configured_image = f"registry/backend:{OLD_SHA}"
+    repo_digest = "registry/backend@sha256:" + "d" * 64
+
+    monkeypatch.setattr(deploy, "_legacy_running_image", lambda _service: image_id)
+    monkeypatch.setattr(deploy, "_legacy_configured_image", lambda _service: configured_image)
+
+    def missing_label_digest(image: str, revision: str) -> str:
+        raise deploy.DeploymentError(f"image {image} revision '' does not match {revision}")
+
+    monkeypatch.setattr(deploy, "_image_digest", missing_label_digest)
+    monkeypatch.setattr(
+        deploy,
+        "_run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args,
+            0,
+            stdout=(f"{json.dumps([repo_digest])}|{json.dumps([configured_image])}|\n"),
+        ),
+    )
+
+    assert deploy._legacy_image_digest("backend", OLD_SHA) == repo_digest
+
+
+def test_legacy_image_digest_rejects_mutable_tag_when_oci_label_is_missing(monkeypatch) -> None:
+    image_id = "sha256:" + "c" * 64
+    configured_image = "registry/backend:latest"
+    repo_digest = "registry/backend@sha256:" + "d" * 64
+
+    monkeypatch.setattr(deploy, "_legacy_running_image", lambda _service: image_id)
+    monkeypatch.setattr(deploy, "_legacy_configured_image", lambda _service: configured_image)
+
+    def missing_label_digest(image: str, revision: str) -> str:
+        raise deploy.DeploymentError(f"image {image} revision '' does not match {revision}")
+
+    monkeypatch.setattr(
+        deploy,
+        "_image_digest",
+        missing_label_digest,
+    )
+    monkeypatch.setattr(
+        deploy,
+        "_run",
+        lambda *args, **kwargs: subprocess.CompletedProcess(
+            args,
+            0,
+            stdout=f"{json.dumps([repo_digest])}|{json.dumps([configured_image])}|\n",
+        ),
+    )
+
+    with pytest.raises(deploy.DeploymentError, match="exact revision tag"):
+        deploy._legacy_image_digest("backend", OLD_SHA)
+
+
 def test_config_can_keep_rollout_state_outside_immutable_release(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Task

Closes #217 after terminal production closeout.

This PR delivers the post-merge remediation from Task 149R. It remains open until exact-head merge, automatic deployment, authenticated/browser smoke, and controller closeout are complete.

## Scope

- Harden immutable image provenance and single-slot recovery in `zero_downtime_deploy.py`.
- Keep deployment SSH retries bounded and preserve exact-SHA migration/deployment behavior.
- Align deployment smoke auth bootstrap with the frontend refresh contract and require fail-closed unauthenticated `/api/v1/me` behavior.
- Reject Hermes source publications outside the inclusive 60-day freshness window, including future dates, with a stable API response.
- Keep the continuous deployment probe below the `refresh_tokens` `10/minute` limiter by checking that boundary no more often than once per 7 seconds while preserving frequent health/shell/asset checks.
- Add regression coverage across deployment, auth bootstrap, Hermes freshness, probe rate limiting, and recovery behavior.

## Delivery evidence

- Branch: `task/149R-post-merge-remediation`
- Exact head: `d59fcabee57774ba9732cd086dd4ea98bc220ecc`
- Base: `master` at `9ec722d42743caa351257f9e6b3ff9714cabdbe2`
- Local final gate: `PRE_PUSH_CI_PASS`
- Evidence: `.artifacts/tasks/149R/evidence/pre-push/gate.json`
- Targeted review recheck: APPROVED; QA recheck: PASS
- Local gate covered quality, frontend checks/E2E/mobile, 1,023 Python tests, migrated stack, dependency audit, critical smoke, policy and workflow/image/deployment/container contracts.

## Review blocker resolution

The P1 review finding about repeated anonymous refresh requests was fixed by separating the refresh boundary from the frequent deployment checks. The first boundary check is immediate; subsequent checks are spaced by `max(interval, 7s)`, so one probe emits at most 9 refresh requests per 60 seconds. The scheduling is covered by deterministic regression tests.

## Release contract

- Production deployment must be the normal post-merge workflow for the exact merged SHA.
- Required exact-head checks and review must be complete before merge.
- Production auth/browser smoke and `task_session.py complete-production` remain required before closing #217.
- `env change required: no` — the diff changes no production environment variable names, values, secrets, or deployment placement.