### PR TITLE
[Task 230] Hermes news Telegram proxy delivery

### DIFF
--- a/backend/fitminiapp_api/api/v1/bot.py
+++ b/backend/fitminiapp_api/api/v1/bot.py
@@ -70,6 +70,7 @@ from fitminiapp_api.services.telegram_auth import (
     get_or_insert_telegram_user,
     normalize_telegram_username,
 )
+from fitminiapp_api.services.telegram_transport import telegram_transport_options
 from fitminiapp_api.services.weekly_digest import (
     DigestIssueView,
     approve_digest_issue,
@@ -553,7 +554,7 @@ async def manage_published_news_from_bot(
 ) -> BotNewsRevisionActionResponse:
     _check_bot_token(x_bot_token)
     _check_support_admin(payload.admin_telegram_user_id)
-    async with httpx.AsyncClient(timeout=15) as client:
+    async with httpx.AsyncClient(timeout=15, **telegram_transport_options()) as client:
         with get_session_context() as db:
             result = await manage_published_post(
                 db,

--- a/backend/fitminiapp_api/services/news_worker.py
+++ b/backend/fitminiapp_api/services/news_worker.py
@@ -43,6 +43,10 @@ from fitminiapp_api.services.news_review_schedule import (
     NewsReviewSlot,
 )
 from fitminiapp_api.services.notifications import safe_delivery_error
+from fitminiapp_api.services.telegram_transport import (
+    TelegramPublicationError,
+    telegram_transport_options,
+)
 
 logger = logging.getLogger(__name__)
 MAX_GENERATIONS_PER_CYCLE = 10
@@ -416,8 +420,6 @@ async def publish_due_snapshots(
     send_publication: Callable[..., Awaitable[PublicationResult]],
     send_message: Callable[..., Awaitable[int | None]],
 ) -> int:
-    from fitminiapp_api.services.worker import TelegramPublicationError
-
     with get_session_context() as db:
         snapshot_ids = claim_due_publications(db)
     published = 0
@@ -541,7 +543,11 @@ async def run_news_pipeline_once(
         quarantine_non_hermes_news_work(db)
 
     timeout = httpx.Timeout(settings.news_source_timeout_seconds)
-    async with httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client:
+    async with httpx.AsyncClient(
+        timeout=timeout,
+        follow_redirects=False,
+        **telegram_transport_options(),
+    ) as client:
         published = (
             await publish_due_snapshots(client, send_publication, send_message)
             if publication_ready

--- a/backend/fitminiapp_api/services/notifications.py
+++ b/backend/fitminiapp_api/services/notifications.py
@@ -35,6 +35,7 @@ from fitminiapp_api.models.user import (
     User,
     UserProfile,
 )
+from fitminiapp_api.services.telegram_transport import TelegramPublicationError
 
 MAX_DELIVERY_ATTEMPTS = 5
 PROCESSING_TIMEOUT = timedelta(minutes=5)
@@ -293,6 +294,8 @@ def utcnow() -> datetime:
 def safe_delivery_error(error: Exception) -> str:
     """Return a bounded diagnostic code without serializing request URLs or secrets."""
     if isinstance(error, NotificationDeliveryError):
+        return error.code
+    if isinstance(error, TelegramPublicationError):
         return error.code
     if isinstance(error, httpx.HTTPStatusError):
         return f"http_status:{error.response.status_code}"

--- a/backend/fitminiapp_api/services/telegram_transport.py
+++ b/backend/fitminiapp_api/services/telegram_transport.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from fitminiapp_api.core.config import settings
+
+
+class TelegramPublicationError(RuntimeError):
+    def __init__(
+        self,
+        code: str,
+        *,
+        retry_after: timedelta | None = None,
+        terminal: bool = False,
+        uncertain: bool = False,
+    ) -> None:
+        super().__init__(code)
+        self.code = code
+        self.retry_after = retry_after
+        self.terminal = terminal
+        self.uncertain = uncertain
+
+
+def telegram_transport_options() -> dict[str, object]:
+    """Return the explicit Bot API route without inheriting ambient proxy settings."""
+
+    options: dict[str, object] = {"trust_env": False}
+    if settings.telegram_bot_proxy_url:
+        options["proxy"] = settings.telegram_bot_proxy_url
+    return options

--- a/backend/fitminiapp_api/services/worker.py
+++ b/backend/fitminiapp_api/services/worker.py
@@ -55,6 +55,10 @@ from fitminiapp_api.services.notifications import (
 )
 from fitminiapp_api.services.program_imports import expire_program_imports
 from fitminiapp_api.services.reminder_templates import sync_contextual_reminders
+from fitminiapp_api.services.telegram_transport import (
+    TelegramPublicationError,
+    telegram_transport_options,
+)
 from fitminiapp_api.services.web_push import send_web_push
 from fitminiapp_api.services.weekly_digest import (
     claim_due_digest_deliveries,
@@ -75,22 +79,6 @@ WORKER_HEARTBEAT_PATH = Path("/tmp/fitminiapp-worker-heartbeat")
 class TelegramPublicationResult:
     message_id: int
     message_date: datetime
-
-
-class TelegramPublicationError(RuntimeError):
-    def __init__(
-        self,
-        code: str,
-        *,
-        retry_after: timedelta | None = None,
-        terminal: bool = False,
-        uncertain: bool = False,
-    ) -> None:
-        super().__init__(code)
-        self.code = code
-        self.retry_after = retry_after
-        self.terminal = terminal
-        self.uncertain = uncertain
 
 
 class TelegramRateLimiter:
@@ -168,15 +156,6 @@ def _telegram_delivery_error(response: httpx.Response) -> NotificationDeliveryEr
             terminal_status="failed",
         )
     return NotificationDeliveryError(f"telegram_http_status:{error_code}")
-
-
-def telegram_transport_options() -> dict[str, object]:
-    """Return an explicit Bot API route without inheriting ambient proxy settings."""
-
-    options: dict[str, object] = {"trust_env": False}
-    if settings.bot_api_proxy_url:
-        options["proxy"] = settings.bot_api_proxy_url
-    return options
 
 
 def _log_delivery_failure(
@@ -296,7 +275,7 @@ async def run_weekly_digest_once() -> None:
 
     semaphore = asyncio.Semaphore(settings.weekly_digest_delivery_concurrency)
     rate_limiter = TelegramRateLimiter(TELEGRAM_DELIVERY_RATE_PER_SECOND)
-    async with httpx.AsyncClient(timeout=20) as client:
+    async with httpx.AsyncClient(timeout=20, **telegram_transport_options()) as client:
 
         async def deliver(delivery_id: int) -> tuple[int, Exception | None, int | None]:
             try:
@@ -896,7 +875,10 @@ async def main() -> None:
     logger.info("worker_started")
     heartbeat_task = asyncio.create_task(refresh_worker_heartbeat(stop_requested))
     try:
-        async with httpx.AsyncClient(timeout=15) as preflight_client:
+        async with httpx.AsyncClient(
+            timeout=15,
+            **telegram_transport_options(),
+        ) as preflight_client:
             news_publication_ready = await check_news_channel_rights(preflight_client)
         await run_until_stopped(
             stop_requested,

--- a/backend/tests/test_news_publishing.py
+++ b/backend/tests/test_news_publishing.py
@@ -25,7 +25,7 @@ from fitminiapp_api.models.news import (
     NewsReviewDelivery,
     NewsSource,
 )
-from fitminiapp_api.services import news_images, news_publication
+from fitminiapp_api.services import news_images, news_publication, news_worker
 from fitminiapp_api.services.news_content import (
     EditorialContent,
     parse_editorial_content,
@@ -1255,7 +1255,7 @@ def test_private_preview_matches_exact_artifact_and_retry_does_not_duplicate_it(
             }
         )
         if len(control_calls) == 1:
-            raise RuntimeError("simulated control-card failure")
+            raise TelegramPublicationError("telegram_network_error")
         return 202
 
     stats = NewsCycleStats()
@@ -1276,6 +1276,7 @@ def test_private_preview_matches_exact_artifact_and_retry_does_not_duplicate_it(
         delivery = db.query(NewsReviewDelivery).one()
         assert delivery.status == "queued"
         assert delivery.telegram_message_id == 101
+        assert delivery.last_error_code == "telegram_network_error"
         delivery.next_attempt_at = utcnow() - timedelta(seconds=1)
 
     assert asyncio.run(deliver()) == 1
@@ -1304,6 +1305,58 @@ def test_private_preview_matches_exact_artifact_and_retry_does_not_duplicate_it(
         assert event.details["artifact_hash"] == expected_hash
         assert event.details["preview_message_id"] == 101
         assert event.details["control_message_id"] == 202
+
+
+@pytest.mark.parametrize(
+    ("proxy_url", "expected_proxy"),
+    [
+        ("socks5://bot-proxy.test:1081", "socks5://bot-proxy.test:1081"),
+        ("", None),
+    ],
+)
+def test_news_pipeline_uses_explicit_telegram_transport(
+    monkeypatch,
+    proxy_url: str,
+    expected_proxy: str | None,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class RecordingAsyncClient:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        async def __aenter__(self) -> RecordingAsyncClient:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+    async def no_images(_client: httpx.AsyncClient) -> int:
+        return 0
+
+    monkeypatch.setattr(settings, "telegram_bot_proxy_url", proxy_url)
+    monkeypatch.setattr(news_worker.httpx, "AsyncClient", RecordingAsyncClient)
+    monkeypatch.setattr(news_worker, "prune_news_editorial", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(news_worker, "quarantine_non_hermes_news_work", lambda *_args: None)
+    monkeypatch.setattr(news_worker, "generate_pending_images", no_images)
+    monkeypatch.setattr(news_worker, "enqueue_review_deliveries", lambda *_args: 0)
+
+    async def unused_sender(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("sender should not run in transport construction test")
+
+    asyncio.run(
+        run_news_pipeline_once(
+            send_message=unused_sender,
+            send_preview=unused_sender,
+            send_publication=unused_sender,
+            publication_ready=False,
+            review_delivery_due=False,
+        )
+    )
+
+    assert captured["trust_env"] is False
+    assert captured["follow_redirects"] is False
+    assert captured.get("proxy") == expected_proxy
 
 
 def test_scheduled_review_delivery_sends_at_most_five_distinct_drafts(monkeypatch) -> None:

--- a/backend/tests/test_worker_delivery.py
+++ b/backend/tests/test_worker_delivery.py
@@ -26,6 +26,7 @@ from fitminiapp_api.services.notifications import (
     safe_delivery_error,
 )
 from fitminiapp_api.services.worker import (
+    TelegramPublicationError,
     TelegramRateLimiter,
     _log_delivery_failure,
     send_telegram_message,
@@ -316,6 +317,7 @@ def test_worker_rate_limits_send_starts_after_waiting_for_delivery_slot(monkeypa
             NotificationDeliveryError("telegram_chat_unavailable", terminal_status="cancelled"),
             "telegram_chat_unavailable",
         ),
+        (TelegramPublicationError("telegram_network_error"), "telegram_network_error"),
         (RuntimeError("secret unexpected details"), "unexpected:RuntimeError"),
     ],
 )


### PR DESCRIPTION
## Summary
- Route the Hermes/news pipeline Bot API client through the shared explicit Telegram transport.
- Preserve `trust_env=False` and configured `TELEGRAM_BOT_PROXY_URL` while avoiding ambient proxies.
- Preserve `TelegramPublicationError.code` in safe delivery diagnostics and news review retries.

## Verification
- Targeted worker/news: 65 passed.
- Relevant backend split profile: 311 passed, 2 skipped; the two initial Windows `WinError 10055` cases passed in isolated rerun.
- Ruff, format, pre-commit and mypy backend package: passed.
- `py_compile`: passed.

Production environment contract: unchanged; no env change required.