### PR TITLE
[Task 151A] Remediate container SBOM scan expiry

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -2,7 +2,7 @@ vulnerabilities:
   - id: GHSA-6v7p-g79w-8964
     purls:
       - pkg:pypi/msgpack@1.1.2
-    expired_at: 2026-09-11
+    expired_at: 2026-10-11
     statement: >-
       python:3.14-slim embeds a third-party SBOM that still reports msgpack
       1.1.2. The final application image replaces it with msgpack 1.2.1,
@@ -10,7 +10,7 @@ vulnerabilities:
   - id: CVE-2025-47273
     purls:
       - pkg:pypi/setuptools@70.3.0
-    expired_at: 2026-09-11
+    expired_at: 2026-10-11
     statement: >-
       python:3.14-slim embeds a third-party SBOM that still reports setuptools
       70.3.0. The final application image replaces it with setuptools 84.0.0,


### PR DESCRIPTION
## Причина

Post-merge CI для PR #235 на merge SHA `d1a815a24a67d0b72866c78757966cc8bcdc284d` остановился на обязательном container scan: Trivy увидел устаревшие записи `msgpack 1.1.2` и `setuptools 70.3.0` из стороннего SBOM базового `python:3.14-slim`. Runtime requirements уже устанавливают исправленные версии (`msgpack 1.2.1`, `setuptools 84.0.0`), а в bot-образе эти пакеты отсутствуют.

## Изменение

Продлены до `2026-10-11` только два ограниченных `.trivyignore.yaml` исключения с сохранением исходных package coordinates и обоснования false positive. Срок ограничен и требует повторной проверки до истечения.

## Проверки

- `git diff --check`
- `scripts/ci_contract.py validate` (PASS)
- `scripts/deployment_contract.py check` (PASS)
- `tests/test_ci_contract.py` — 42 passed
- локальный Trivy v0.73.0 scan базового образа с текущим ignore file — 0 выявленных HIGH/CRITICAL
- pre-commit hooks — PASS

PR #235 содержит визуальный релиз профиля; этот PR только разблокирует его exact-SHA production delivery.
