### PR TITLE
[Task 226] Fix Hermes owner review delivery blockers

### DIFF
--- a/backend/fitminiapp_api/services/news_editorial.py
+++ b/backend/fitminiapp_api/services/news_editorial.py
@@ -27,7 +27,10 @@ from fitminiapp_api.services.audit import record_audit_event
 from fitminiapp_api.services.news_content import parse_editorial_content
 from fitminiapp_api.services.news_drafts import quality_warnings
 from fitminiapp_api.services.news_freshness import source_metadata_is_fresh
-from fitminiapp_api.services.news_images import create_uploaded_image_revision, current_image
+from fitminiapp_api.services.news_images import (
+    create_uploaded_image_revision,
+    current_image,
+)
 from fitminiapp_api.services.news_ingestion import utcnow
 from fitminiapp_api.services.news_publication import (
     ARTIFACT_HASH_PREFIX_LENGTH,
@@ -96,7 +99,21 @@ class ReviewArtifact:
 HERMES_SUBMISSION_MARKER = "hermes_narrow_intake"
 PREVIEW_OPERATIONAL_BLOCKERS = frozenset({"publishing_disabled", "channel_rights_missing"})
 LEGACY_REVIEW_DELIVERY_DISABLED = "legacy_review_delivery_disabled"
-MANUAL_REVIEW_ALLOWED_WARNINGS = frozenset({"medical_prescription_language"})
+MANUAL_REVIEW_ALLOWED_WARNINGS = frozenset(
+    {
+        "medical_prescription_language",
+        "unsupported_number",
+        "telegram_photo_caption_too_long",
+    }
+)
+MANUAL_REVIEW_ALLOWED_BLOCKERS = frozenset(
+    {
+        "unresolved_warning:medical_prescription_language",
+        "unresolved_warning:unsupported_number",
+        "unresolved_warning:telegram_photo_caption_too_long",
+        "telegram_photo_caption_too_long",
+    }
+)
 MANUAL_REVIEW_ALLOWED_CONTENT_BLOCKERS = frozenset(
     {
         "prohibited_medical_or_aas_language",
@@ -114,16 +131,22 @@ def review_delivery_blockers(
     draft: NewsDraftRevision,
     review: ReviewArtifact,
 ) -> tuple[str, ...]:
-    """Return blockers that make an owner Telegram delivery unsafe or misleading."""
+    """Block only owner-preview states that cannot be reviewed safely.
+
+    Publication-quality warnings remain visible on the owner control card and
+    continue to block publication. Recoverable editorial issues must not make
+    the review item disappear from the owner's Telegram queue.
+    """
 
     is_hermes_draft = is_hermes_origin_draft(draft)
     blockers: list[str] = []
+
     if is_hermes_draft:
         blockers.extend(
             blocker
             for blocker in review.blockers
             if blocker not in PREVIEW_OPERATIONAL_BLOCKERS
-            and blocker != "unresolved_warning:medical_prescription_language"
+            and blocker not in MANUAL_REVIEW_ALLOWED_BLOCKERS
             and blocker not in MANUAL_REVIEW_ALLOWED_CONTENT_BLOCKERS
         )
         blockers.extend(
@@ -135,10 +158,23 @@ def review_delivery_blockers(
                 and warning not in MANUAL_REVIEW_ALLOWED_WARNINGS
             )
         )
+
+    # An overlong photo caption is recoverable in the owner UI: the exact
+    # publication artifact is unavailable, but review_message() can still
+    # deliver a control card with edit/regenerate actions.
     if is_hermes_draft and review.artifact is None:
-        blockers.append("preview_artifact_unavailable")
+        recoverable_overlong_caption = (
+            "telegram_photo_caption_too_long" in review.blockers and not blockers
+        )
+        if not recoverable_overlong_caption:
+            blockers.append("preview_artifact_unavailable")
+
+    # Hermes publication still requires its image path. Keep this as a hard
+    # preview gate rather than silently degrading to a publishable text-only
+    # item.
     if is_hermes_draft and (review.image is None or not review.image.image_data):
         blockers.append("preview_image_missing")
+
     return tuple(dict.fromkeys(blockers))
 
 

--- a/backend/tests/test_news_publishing.py
+++ b/backend/tests/test_news_publishing.py
@@ -25,7 +25,10 @@ from fitminiapp_api.models.news import (
     NewsSource,
 )
 from fitminiapp_api.services import news_images, news_publication, news_worker
-from fitminiapp_api.services.news_content import EditorialContent, parse_editorial_content
+from fitminiapp_api.services.news_content import (
+    EditorialContent,
+    parse_editorial_content,
+)
 from fitminiapp_api.services.news_drafts import create_draft_revision
 from fitminiapp_api.services.news_editorial import (
     compose_review_artifact,
@@ -58,7 +61,10 @@ from fitminiapp_api.services.news_publication import (
     retry_uncertain_publication,
 )
 from fitminiapp_api.services.news_review_schedule import current_news_review_slot
-from fitminiapp_api.services.news_sources import apply_source_allowlist, parse_source_allowlist
+from fitminiapp_api.services.news_sources import (
+    apply_source_allowlist,
+    parse_source_allowlist,
+)
 from fitminiapp_api.services.news_worker import (
     NewsCycleStats,
     deliver_review_queue,
@@ -1890,7 +1896,7 @@ def test_hermes_fallback_draft_is_not_delivered_or_requeued(monkeypatch) -> None
         assert enqueue_review_deliveries(db, {7001}) == 0
 
 
-def test_overlong_preview_never_sends_control_card_without_artifact(monkeypatch) -> None:
+def test_overlong_hermes_preview_sends_recovery_control_card(monkeypatch) -> None:
     cluster_id = _source_and_candidate(external_id="overlong-delivery-guard")
     draft_id, _ = _draft(cluster_id)
     monkeypatch.setattr(settings, "news_image_provider", "disabled")
@@ -1935,12 +1941,13 @@ def test_overlong_preview_never_sends_control_card_without_artifact(monkeypatch)
             )
 
     delivered = asyncio.run(deliver())
-    assert delivered == 0
+    assert delivered == 1
     assert preview_calls == []
-    assert control_calls == []
+    assert control_calls == [7001]
     with get_session_context() as db:
         delivery = db.query(NewsReviewDelivery).one()
-        assert delivery.last_error_code == "preview_delivery_blocked"
+        assert delivery.status == "sent"
+        assert delivery.last_error_code is None
 
 
 def test_hermes_without_image_is_not_delivered_as_text_only(monkeypatch) -> None:
@@ -2112,3 +2119,79 @@ def test_legacy_plain_snapshot_does_not_block_html_renderer_approval(monkeypatch
         assert current.renderer_version == "news-publication-html-v1"
         assert current.parse_mode == "HTML"
         assert current.link_preview_disabled is True
+
+
+def test_hermes_unsupported_number_reaches_owner_review_but_cannot_publish(
+    monkeypatch,
+) -> None:
+    cluster_id = _source_and_candidate(external_id="hermes-unsupported-number-review")
+    draft_id, _ = _draft(cluster_id)
+
+    monkeypatch.setattr(settings, "news_legacy_source_fetch_enabled", False)
+    monkeypatch.setattr(settings, "news_image_provider", "disabled")
+    monkeypatch.setattr(settings, "news_publication_enabled", True)
+    monkeypatch.setattr(settings, "news_channel_id", -1001234567890)
+    monkeypatch.setattr(settings, "news_channel_username", "yfc_test_news")
+    monkeypatch.setattr(settings, "admin_telegram_user_ids", "7001")
+
+    with get_session_context() as db:
+        cluster = db.get(NewsCluster, cluster_id)
+        draft = db.get(NewsDraftRevision, draft_id)
+        assert cluster is not None and draft is not None
+
+        draft.evidence_metadata = {
+            **draft.evidence_metadata,
+            "submitted_by": "hermes_narrow_intake",
+        }
+        draft.warnings = ["unsupported_number"]
+
+        asyncio.run(create_image_revision(db, cluster, draft, client=None))
+        assert enqueue_review_deliveries(db, {7001}) == 1
+
+    preview_calls: list[int] = []
+    control_calls: list[dict[str, object]] = []
+
+    async def send_preview(_client, chat_id, *_args, **_kwargs):
+        preview_calls.append(chat_id)
+        return SimpleNamespace(message_id=901, message_date=utcnow())
+
+    async def send_control(_client, chat_id, text, *, reply_markup):
+        control_calls.append(
+            {
+                "chat_id": chat_id,
+                "text": text,
+                "reply_markup": reply_markup,
+            }
+        )
+        return 902
+
+    async def deliver() -> int:
+        async with httpx.AsyncClient() as client:
+            return await deliver_review_queue(
+                client,
+                send_control,
+                send_preview,
+                channel_ready=True,
+            )
+
+    assert asyncio.run(deliver()) == 1
+    assert preview_calls == [7001]
+    assert len(control_calls) == 1
+
+    control = control_calls[0]
+    assert "unsupported_number" in control["text"]
+
+    callback_values = [
+        button["callback_data"]
+        for row in control["reply_markup"]["inline_keyboard"]
+        for button in row
+        if "callback_data" in button
+    ]
+
+    assert not any(value.startswith("newsp:p:") for value in callback_values)
+    assert not any(value.startswith("newsp:s:") for value in callback_values)
+
+    with get_session_context() as db:
+        delivery = db.query(NewsReviewDelivery).one()
+        assert delivery.status == "sent"
+        assert delivery.last_error_code is None

--- a/docs/telegram-news-editorial-automation.md
+++ b/docs/telegram-news-editorial-automation.md
@@ -43,9 +43,10 @@ Hermes может передавать владельцу полноценный
 которые требуют ручного решения: AAS/фармакология/пептиды/БАДы и дозировки. Такие карточки не
 включаются в autopublish: `NEWS_AUTO_PUBLISH_LOW_RISK` остаётся `false`, а существующие
 publication quality gates сохраняют право скрыть кнопку публикации до редактирования текста.
-Это расширяет только ручной editorial recall; отсутствие exact image/caption, malformed provider
-response, fallback-заглушка, неподтверждённые числа и другие технические blockers по-прежнему
-fail-closed и не отправляются владельцу как будто это готовая новость.
+Это расширяет только ручной editorial recall. Malformed provider response, fallback-заглушка и
+отсутствующее Hermes image по-прежнему остаются hard delivery blockers. Recoverable
+publication-quality warnings `unsupported_number` и `telegram_photo_caption_too_long` могут
+дойти до owner review, но продолжают блокировать publication до исправления.
 
 После production release целевые значения для разделения контуров такие:
 
@@ -125,16 +126,19 @@ draft и transient retry; paid/cloud fallback, новые credentials и provide
 публикацию. YFC по-прежнему применяет `manual_required`, Gate B/C и остаётся единственным
 publisher.
 
-YFC имеет дополнительный final delivery gate: Hermes draft не отправляется владельцу в Telegram,
-пока не собраны exact image и rendered caption и не сняты технические delivery blockers.
-Fallback-заглушки, unresolved provider warnings, переполненный caption и отсутствие artifact не
-создают ни preview, ни управляющую карточку. Разрешённые для owner review sensitive warnings
-могут оставаться publication blockers: они показываются в полноценной карточке, но скрывают
-кнопку публикации до ручного решения/редактирования. Заблокированная техническая попытка
-фиксируется как bounded failure и не повторяется для той же text/image revision; новая попытка
-появляется только после новой ревизии текста или изображения. Операционные состояния
-`publishing_disabled` и `channel_rights_missing` не меняют требование наличия image+text preview и
-не считаются содержательным fallback.
+YFC имеет дополнительный final delivery gate. Hard preview states — fallback/provider failure и
+отсутствующее Hermes image — остаются fail-closed и не отправляются владельцу как готовый
+review item. Recoverable publication-quality warnings `unsupported_number` и
+`telegram_photo_caption_too_long` не должны скрывать материал из owner review queue: они
+остаются publication blockers и поэтому не дают кнопок publish/schedule.
+
+При `unsupported_number`, если exact artifact и image доступны, владельцу отправляются private
+preview и управляющая карточка. При `telegram_photo_caption_too_long` exact publication artifact
+может быть недоступен из-за лимита Telegram; тогда photo preview не отправляется, но владелец
+получает recovery/control card с действиями редактирования, перегенерации, отклонения и defer.
+Публикация остаётся запрещённой, пока blocker не устранён. Операционные состояния
+`publishing_disabled` и `channel_rights_missing` не превращают blocked material в publishable
+fallback.
 
 ## Taxonomy and policy
 
@@ -170,8 +174,9 @@ blocked | manual_required | auto_eligible
 индивидуальные рекомендации, pregnancy/minors/chronic disease/symptoms, interactions,
 recalls/contamination, preliminary или conflicting evidence и любая неоднозначность имеют как
 минимум `manual_required`; Hermes intake может доставить их владельцу как полноценный preview для
-ручного решения. Prompt injection, unsupported numbers и явные unsafe/guaranteed claims по-прежнему
-заблокированы для delivery или publication. `auto_eligible` дополнительно требует
+ручного решения. Prompt injection и явные unsafe/guaranteed claims по-прежнему остаются hard
+blockers. `unsupported_number` может быть доставлен владельцу для ручного исправления, но
+остаётся publication blocker. `auto_eligible` дополнительно требует
 owner-controlled `NEWS_AUTO_PUBLISH_LOW_RISK=true`, valid source provenance, quality checks, exact
 snapshot и active kill-switch. Committed default — `false`.
 


### PR DESCRIPTION
## Summary

Manual hotfix for Issue #226. No Codex/autopilot.

Production evidence showed Hermes drafts reached YFC, images were generated, and review deliveries were queued, but drafts with recoverable publication warnings such as `unsupported_number` and `telegram_photo_caption_too_long` failed as `preview_delivery_blocked` before reaching the owner.

This change restores owner review delivery while preserving publication safety:

- `unsupported_number` remains a publication blocker, but the owner receives the review/control card;
- `telegram_photo_caption_too_long` remains a publication blocker, but the owner receives a recovery/control card when exact photo preview cannot be composed;
- publish/schedule buttons remain unavailable while publication blockers exist;
- hard preview gates such as missing Hermes image and deterministic fallback remain blocked.

## Verification

- Python 3.14 production backend image
- targeted regression suite: 7 passed
- changed production code Ruff: passed
- test file Ruff excluding pre-existing `DTZ001`: passed
- `git diff --check`: passed
- prior CI critical application smoke on the same logical patch: passed

Base: `a96b6abcd038907e2481274ea1116e61d20dc1d8`
Head: `c8923f75af244c11cb5215b956d903a62d202d2d`

Broader permanent retirement of the legacy YFC news acquisition/draft-generation path remains tracked separately in Issue #224.