### PR TITLE
[Controller] Add owner-safe superseded lease closeout

### DIFF
--- a/codex-backlog/GLOBAL_RULES.md
+++ b/codex-backlog/GLOBAL_RULES.md
@@ -122,7 +122,8 @@ gate, evidence и точки остановки в task-файле.
   canonical controller worktree запрещена.
 - Controller-only governance fixes, которые не являются product task, проходят отдельный
   controller PR: branch `codex/controller-<lowercase-kebab-slug>`, title и commit messages с
-  префиксом `[Controller]`, exact required checks и тот же protected-master merge provenance.
+  префиксом `[Controller]`, только allowlisted governance-файлы, exact required checks и тот же
+  protected-master merge provenance.
 - Внутри текущей task после terminal success автоматически выполняются self-review, применимую QA,
   commit, PR в `master`, CI и normal release шаги, если task явно не объявляет checkpoint или
   blocker. Следующая product task автоматически не запускается.

--- a/codex-backlog/GLOBAL_RULES.md
+++ b/codex-backlog/GLOBAL_RULES.md
@@ -120,6 +120,9 @@ gate, evidence и точки остановки в task-файле.
 - `master` является единственной защищённой release-веткой. Task branch/worktree создаются от
   чистого, проверенного exact `origin/master` SHA; feature implementation непосредственно в
   canonical controller worktree запрещена.
+- Controller-only governance fixes, которые не являются product task, проходят отдельный
+  controller PR: branch `codex/controller-<lowercase-kebab-slug>`, title и commit messages с
+  префиксом `[Controller]`, exact required checks и тот же protected-master merge provenance.
 - Внутри текущей task после terminal success автоматически выполняются self-review, применимую QA,
   commit, PR в `master`, CI и normal release шаги, если task явно не объявляет checkpoint или
   blocker. Следующая product task автоматически не запускается.

--- a/codex-backlog/GLOBAL_RULES.md
+++ b/codex-backlog/GLOBAL_RULES.md
@@ -113,7 +113,10 @@ gate, evidence и точки остановки в task-файле.
   `starting/implementation/review/qa`; после durable readiness task lease сохраняется, но
   implementation exclusion освобождается. Обычная task без `concurrency` metadata считается
   `independent-write`; `exclusive-write` используется только для действительно global или
-  coordination-sensitive изменений. Delivery lane хранится отдельным минимальным mutex/queue.
+  coordination-sensitive изменений. Owner-authorized `supersede` является отдельным non-release
+  terminal переходом: он сохраняет clean branch/worktree lease как audit/recovery anchor, снимает
+  implementation exclusion, не получает delivery ownership и не считается `production-success`.
+  Delivery lane хранится отдельным минимальным mutex/queue.
 - `master` является единственной защищённой release-веткой. Task branch/worktree создаются от
   чистого, проверенного exact `origin/master` SHA; feature implementation непосредственно в
   canonical controller worktree запрещена.

--- a/codex-backlog/TASK_EXECUTION_LIFECYCLE.md
+++ b/codex-backlog/TASK_EXECUTION_LIFECYCLE.md
@@ -52,6 +52,11 @@ Lifecycle разделён на две coordination boundary:
   `implementation`, legacy `review` rework или `qa`; queued, delivery, CI и production states этот exclusion
   не удерживают. Dirty, interrupted, corrupt, missing, duplicate, recovery и ambiguous state
   остаются fail-closed.
+- Owner-authorized `supersede` — отдельный non-release terminal переход для task, которую владелец
+  заменил другой канонической task. Он проверяет clean, однозначные branch/worktree и сохраняет
+  lease и Git anchor для audit/recovery, но снимает implementation exclusion и не получает delivery
+  ownership. `superseded` не является `production-success`; такой task нельзя закрывать через
+  `finish` или выпускать в production.
 - `delivery lane`: один минимальный shared owner/queue в Git common directory. Только её owner
   может выполнить `refresh/rebase` относительно latest `origin/master`, current-base/provenance
   check, PR/CI, merge, production deploy, smoke и terminal closeout. Owner сохраняется до завершения

--- a/codex-backlog/TASK_EXECUTION_LIFECYCLE.md
+++ b/codex-backlog/TASK_EXECUTION_LIFECYCLE.md
@@ -55,8 +55,9 @@ Lifecycle разделён на две coordination boundary:
 - Owner-authorized `supersede` — отдельный non-release terminal переход для task, которую владелец
   заменил другой канонической task. Он проверяет clean, однозначные branch/worktree и сохраняет
   lease и Git anchor для audit/recovery, но снимает implementation exclusion и не получает delivery
-  ownership. `superseded` не является `production-success`; такой task нельзя закрывать через
-  `finish` или выпускать в production.
+  ownership. Перед переходом controller проверяет отсутствие открытого PR этой task; archived
+  `superseded` task не считается выполненной dependency. `superseded` не является
+  `production-success`; такой task нельзя закрывать через `finish` или выпускать в production.
 - `delivery lane`: один минимальный shared owner/queue в Git common directory. Только её owner
   может выполнить `refresh/rebase` относительно latest `origin/master`, current-base/provenance
   check, PR/CI, merge, production deploy, smoke и terminal closeout. Owner сохраняется до завершения

--- a/scripts/archive_backlog_task.py
+++ b/scripts/archive_backlog_task.py
@@ -1,4 +1,4 @@
-"""Archive a completed backlog task and keep backlog manifests synchronized."""
+"""Archive a completed or owner-superseded backlog task and sync manifests."""
 
 from __future__ import annotations
 
@@ -231,7 +231,7 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    archive = subparsers.add_parser("archive", help="archive one completed task")
+    archive = subparsers.add_parser("archive", help="archive one completed or superseded task")
     archive.add_argument("--backlog", required=True, type=Path)
     archive.add_argument("--task", required=True)
 

--- a/scripts/task_session.py
+++ b/scripts/task_session.py
@@ -41,6 +41,16 @@ TASK_BRANCH_RE = re.compile(
 CONTROLLER_BRANCH_RE = re.compile(r"^codex/controller-[a-z0-9]+(?:-[a-z0-9]+)*$")
 TASK_COMMIT_RE = re.compile(rf"\[Task (?P<task_id>{TASK_ID_PATTERN})\]", re.IGNORECASE)
 CONTROLLER_COMMIT_RE = re.compile(r"^\[Controller\]\s+\S")
+CONTROLLER_ALLOWED_PATHS = frozenset(
+    {
+        "codex-backlog/GLOBAL_RULES.md",
+        "codex-backlog/TASK_EXECUTION_LIFECYCLE.md",
+        "scripts/archive_backlog_task.py",
+        "scripts/task_session.py",
+        "tests/test_archive_backlog_task.py",
+        "tests/test_task_session.py",
+    }
+)
 TASK_DEPENDENCY_RE = re.compile(r"(?im)^Depends-on:\s*(?P<value>.+)$")
 TASK_FILE_RE = re.compile(rf"^(?P<task_id>{TASK_ID_PATTERN})-(?P<slug>.+)\.md$", re.IGNORECASE)
 TASK_STATE_VERSION = 2
@@ -1281,6 +1291,21 @@ def validate_controller_pull_request(
     return branch
 
 
+def validate_controller_pull_request_files(
+    files: Sequence[Mapping[str, Any]], *, expected_count: int | None = None
+) -> None:
+    """Keep controller-only provenance from becoming a product-code bypass."""
+
+    validate_task_pull_request_files(files, expected_count=expected_count)
+    changed = {str(item.get("filename", "")).replace("\\", "/") for item in files}
+    disallowed = sorted(changed - CONTROLLER_ALLOWED_PATHS)
+    if disallowed:
+        raise TaskSessionError(
+            "Controller PR contains paths outside the governance allowlist: "
+            + ", ".join(disallowed)
+        )
+
+
 def validate_task_pull_request_files(
     files: Sequence[Mapping[str, Any]], *, expected_count: int | None = None
 ) -> None:
@@ -1375,7 +1400,7 @@ def validate_pr_event(
             expected_base_sha=event_base_sha,
             require_checks=False,
         )
-        validate_task_pull_request_files(
+        validate_controller_pull_request_files(
             files, expected_count=int(pull_request.get("changed_files", len(files)))
         )
         return {
@@ -2238,7 +2263,14 @@ class TaskController:
                 for path in root.glob("*.md"):
                     match = TASK_FILE_RE.fullmatch(path.name)
                     if match:
-                        result.add(match.group("task_id").upper())
+                        task_id = match.group("task_id").upper()
+                        lease = self.store.read_json(self.store.task_lease_path(task_id))
+                        if (
+                            isinstance(lease, dict)
+                            and self._lease_state(lease) in SUPERSEDED_LEASE_STATES
+                        ):
+                            continue
+                        result.add(task_id)
         return result
 
     @staticmethod
@@ -3795,12 +3827,40 @@ class TaskController:
                 )
             return worktree, head
 
+        def verified_open_pr_numbers(branch: object) -> list[str]:
+            if not isinstance(branch, str) or not branch:
+                raise TaskSessionError(
+                    f"Task {expected} supersede lease has no valid branch anchor"
+                )
+            try:
+                open_prs = self._github().open_pull_requests()
+            except (TaskSessionError, OSError) as error:
+                raise TaskSessionError(
+                    f"Task {expected} supersede requires a verified open-PR inventory"
+                ) from error
+            matching: list[str] = []
+            for pull_request in open_prs:
+                if not isinstance(pull_request, Mapping):
+                    raise TaskSessionError("GitHub returned an invalid open-PR inventory")
+                head = pull_request.get("head", {})
+                if not isinstance(head, Mapping):
+                    raise TaskSessionError("GitHub returned an open PR without a valid head")
+                if head.get("ref") == branch:
+                    matching.append(str(pull_request.get("number", "<unknown>")))
+            return matching
+
         delivery = self.store.delivery_state()
         owner = delivery.get("owner")
         owner_id = str(owner.get("task_id", "")).upper() if isinstance(owner, dict) else ""
         if owner_id == expected:
             raise TaskSessionError(
                 f"Task {expected} cannot be superseded while owning the delivery lane"
+            )
+        matching_pr_numbers = verified_open_pr_numbers(lease.get("branch"))
+        if matching_pr_numbers:
+            raise TaskSessionError(
+                f"Task {expected} supersede refuses open task PR(s): "
+                + ", ".join(sorted(matching_pr_numbers))
             )
         verify_anchor(lease)
 
@@ -3838,6 +3898,12 @@ class TaskController:
                     f"Task {expected} cannot be superseded from {current.get('lifecycle_state')}"
                 )
             verify_anchor(current)
+            matching_pr_numbers = verified_open_pr_numbers(current.get("branch"))
+            if matching_pr_numbers:
+                raise TaskSessionError(
+                    f"Task {expected} supersede refuses open task PR(s): "
+                    + ", ".join(sorted(matching_pr_numbers))
+                )
             self._validated_lease_concurrency_class(current)
             previous_state = current_state
             now = utc_now()

--- a/scripts/task_session.py
+++ b/scripts/task_session.py
@@ -68,20 +68,23 @@ REVIEW_BLOCKING_MARKER_RE = re.compile(
 
 # A task lease, an implementation exclusion, and delivery ownership are separate controller
 # concerns.  Only an exclusive-write lease in an implementation state owns the implementation
-# exclusion.  A ready, waiting, delivery, or production-success lease remains a task session but
-# does not hold that exclusion; delivery ownership is serialized independently below.
+# exclusion.  A ready, waiting, delivery, production-success, or superseded lease does not hold
+# that exclusion; delivery ownership is serialized independently below. A superseded lease is a
+# non-release terminal record whose clean Git anchor is retained for audit/recovery.
 IMPLEMENTATION_STATES = frozenset({"starting", "implementation", "review", "qa"})
 READY_STATES = frozenset({"ready-for-delivery", "ready-for-pr"})
 WAITING_STATES = frozenset({"waiting-for-delivery"})
 DELIVERY_STATES = frozenset({"delivering", "delivery-refreshing", "delivery-gate"})
 TERMINAL_LEASE_STATES = frozenset({"production-success"})
+SUPERSEDED_LEASE_STATES = frozenset({"superseded"})
+CLOSED_LEASE_STATES = TERMINAL_LEASE_STATES | SUPERSEDED_LEASE_STATES
 RECOVERY_STATES = frozenset({"recovery-required", "start-failed-recovery-required"})
 KNOWN_LEASE_STATES = (
     IMPLEMENTATION_STATES
     | READY_STATES
     | WAITING_STATES
     | DELIVERY_STATES
-    | TERMINAL_LEASE_STATES
+    | CLOSED_LEASE_STATES
     | RECOVERY_STATES
 )
 DELIVERY_OWNER_STATES = DELIVERY_STATES | TERMINAL_LEASE_STATES
@@ -1597,6 +1600,8 @@ class TaskController:
                     f"Task {raw_task_id} lease worktree branch does not match {branch}",
                 )
             state = self._lease_state(lease)
+            if state in SUPERSEDED_LEASE_STATES:
+                continue
             if state in RECOVERY_STATES:
                 return ("BLOCKED", f"Task {raw_task_id} requires controller recovery")
             if state in DELIVERY_STATES:
@@ -2152,7 +2157,7 @@ class TaskController:
 
     @classmethod
     def _is_active_write_lease(cls, lease: Mapping[str, Any]) -> bool:
-        return lease.get("mode") == "write" and cls._lease_state(lease) not in TERMINAL_LEASE_STATES
+        return lease.get("mode") == "write" and cls._lease_state(lease) not in CLOSED_LEASE_STATES
 
     @classmethod
     def _validated_lease_concurrency_class(cls, lease: Mapping[str, Any]) -> str:
@@ -2189,7 +2194,9 @@ class TaskController:
     def _lease_ownership_snapshot(
         cls, lease: Mapping[str, Any], *, delivery_owner_id: str
     ) -> dict[str, bool]:
-        task_session_active = lease.get("mode") == "write"
+        task_session_active = lease.get("mode") == "write" and (
+            cls._lease_state(lease) not in SUPERSEDED_LEASE_STATES
+        )
         try:
             implementation_exclusion_active = cls._lease_holds_implementation_exclusion(lease)
         except TaskSessionError:
@@ -2518,7 +2525,12 @@ class TaskController:
             except TaskSessionError as error:
                 delivery_blockers.append(f"GitHub state unavailable: {error}")
                 active_runs = open_task_prs = rulesets = "unavailable"
-        active_task_ids = {item.get("task_id") for item in leases if item.get("mode") == "write"}
+        active_task_ids = {
+            item.get("task_id")
+            for item in leases
+            if item.get("mode") == "write"
+            and self._lease_state(item) not in SUPERSEDED_LEASE_STATES
+        }
         if any(item.get("mode") in {"integration", "release"} for item in leases):
             recovery_findings.append(
                 "obsolete integration/release lease requires explicit recovery"
@@ -2816,7 +2828,7 @@ class TaskController:
                 raise TaskSessionError(f"No active queue lease exists for Task {expected}")
             if lease.get("queue_mode") is not True:
                 raise TaskSessionError(f"Task {expected} is not running in continuous queue mode")
-            if self._lease_state(lease) in TERMINAL_LEASE_STATES:
+            if self._lease_state(lease) in CLOSED_LEASE_STATES:
                 raise TaskSessionError(f"Task {expected} is already terminal")
             raw_budget = lease.get("queue_budget")
             if not isinstance(raw_budget, dict):
@@ -3612,6 +3624,168 @@ class TaskController:
             StateStore.replace_json(self.store.delivery_path, current_delivery)
         return current
 
+    def supersede(self, task_id: str, *, reason: str, owner_authorize: bool) -> dict[str, Any]:
+        """Close a task as superseded while retaining its clean Git anchor."""
+
+        expected = normalize_task_id(task_id)
+        if not owner_authorize:
+            raise TaskSessionError("supersede requires explicit owner authorization")
+        normalized_reason = reason.strip()
+        if not normalized_reason or len(normalized_reason) > 4096:
+            raise TaskSessionError("supersede reason must be a bounded non-empty string")
+
+        lease_path = self.store.task_lease_path(expected)
+        lease = self.store.read_json(lease_path)
+        if not isinstance(lease, dict):
+            raise TaskSessionError(f"Task {expected} has no active lease")
+
+        initial_state = self._lease_state(lease)
+        if initial_state in TERMINAL_LEASE_STATES:
+            raise TaskSessionError(
+                f"Task {expected} cannot be superseded from terminal state {initial_state}"
+            )
+        if initial_state not in (
+            IMPLEMENTATION_STATES
+            | READY_STATES
+            | WAITING_STATES
+            | RECOVERY_STATES
+            | SUPERSEDED_LEASE_STATES
+        ):
+            raise TaskSessionError(
+                f"Task {expected} cannot be superseded from {lease.get('lifecycle_state')}"
+            )
+
+        def verify_anchor(current: Mapping[str, Any]) -> tuple[Path, str]:
+            if current.get("mode") != "write":
+                raise TaskSessionError(f"Task {expected} supersede lease is not writable")
+            if str(current.get("task_id", "")).upper() != expected:
+                raise TaskSessionError(f"Task {expected} supersede lease has mismatched task ID")
+            branch = current.get("branch")
+            worktree_value = current.get("worktree")
+            if not isinstance(branch, str) or not isinstance(worktree_value, str):
+                raise TaskSessionError(
+                    f"Task {expected} supersede lease has no valid branch/worktree anchor"
+                )
+            if task_id_from_branch(branch) != expected:
+                raise TaskSessionError(f"Task {expected} supersede lease has an invalid branch")
+            worktree = Path(worktree_value).resolve()
+            matches = [
+                item
+                for item in self.repository.worktrees()
+                if str(item.path.resolve()).casefold() == str(worktree).casefold()
+                or item.branch == branch
+            ]
+            if len(matches) != 1 or matches[0].branch != branch:
+                raise TaskSessionError(
+                    f"Task {expected} supersede requires exactly one matching branch/worktree"
+                )
+            branch_refs = [
+                line.removeprefix("refs/heads/")
+                for line in self.repository.git(
+                    "for-each-ref", "--format=%(refname)", f"refs/heads/{branch}"
+                ).splitlines()
+                if line
+            ]
+            if branch_refs != [branch]:
+                raise TaskSessionError(
+                    f"Task {expected} supersede requires exactly one local task branch"
+                )
+            if self.repository.status(worktree):
+                raise TaskSessionError(f"Task {expected} supersede refuses a dirty worktree")
+            operations = self.repository.operation_issues(worktree)
+            if operations:
+                raise TaskSessionError(
+                    f"Task {expected} supersede refuses interrupted Git operation: {operations}"
+                )
+            head = self.repository.head(cwd=worktree)
+            base_sha = str(current.get("base_origin_master_sha", ""))
+            if not base_sha or not self.repository.is_ancestor(base_sha, head):
+                raise TaskSessionError(
+                    f"Task {expected} supersede worktree does not descend from its leased base"
+                )
+            return worktree, head
+
+        delivery = self.store.delivery_state()
+        owner = delivery.get("owner")
+        owner_id = str(owner.get("task_id", "")).upper() if isinstance(owner, dict) else ""
+        if owner_id == expected:
+            raise TaskSessionError(
+                f"Task {expected} cannot be superseded while owning the delivery lane"
+            )
+        verify_anchor(lease)
+
+        with self.store.lock():
+            current = self.store.read_json(lease_path)
+            current_delivery = self.store.delivery_state()
+            if not isinstance(current, dict):
+                raise TaskSessionError(f"Task {expected} lease disappeared during supersede")
+            if current.get("updated_at") != lease.get("updated_at"):
+                raise TaskSessionError("Task supersede lease changed during transition")
+            if current_delivery.get("owner") != delivery.get("owner"):
+                raise TaskSessionError("Delivery ownership changed during task supersede")
+            current_owner = current_delivery.get("owner")
+            current_owner_id = (
+                str(current_owner.get("task_id", "")).upper()
+                if isinstance(current_owner, dict)
+                else ""
+            )
+            if current_owner_id == expected:
+                raise TaskSessionError(
+                    f"Task {expected} cannot be superseded while owning the delivery lane"
+                )
+            current_state = self._lease_state(current)
+            if current_state in TERMINAL_LEASE_STATES:
+                raise TaskSessionError(
+                    f"Task {expected} cannot be superseded from terminal state {current_state}"
+                )
+            if current_state in SUPERSEDED_LEASE_STATES:
+                verify_anchor(current)
+                return current
+            if current_state not in (
+                IMPLEMENTATION_STATES | READY_STATES | WAITING_STATES | RECOVERY_STATES
+            ):
+                raise TaskSessionError(
+                    f"Task {expected} cannot be superseded from {current.get('lifecycle_state')}"
+                )
+            verify_anchor(current)
+            self._validated_lease_concurrency_class(current)
+            previous_state = current_state
+            now = utc_now()
+            for key in (
+                "delivery_owner",
+                "delivery_acquired_at",
+                "delivery_base_origin_master_sha",
+                "delivery_head_sha",
+                "delivery_anchor",
+                "delivery_released_at",
+                "delivery_failed_at",
+                "delivery_handoff_blocker",
+                "delivery_next_owner",
+                "delivery_waiting_since",
+                "ready_head_sha",
+                "ready_base_origin_master_sha",
+                "ready_for_delivery_at",
+                "ready_sequence",
+                "quality_verdict",
+                "qa_verdict",
+                "task_provenance",
+                "canonical_master_refresh",
+                "delivery_priority_override",
+            ):
+                current.pop(key, None)
+            current.update(
+                {
+                    "lifecycle_state": "superseded",
+                    "superseded_from_state": previous_state,
+                    "superseded_at": now,
+                    "superseded_reason": normalized_reason,
+                    "owner_authorized": True,
+                    "updated_at": now,
+                }
+            )
+            StateStore.replace_json(lease_path, current)
+        return current
+
     def record_production_success(
         self,
         task_id: str,
@@ -3790,6 +3964,8 @@ class TaskController:
             classification = "READY_FOR_DELIVERY"
         elif state in WAITING_STATES:
             classification = "WAITING_FOR_DELIVERY"
+        elif state in SUPERSEDED_LEASE_STATES:
+            classification = "SUPERSEDED"
         elif state in TERMINAL_LEASE_STATES:
             classification = "TERMINAL_SUCCESS"
         elif state in DELIVERY_STATES:
@@ -3967,11 +4143,26 @@ def archive_guard(backlog_root: Path, task_id: str) -> None:
     store = StateStore(common_dir)
     if not (store.root / "contract.json").exists():
         return
-    history = store.read_json(store.history / f"task-{normalize_task_id(task_id)}.json")
-    if history is None or history.get("state") != "finished":
-        raise TaskSessionError(
-            f"Task {task_id} cannot be archived before controller finish and terminal production success"
-        )
+    expected = normalize_task_id(task_id)
+    history = store.read_json(store.history / f"task-{expected}.json")
+    if isinstance(history, dict) and history.get("state") == "finished":
+        return
+    lease = store.read_json(store.task_lease_path(expected))
+    if (
+        isinstance(lease, dict)
+        and lease.get("task_id") == expected
+        and lease.get("mode") == "write"
+        and lease.get("owner_authorized") is True
+        and lease.get("lifecycle_state") in SUPERSEDED_LEASE_STATES
+    ):
+        reason = lease.get("superseded_reason")
+        timestamp = lease.get("superseded_at")
+        if isinstance(reason, str) and reason.strip() and isinstance(timestamp, str) and timestamp:
+            return
+    raise TaskSessionError(
+        f"Task {task_id} cannot be archived before controller finish/terminal production success "
+        "or owner-authorized supersede"
+    )
 
 
 def _print(payload: Mapping[str, Any]) -> None:
@@ -4035,6 +4226,10 @@ def _parser() -> argparse.ArgumentParser:
     resolve_recovery.add_argument("task_id")
     resolve_recovery.add_argument("--reason", required=True)
     resolve_recovery.add_argument("--owner-authorize", action="store_true")
+    supersede = subparsers.add_parser("supersede")
+    supersede.add_argument("task_id")
+    supersede.add_argument("--reason", required=True)
+    supersede.add_argument("--owner-authorize", action="store_true")
     queue_cycle = subparsers.add_parser("record-queue-cycle")
     queue_cycle.add_argument("task_id")
     queue_cycle.add_argument("--kind", choices=("review", "ci"), required=True)
@@ -4140,6 +4335,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.command == "resolve-recovery":
             _print(
                 controller.resolve_recovery(
+                    args.task_id,
+                    reason=args.reason,
+                    owner_authorize=args.owner_authorize,
+                )
+            )
+            return 0
+        if args.command == "supersede":
+            _print(
+                controller.supersede(
                     args.task_id,
                     reason=args.reason,
                     owner_authorize=args.owner_authorize,

--- a/scripts/task_session.py
+++ b/scripts/task_session.py
@@ -38,7 +38,9 @@ TASK_BRANCH_RE = re.compile(
     rf"^task/(?P<task_id>{TASK_ID_PATTERN})-(?P<slug>[a-z0-9]+(?:-[a-z0-9]+)*)$",
     re.IGNORECASE,
 )
+CONTROLLER_BRANCH_RE = re.compile(r"^codex/controller-[a-z0-9]+(?:-[a-z0-9]+)*$")
 TASK_COMMIT_RE = re.compile(rf"\[Task (?P<task_id>{TASK_ID_PATTERN})\]", re.IGNORECASE)
+CONTROLLER_COMMIT_RE = re.compile(r"^\[Controller\]\s+\S")
 TASK_DEPENDENCY_RE = re.compile(r"(?im)^Depends-on:\s*(?P<value>.+)$")
 TASK_FILE_RE = re.compile(rf"^(?P<task_id>{TASK_ID_PATTERN})-(?P<slug>.+)\.md$", re.IGNORECASE)
 TASK_STATE_VERSION = 2
@@ -1214,6 +1216,71 @@ def validate_task_pull_request(
     return task_id
 
 
+def validate_controller_pull_request(
+    pull_request: Mapping[str, Any],
+    commits: Sequence[Mapping[str, Any]],
+    checks: Sequence[Mapping[str, Any]],
+    *,
+    expected_base_sha: str,
+    expected_base_branch: str = TARGET_BASE_BRANCH,
+    require_checks: bool = True,
+) -> str:
+    """Validate a controller-only maintenance PR without inventing a product task."""
+
+    base = pull_request.get("base", {})
+    head = pull_request.get("head", {})
+    if base.get("ref") != expected_base_branch:
+        raise TaskSessionError(
+            f"Controller pull request base must be {expected_base_branch}, found {base.get('ref')}"
+        )
+    branch = str(head.get("ref", ""))
+    if CONTROLLER_BRANCH_RE.fullmatch(branch) is None:
+        raise TaskSessionError(
+            f"Controller branch {branch!r} must match codex/controller-<lowercase-kebab-slug>"
+        )
+    if base.get("sha") != expected_base_sha:
+        raise TaskSessionError(
+            f"Controller PR is stale: base {base.get('sha')} != current {expected_base_sha}"
+        )
+    base_repo = base.get("repo", {})
+    head_repo = head.get("repo", {})
+    if (
+        not isinstance(base_repo, Mapping)
+        or not isinstance(head_repo, Mapping)
+        or not base_repo.get("full_name")
+        or head_repo.get("full_name") != base_repo.get("full_name")
+    ):
+        raise TaskSessionError("Controller PR must originate from the same repository")
+    title = str(pull_request.get("title", ""))
+    if not title.startswith("[Controller]"):
+        raise TaskSessionError("Controller PR title must start with [Controller]")
+    messages = [str(item.get("commit", {}).get("message", "")) for item in commits]
+    declared_commit_count = pull_request.get("commits")
+    if declared_commit_count is not None and int(declared_commit_count) != len(commits):
+        raise TaskSessionError(
+            "Controller PR commit inventory is incomplete; split/review the PR instead of truncating provenance"
+        )
+    if not messages:
+        raise TaskSessionError("Controller branch contains no controller commits")
+    invalid = [
+        message.splitlines()[0] if message else "<empty>"
+        for message in messages
+        if not CONTROLLER_COMMIT_RE.match(message)
+    ]
+    if invalid:
+        raise TaskSessionError(
+            "Controller commit messages must start with [Controller]: " + ", ".join(invalid)
+        )
+    head_sha = str(head.get("sha", ""))
+    if not head_sha:
+        raise TaskSessionError("Controller PR head SHA is missing")
+    if require_checks and not _successful_exact_check(checks, "checks", head_sha):
+        raise TaskSessionError(
+            f"Exact-head required check 'checks' is not successful for {head_sha}"
+        )
+    return branch
+
+
 def validate_task_pull_request_files(
     files: Sequence[Mapping[str, Any]], *, expected_count: int | None = None
 ) -> None:
@@ -1299,6 +1366,23 @@ def validate_pr_event(
     number = int(pull_request["number"])
     commits = github.pull_request_commits(number)
     files = github.pull_request_files(number)
+    branch = str(pull_request.get("head", {}).get("ref", ""))
+    if CONTROLLER_BRANCH_RE.fullmatch(branch):
+        validate_controller_pull_request(
+            pull_request,
+            commits,
+            [],
+            expected_base_sha=event_base_sha,
+            require_checks=False,
+        )
+        validate_task_pull_request_files(
+            files, expected_count=int(pull_request.get("changed_files", len(files)))
+        )
+        return {
+            "kind": "controller-pr",
+            "branch": branch,
+            "head_sha": pull_request["head"]["sha"],
+        }
     task_id = validate_task_pull_request(
         pull_request,
         commits,
@@ -1368,9 +1452,12 @@ def verify_master_merge(
             and base.get("ref") == TARGET_BASE_BRANCH
         ):
             continue
-        is_task_merge = TASK_BRANCH_RE.fullmatch(str(head.get("ref", ""))) and str(
-            pull_request.get("title", "")
-        ).startswith("[Task ")
+        branch = str(head.get("ref", ""))
+        title = str(pull_request.get("title", ""))
+        is_task_merge = TASK_BRANCH_RE.fullmatch(branch) and title.startswith("[Task ")
+        is_controller_merge = CONTROLLER_BRANCH_RE.fullmatch(
+            branch
+        ) is not None and title.startswith("[Controller]")
         base_repo = base.get("repo", {})
         head_repo = head.get("repo", {})
         is_same_repository = (
@@ -1382,6 +1469,8 @@ def verify_master_merge(
         is_dependabot_merge = is_dependabot_pull_request(pull_request) and is_same_repository
         if is_task_merge:
             merge_kind = "task-pr-merge"
+        elif is_controller_merge and is_same_repository:
+            merge_kind = "controller-pr-merge"
         elif is_dependabot_merge:
             merge_kind = "dependabot-pr-merge"
         else:
@@ -1395,7 +1484,8 @@ def verify_master_merge(
         )
     if len(matches) != 1:
         raise TaskSessionError(
-            f"Master revision {sha} is not exactly one merged task PR result: found {len(matches)}"
+            f"Master revision {sha} is not exactly one merged task or controller PR result: "
+            f"found {len(matches)}"
         )
     match = matches[0]
     return {

--- a/tests/test_archive_backlog_task.py
+++ b/tests/test_archive_backlog_task.py
@@ -101,3 +101,30 @@ def test_archive_task_requires_finished_controller_history_when_contract_is_acti
     destination = archive_backlog_task.archive_task(backlog, "03-notifications.md")
 
     assert destination.is_file()
+
+
+def test_archive_task_accepts_owner_authorized_superseded_lease(tmp_path: Path) -> None:
+    parent, backlog = _nested_backlog(tmp_path)
+    state_root = parent.parent / ".git" / "codex-task-sessions-v1"
+    leases = state_root / "leases"
+    leases.mkdir(parents=True)
+    (state_root / "contract.json").write_text('{"version": 2}\n', encoding="utf-8")
+    (leases / "task-03.json").write_text(
+        json.dumps(
+            {
+                "task_id": "03",
+                "mode": "write",
+                "lifecycle_state": "superseded",
+                "owner_authorized": True,
+                "superseded_at": "2026-09-10T10:00:00Z",
+                "superseded_reason": "owner selected a canonical replacement",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    destination = archive_backlog_task.archive_task(backlog, "03-notifications.md")
+
+    assert destination.is_file()
+    assert archive_backlog_task.validate_manifests(backlog) == []

--- a/tests/test_task_session.py
+++ b/tests/test_task_session.py
@@ -888,6 +888,7 @@ def test_ready_or_delivery_exclusive_lease_releases_implementation_exclusion(
         ("delivery-refreshing", "exclusive-write", "independent-write", False),
         ("delivery-gate", "exclusive-write", "exclusive-write", False),
         ("production-success", "exclusive-write", "independent-write", False),
+        ("superseded", "exclusive-write", "exclusive-write", False),
     ],
 )
 def test_implementation_exclusion_is_state_aware(
@@ -1258,6 +1259,57 @@ def test_resolve_recovery_refuses_dirty_anchor(repository: tuple[Path, Any]) -> 
 
     with pytest.raises(task_session.TaskSessionError, match="dirty worktree"):
         controller.resolve_recovery("234C", reason="inspect", owner_authorize=True)
+
+
+def test_supersede_releases_exclusion_and_preserves_clean_anchor(
+    repository: tuple[Path, Any],
+) -> None:
+    root, git_repository, controller, worktree, branch, sha_pair = _prepare_started(
+        repository, "234D", concurrency="exclusive-write"
+    )
+    _, head_sha = sha_pair.split(":")
+
+    with pytest.raises(task_session.TaskSessionError, match="owner authorization"):
+        controller.supersede("234D", reason="owner decision", owner_authorize=False)
+
+    superseded = controller.supersede("234D", reason="Task 229 is canonical", owner_authorize=True)
+
+    assert superseded["lifecycle_state"] == "superseded"
+    assert superseded["superseded_from_state"] == "implementation"
+    assert superseded["superseded_reason"] == "Task 229 is canonical"
+    assert worktree.exists()
+    assert not _git(worktree, "status", "--short")
+    assert git_repository.ref(branch) == head_sha
+    assert controller.store.delivery_state()["owner"] is None
+
+    snapshot = next(item for item in controller.status()["leases"] if item["task_id"] == "234D")
+    assert snapshot["ownership"] == {
+        "task_session_active": False,
+        "implementation_exclusion_active": False,
+        "delivery_critical_section_active": False,
+    }
+    recovered = controller.recover("234D")
+    assert recovered["classification"] == "SUPERSEDED"
+    assert recovered["issues"] == []
+    assert recovered["mutation_performed"] is False
+
+    _write_task(root, "234E", "after-supersede", concurrency="exclusive-write")
+    started = controller.start("234E", owner_launch=True, session_label="after", offline=True)
+    assert started["lease"]["lifecycle_state"] == "implementation"
+
+
+def test_supersede_refuses_dirty_anchor_without_mutation(repository: tuple[Path, Any]) -> None:
+    _, _, controller, worktree, _, _ = _prepare_started(
+        repository, "234F", concurrency="exclusive-write"
+    )
+    (worktree / "uncommitted.txt").write_text("preserve\n", encoding="utf-8")
+
+    with pytest.raises(task_session.TaskSessionError, match="dirty worktree"):
+        controller.supersede("234F", reason="owner decision", owner_authorize=True)
+
+    lease = controller.store.read_json(controller.store.task_lease_path("234F"))
+    assert isinstance(lease, dict)
+    assert lease["lifecycle_state"] == "implementation"
 
 
 def test_busy_delivery_lane_does_not_block_compatible_implementation(

--- a/tests/test_task_session.py
+++ b/tests/test_task_session.py
@@ -229,6 +229,34 @@ def _prepare_started(
     return root, git_repository, controller, worktree, branch, base_sha + ":" + head_sha
 
 
+def test_superseded_archived_task_is_not_a_completed_dependency(
+    repository: tuple[Path, Any],
+) -> None:
+    root, git_repository = repository
+    done = root / "codex-backlog" / "tasks" / "done"
+    done.mkdir(parents=True)
+    (done / "152-superseded.md").write_text("superseded\n", encoding="utf-8")
+    (done / "153-delivered.md").write_text("delivered\n", encoding="utf-8")
+    controller = task_session.TaskController(
+        git_repository,
+        github=FakeGitHub(git_repository.ref("origin/master")),
+    )
+    controller.store.initialize()
+    task_session.StateStore.replace_json(
+        controller.store.task_lease_path("152"),
+        {
+            "task_id": "152",
+            "mode": "write",
+            "lifecycle_state": "superseded",
+        },
+    )
+
+    completed = controller._completed_dependency_ids()
+
+    assert "152" not in completed
+    assert "153" in completed
+
+
 def test_record_queue_cycle_is_durable_and_bounded(repository: tuple[Path, Any]) -> None:
     _, _, controller, _, _, _ = _prepare_started(repository, "250", queue_mode=True)
 
@@ -424,6 +452,7 @@ def test_validate_pr_event_accepts_controller_maintenance_branch(
     event_path.write_text(json.dumps({"pull_request": pull_request}), encoding="utf-8")
     github = FakeGitHub(base_sha)
     github.commits[234] = [_controller_commit()]
+    github.files[234] = [{"filename": "scripts/task_session.py"}]
 
     result = task_session.validate_pr_event(
         object(),
@@ -436,6 +465,26 @@ def test_validate_pr_event_accepts_controller_maintenance_branch(
         "branch": "codex/controller-synthetic-maintenance",
         "head_sha": head_sha,
     }
+
+
+def test_controller_pr_rejects_product_paths(
+    tmp_path: Path,
+) -> None:
+    base_sha = "a" * 40
+    head_sha = "b" * 40
+    pull_request = _controller_pr(base_sha, head_sha)
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps({"pull_request": pull_request}), encoding="utf-8")
+    github = FakeGitHub(base_sha)
+    github.commits[234] = [_controller_commit()]
+    github.files[234] = [{"filename": "backend/app.py"}]
+
+    with pytest.raises(task_session.TaskSessionError, match="outside the governance allowlist"):
+        task_session.validate_pr_event(  # type: ignore[arg-type]
+            object(),
+            github,
+            event_path,
+        )
 
 
 def test_validate_pr_event_rejects_dependabot_branch_for_regular_user(
@@ -1343,6 +1392,21 @@ def test_supersede_refuses_dirty_anchor_without_mutation(repository: tuple[Path,
         controller.supersede("234F", reason="owner decision", owner_authorize=True)
 
     lease = controller.store.read_json(controller.store.task_lease_path("234F"))
+    assert isinstance(lease, dict)
+    assert lease["lifecycle_state"] == "implementation"
+
+
+def test_supersede_refuses_open_task_pr_without_mutation(
+    repository: tuple[Path, Any],
+) -> None:
+    _, _, controller, _, branch, _ = _prepare_started(repository, "234G")
+    assert isinstance(controller.github, FakeGitHub)
+    controller.github.open_prs = [{"number": 999, "head": {"ref": branch}}]
+
+    with pytest.raises(task_session.TaskSessionError, match="open task PR"):
+        controller.supersede("234G", reason="owner decision", owner_authorize=True)
+
+    lease = controller.store.read_json(controller.store.task_lease_path("234G"))
     assert isinstance(lease, dict)
     assert lease["lifecycle_state"] == "implementation"
 

--- a/tests/test_task_session.py
+++ b/tests/test_task_session.py
@@ -185,6 +185,17 @@ def _task_commit(task_id: str) -> dict[str, Any]:
     return {"commit": {"message": f"feat: [Task {task_id}] synthetic change"}}
 
 
+def _controller_pr(base_sha: str, head_sha: str) -> dict[str, Any]:
+    pull_request = _task_pr(234, "234", base_sha, head_sha)
+    pull_request["title"] = "[Controller] Synthetic maintenance"
+    pull_request["head"]["ref"] = "codex/controller-synthetic-maintenance"
+    return pull_request
+
+
+def _controller_commit() -> dict[str, Any]:
+    return {"commit": {"message": "[Controller] synthetic maintenance"}}
+
+
 def _success_check(sha: str) -> dict[str, Any]:
     return {"name": "checks", "head_sha": sha, "status": "completed", "conclusion": "SUCCESS"}
 
@@ -401,6 +412,30 @@ def test_validate_pr_event_accepts_trusted_dependabot_without_task_branch(
     )
 
     assert result == {"kind": "dependabot-pr", "head_sha": head_sha}
+
+
+def test_validate_pr_event_accepts_controller_maintenance_branch(
+    tmp_path: Path,
+) -> None:
+    base_sha = "a" * 40
+    head_sha = "b" * 40
+    pull_request = _controller_pr(base_sha, head_sha)
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps({"pull_request": pull_request}), encoding="utf-8")
+    github = FakeGitHub(base_sha)
+    github.commits[234] = [_controller_commit()]
+
+    result = task_session.validate_pr_event(
+        object(),
+        github,
+        event_path,  # type: ignore[arg-type]
+    )
+
+    assert result == {
+        "kind": "controller-pr",
+        "branch": "codex/controller-synthetic-maintenance",
+        "head_sha": head_sha,
+    }
 
 
 def test_validate_pr_event_rejects_dependabot_branch_for_regular_user(
@@ -2053,6 +2088,21 @@ def test_verify_master_merge_accepts_only_one_task_pr_for_current_master() -> No
     assert result["pull_request"]["number"] == 205
 
 
+def test_verify_master_merge_accepts_one_controller_maintenance_pr() -> None:
+    base_sha = "a" * 40
+    merge_sha = "c" * 40
+    controller_pr = _controller_pr(base_sha, "b" * 40)
+    controller_pr["merged_at"] = "2026-09-11T10:00:00Z"
+    controller_pr["merge_commit_sha"] = merge_sha
+    github = FakeGitHub(merge_sha)
+    github.associated_pulls = [controller_pr]
+
+    result = task_session.verify_master_merge(object(), github, sha=merge_sha)
+
+    assert result["kind"] == "controller-pr-merge"
+    assert result["pull_request"]["number"] == 234
+
+
 def test_verify_master_merge_accepts_trusted_dependabot_pr() -> None:
     base_sha = "a" * 40
     merge_sha = "c" * 40
@@ -2080,7 +2130,9 @@ def test_verify_master_merge_rejects_dependabot_fork_pr() -> None:
     github = FakeGitHub(merge_sha)
     github.associated_pulls = [dependabot_pr]
 
-    with pytest.raises(task_session.TaskSessionError, match="not exactly one merged task PR"):
+    with pytest.raises(
+        task_session.TaskSessionError, match="not exactly one merged task or controller PR"
+    ):
         task_session.verify_master_merge(object(), github, sha=merge_sha)
 
 


### PR DESCRIPTION
Adds the owner-authorized non-release superseded lease state and native supersede command. It validates a clean, uniquely anchored task worktree, releases implementation exclusion without delivery ownership, preserves the branch/worktree as an audit anchor, and lets the existing archive helper accept the owner-authorized superseded state. Also adds protected controller-only PR provenance so this maintenance change can enter the protected master lifecycle. Codex Code Review is not used; deterministic tests and static checks are the verification source.