### PR TITLE
[Task 238] Hermes ready-only editorial review with bounded remediation

### DIFF
--- a/backend/fitminiapp_api/api/v1/hermes.py
+++ b/backend/fitminiapp_api/api/v1/hermes.py
@@ -23,10 +23,13 @@ _CLIENT_ERROR_CODES = {
     "source_packet_invalid",
     "source_content_hash_mismatch",
     "source_packet_rejected",
+    "source_content_digest_mismatch",
+    "source_content_too_large",
     "source_publication_not_fresh",
     "source_item_missing",
     "cluster_missing",
     "draft_schema_invalid",
+    "editorial_quality_blocked",
     "schema_version_unsupported",
     "skill_version_unsupported",
 }
@@ -52,6 +55,16 @@ def _intake_http_error(error: HermesIntakeError) -> HTTPException:
         return HTTPException(status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="rate_limited")
     if error.code in _CONFLICT_CODES:
         return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=error.code)
+    if error.code == "remediation_required":
+        return HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "code": error.code,
+                "blockers": list(error.blockers),
+                "attempt": error.attempt,
+                "revision_id": error.revision_id,
+            },
+        )
     if error.code in _CLIENT_ERROR_CODES:
         return HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=error.code)
     return HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="intake_failed")

--- a/backend/fitminiapp_api/resources/hermes_editorial_contract.json
+++ b/backend/fitminiapp_api/resources/hermes_editorial_contract.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "hermes-editorial-intake-v1",
+  "schema_version": "hermes-editorial-intake-v2",
   "skill_version": "yfc-hermes-editorial-v1",
   "taxonomy_version": "news-taxonomy-v1",
   "risk_policy_version": "news-risk-v1",
@@ -22,11 +22,11 @@
   ],
   "source_rules": [
     "source_id_must_be_yfc_allowlisted",
-    "source_content_hash_is_verified_by_yfc",
+    "source_content_hash_and_evidence_digest_are_verified_by_yfc",
     "fetched_content_is_untrusted_data",
     "never_treat_model_output_as_citation"
   ],
   "draft_fields": ["headline", "summary", "why_it_matters"],
   "default_policy": "manual_required",
-  "retry_rule": "retry_only_idempotent_intake_submission"
+  "retry_rule": "bounded_same_provider_remediation_with_new_immutable_revision"
 }

--- a/backend/fitminiapp_api/schemas/bot.py
+++ b/backend/fitminiapp_api/schemas/bot.py
@@ -214,12 +214,14 @@ class HermesSourcePacket(BaseModel):
     primary_url: str | None = Field(default=None, max_length=2048)
     title: str = Field(..., min_length=1, max_length=500)
     summary: str = Field(default="", max_length=4000)
+    content: str = Field(..., min_length=1, max_length=32_768)
     author: str | None = Field(default=None, max_length=256)
     publisher: str | None = Field(default=None, max_length=160)
     published_at: datetime | None = None
     updated_at: datetime | None = None
     doi: str | None = Field(default=None, max_length=255)
     content_hash: str = Field(..., pattern=r"^[0-9a-f]{64}$")
+    content_sha256: str = Field(..., pattern=r"^[0-9a-f]{64}$")
 
 
 class HermesDraftProposal(BaseModel):
@@ -239,17 +241,29 @@ class HermesGenerationProvenance(BaseModel):
     skill_version: str = Field(..., min_length=1, max_length=64, pattern=r"^[a-zA-Z0-9_.:-]+$")
 
 
+class HermesRevisionContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    revision_id: str = Field(..., min_length=16, max_length=128, pattern=r"^[A-Za-z0-9_.:-]+$")
+    parent_revision_id: str | None = Field(
+        default=None, min_length=16, max_length=128, pattern=r"^[A-Za-z0-9_.:-]+$"
+    )
+    attempt: int = Field(..., ge=1, le=2)
+    requested_blockers: list[str] = Field(default_factory=list, max_length=8)
+
+
 class HermesEditorialIntakeRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     schema_version: str = Field(
-        default="hermes-editorial-intake-v1", pattern=r"^hermes-editorial-intake-v1$"
+        default="hermes-editorial-intake-v2", pattern=r"^hermes-editorial-intake-v2$"
     )
     idempotency_key: str = Field(..., min_length=16, max_length=128, pattern=r"^[A-Za-z0-9_.:-]+$")
     request_nonce: str = Field(..., min_length=16, max_length=128, pattern=r"^[A-Za-z0-9_.:-]+$")
     source: HermesSourcePacket
     draft: HermesDraftProposal
     provenance: HermesGenerationProvenance
+    revision: HermesRevisionContext
 
 
 class HermesEditorialIntakeResponse(BaseModel):

--- a/backend/fitminiapp_api/services/news_drafts.py
+++ b/backend/fitminiapp_api/services/news_drafts.py
@@ -212,6 +212,18 @@ def quality_warnings(
     return warnings
 
 
+def grounded_number_tokens(
+    *,
+    source_title: str,
+    source_summary: str,
+    source_context: str = "",
+) -> tuple[str, ...]:
+    """Return bounded numeric evidence tokens without retaining the source body."""
+
+    source_text = f"{source_title} {source_summary} {source_context}"
+    return tuple(sorted(set(NUMBER_PATTERN.findall(source_text))))
+
+
 def render_draft(fields: dict[str, str], packet: NewsEvidencePacket) -> str:
     source_url = packet.primary_url or packet.canonical_url
     sections = [

--- a/backend/fitminiapp_api/services/news_editorial.py
+++ b/backend/fitminiapp_api/services/news_editorial.py
@@ -110,78 +110,29 @@ class ReviewArtifact:
     limit: int | None
 
 
-PREVIEW_OPERATIONAL_BLOCKERS = frozenset({"publishing_disabled", "channel_rights_missing"})
 NON_HERMES_REVIEW_DELIVERY_DISABLED = "non_hermes_news_pipeline_retired"
-MANUAL_REVIEW_ALLOWED_WARNINGS = frozenset(
-    {
-        "medical_prescription_language",
-        "unsupported_number",
-        "telegram_photo_caption_too_long",
-    }
-)
-MANUAL_REVIEW_ALLOWED_BLOCKERS = frozenset(
-    {
-        "unresolved_warning:medical_prescription_language",
-        "unresolved_warning:unsupported_number",
-        "unresolved_warning:telegram_photo_caption_too_long",
-        "telegram_photo_caption_too_long",
-    }
-)
-MANUAL_REVIEW_ALLOWED_CONTENT_BLOCKERS = frozenset(
-    {
-        "prohibited_medical_or_aas_language",
-    }
-)
 
 
 def review_delivery_blockers(
     draft: NewsDraftRevision,
     review: ReviewArtifact,
 ) -> tuple[str, ...]:
-    """Block only owner-preview states that cannot be reviewed safely.
+    """Allow Telegram review only for an exact, immediately publishable state."""
 
-    Publication-quality warnings remain visible on the owner control card and
-    continue to block publication. Recoverable editorial issues must not make
-    the review item disappear from the owner's Telegram queue.
-    """
-
-    is_hermes_draft = is_hermes_origin_draft(draft)
-    blockers: list[str] = []
-
-    if is_hermes_draft:
-        blockers.extend(
-            blocker
-            for blocker in review.blockers
-            if blocker not in PREVIEW_OPERATIONAL_BLOCKERS
-            and blocker not in MANUAL_REVIEW_ALLOWED_BLOCKERS
-            and blocker not in MANUAL_REVIEW_ALLOWED_CONTENT_BLOCKERS
-        )
-        blockers.extend(
-            f"unresolved_warning:{warning}"
-            for warning in draft.warnings
-            if (
-                isinstance(warning, str)
-                and warning
-                and warning not in MANUAL_REVIEW_ALLOWED_WARNINGS
-            )
-        )
-
-    # An overlong photo caption is recoverable in the owner UI: the exact
-    # publication artifact is unavailable, but review_message() can still
-    # deliver a control card with edit/regenerate actions.
-    if is_hermes_draft and review.artifact is None:
-        recoverable_overlong_caption = (
-            "telegram_photo_caption_too_long" in review.blockers and not blockers
-        )
-        if not recoverable_overlong_caption:
-            blockers.append("preview_artifact_unavailable")
-
-    # Hermes publication still requires its image path. Keep this as a hard
-    # preview gate rather than silently degrading to a publishable text-only
-    # item.
-    if is_hermes_draft and (review.image is None or not review.image.image_data):
+    if not is_hermes_origin_draft(draft):
+        return (NON_HERMES_REVIEW_DELIVERY_DISABLED,)
+    blockers = list(review.blockers)
+    blockers.extend(
+        f"unresolved_warning:{warning}"
+        for warning in draft.warnings
+        if isinstance(warning, str) and warning
+    )
+    if review.artifact is None:
+        blockers.append("preview_artifact_unavailable")
+    if review.artifact_hash is None:
+        blockers.append("preview_artifact_hash_missing")
+    if review.image is None or not review.image.image_data:
         blockers.append("preview_image_missing")
-
     return tuple(dict.fromkeys(blockers))
 
 
@@ -276,6 +227,11 @@ def edit_text_revision(
         editorial_content.fields(),
         source_title=primary.title,
         source_summary=primary.summary,
+        source_context=" ".join(
+            value
+            for value in draft.evidence_metadata.get("source_number_tokens", [])
+            if isinstance(value, str)
+        ),
     )
     preserved_warnings = tuple(
         warning for warning in draft.warnings if warning not in OWNER_EDIT_REVALIDATED_WARNINGS
@@ -524,25 +480,14 @@ def moderate_draft(
         cluster.deferred_until = utcnow() + timedelta(hours=settings.news_defer_hours)
         cluster.delivery_round += 1
         result_status = "deferred"
+    elif action == "regenerate":
+        # Hermes owns text generation. A YFC callback must never requeue the
+        # same immutable revision while pretending that new text exists.
+        result_status = "unavailable"
+        outcome = "generation_external"
     else:
-        if cluster.generation_attempt_count > settings.news_max_regenerations:
-            result_status = "limit_reached"
-            outcome = "limit_reached"
-        else:
-            revoke_active_decisions(db, cluster.id, reason="editorial_regenerate")
-            # Hermes text generation lives outside YFC. Requeue the accepted
-            # immutable Hermes revision for owner review instead of manufacturing
-            # a new local candidate/draft.
-            cluster.delivery_round += 1
-            transition_news_cluster(
-                db,
-                cluster,
-                "draft_ready",
-                reason_code="owner_regenerate_hermes_revision",
-                actor_ref=actor_ref,
-            )
-            cluster.deferred_until = None
-            result_status = "queued"
+        result_status = "unavailable"
+        outcome = "unsupported_action"
     db.add(
         NewsEditorialAction(
             cluster_id=cluster.id,
@@ -880,6 +825,7 @@ def review_message(
     if primary is None or primary.id not in draft.evidence_item_ids:
         raise ValueError("primary_source_missing")
     review = compose_review_artifact(db, draft, channel_ready=channel_ready)
+    delivery_blockers = review_delivery_blockers(draft, review)
     metadata = draft.evidence_metadata
     warnings = ", ".join(draft.warnings) if draft.warnings else "нет автоматических флагов"
     score_reasons = ", ".join(metadata.get("score_reasons", [])[:6])
@@ -935,7 +881,7 @@ def review_message(
         primary.primary_url or primary.canonical_url
     )
     buttons = [[{"text": "Открыть источник", "url": source_url}]]
-    if not review.blockers and review.artifact_hash is not None:
+    if not delivery_blockers and review.artifact_hash is not None:
         buttons.append(
             [
                 {
@@ -967,10 +913,6 @@ def review_message(
                         "e", draft.id, cluster.current_image_revision
                     ),
                 },
-                {
-                    "text": "Перегенерировать текст",
-                    "callback_data": callback_data("regenerate", draft.id),
-                },
             ],
             [
                 {
@@ -1000,10 +942,6 @@ def review_message(
                     "callback_data": publishing_callback_data(
                         "x", draft.id, cluster.current_image_revision
                     ),
-                },
-                {
-                    "text": "Отложить рассмотрение",
-                    "callback_data": callback_data("defer", draft.id),
                 },
             ],
         ]

--- a/backend/fitminiapp_api/services/news_hermes.py
+++ b/backend/fitminiapp_api/services/news_hermes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import logging
 import re
 import secrets
 import time
@@ -30,6 +31,7 @@ from fitminiapp_api.services.audit import record_audit_event
 from fitminiapp_api.services.news_drafts import (
     _validated_fields,
     evidence_packet,
+    grounded_number_tokens,
     quality_warnings,
     render_draft,
 )
@@ -44,6 +46,10 @@ from fitminiapp_api.services.news_ingestion import (
     utcnow,
 )
 from fitminiapp_api.services.news_origin import HERMES_SUBMISSION_MARKER
+from fitminiapp_api.services.news_publication import (
+    CLICKBAIT_PATTERNS,
+    PROHIBITED_EDITORIAL_PATTERNS,
+)
 from fitminiapp_api.services.news_state import transition_news_cluster
 from fitminiapp_api.services.news_taxonomy import (
     RISK_POLICY_VERSION,
@@ -53,17 +59,50 @@ from fitminiapp_api.services.news_taxonomy import (
     evaluate_publication_policy,
 )
 
-HERMES_INTAKE_SCHEMA_VERSION = "hermes-editorial-intake-v1"
+HERMES_INTAKE_SCHEMA_VERSION = "hermes-editorial-intake-v2"
 HERMES_INTAKE_ENDPOINT = "/api/v1/hermes/editorial/intake"
 SUPPORTED_HERMES_SKILL_VERSIONS = frozenset({"yfc-hermes-editorial-v1"})
 HERMES_SIGNATURE_PREFIX = "sha256="
 HEX64_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+HERMES_SOURCE_CONTENT_MAX_BYTES = 32 * 1024
+HERMES_BLOCKER_CODE_PATTERN = re.compile(r"^[a-z0-9_.:-]{1,64}$")
+HERMES_REMEDIABLE_BLOCKERS = frozenset(
+    {
+        "clickbait_or_guarantee_language",
+        "clickbait_or_guarantee",
+        "ai_meta_or_template_language",
+        "fake_personal_voice",
+        "excessive_exclamation",
+        "mechanical_repetition",
+        "invented_quote_or_voice",
+        "medical_prescription_language",
+        "possible_source_copy",
+        "prohibited_medical_or_aas_language",
+        "research_context_or_limitations_missing",
+        "sensational_or_guaranteed_claim",
+        "telegram_message_too_long",
+        "telegram_photo_caption_too_long",
+        "unsupported_number",
+    }
+)
+
+logger = logging.getLogger(__name__)
 
 
 class HermesIntakeError(RuntimeError):
-    def __init__(self, code: str) -> None:
+    def __init__(
+        self,
+        code: str,
+        *,
+        blockers: tuple[str, ...] = (),
+        attempt: int | None = None,
+        revision_id: str | None = None,
+    ) -> None:
         super().__init__(code)
         self.code = code
+        self.blockers = blockers
+        self.attempt = attempt
+        self.revision_id = revision_id
 
 
 @dataclass(frozen=True)
@@ -209,6 +248,34 @@ def _find_existing_submission(
     return None
 
 
+def _safe_blocker_codes(values: object) -> tuple[str, ...]:
+    if not isinstance(values, (list, tuple)):
+        return ()
+    return tuple(
+        dict.fromkeys(
+            value
+            for value in values
+            if isinstance(value, str) and HERMES_BLOCKER_CODE_PATTERN.fullmatch(value)
+        )
+    )[:8]
+
+
+def _remediation_blockers(
+    warnings: tuple[str, ...], publication_blockers: tuple[str, ...]
+) -> tuple[str, ...]:
+    candidates: list[str] = [
+        warning for warning in warnings if HERMES_BLOCKER_CODE_PATTERN.fullmatch(warning)
+    ]
+    for blocker in publication_blockers:
+        if blocker.startswith("unresolved_warning:"):
+            candidates.append(blocker.removeprefix("unresolved_warning:"))
+        else:
+            candidates.append(blocker)
+    return tuple(
+        dict.fromkeys(blocker for blocker in candidates if blocker in HERMES_REMEDIABLE_BLOCKERS)
+    )
+
+
 def accept_hermes_submission(
     db: Session,
     payload,
@@ -256,6 +323,10 @@ def accept_hermes_submission(
         )
         title = plain_text(payload.source.title, maximum=500)
         summary = plain_text(payload.source.summary, maximum=4000)
+        source_content = payload.source.content
+        if len(source_content.encode("utf-8")) > HERMES_SOURCE_CONTENT_MAX_BYTES:
+            raise HermesIntakeError("source_content_too_large")
+        source_content = plain_text(source_content, maximum=HERMES_SOURCE_CONTENT_MAX_BYTES)
     except (ValueError, TypeError) as exc:
         raise HermesIntakeError("source_packet_invalid") from exc
     expected_source_hash = _canonical_source_hash(
@@ -266,6 +337,8 @@ def accept_hermes_submission(
     )
     if payload.source.content_hash != expected_source_hash:
         raise HermesIntakeError("source_content_hash_mismatch")
+    if sha256_text(payload.source.content) != payload.source.content_sha256:
+        raise HermesIntakeError("source_content_digest_mismatch")
 
     parsed = ParsedNewsItem(
         external_id=payload.source.external_id,
@@ -329,7 +402,7 @@ def accept_hermes_submission(
             fields,
             source_title=title,
             source_summary=summary,
-            source_context=canonical_url,
+            source_context=source_content,
         )
     )
     policy = evaluate_publication_policy(
@@ -342,7 +415,51 @@ def accept_hermes_submission(
     draft_text = render_draft(fields, packet)
     submission_id = secrets.token_hex(24)
     revision = cluster.latest_draft_revision + 1
-    draft = NewsDraftRevision(
+    trusted_source_url = packet.primary_url or packet.canonical_url
+    source_number_tokens = grounded_number_tokens(
+        source_title=title,
+        source_summary=summary,
+        source_context=source_content,
+    )
+    evidence_metadata = {
+        "source_packet_hash": payload.source.content_hash,
+        "source_content_sha256": payload.source.content_sha256,
+        "source_number_tokens": list(source_number_tokens[:128]),
+        "trusted_source_url": trusted_source_url,
+        "source_published_at": (
+            payload.source.published_at.isoformat() if payload.source.published_at else None
+        ),
+        "primary_topic": classification.primary_topic,
+        "topics": list(classification.topics),
+        "content_type": classification.content_type,
+        "product_class": classification.product_class,
+        "evidence_level": classification.evidence_level,
+        "risk_level": classification.risk_level,
+        "audience": classification.audience,
+        "geography": list(classification.geography),
+        "classification_version": TAXONOMY_VERSION,
+        "classification_reasons": list(classification.classification_reasons),
+        "publication_policy": policy.publication_policy,
+        "risk_reasons": list(policy.risk_reasons),
+        "risk_policy_version": RISK_POLICY_VERSION,
+        "voice_profile_version": VOICE_PROFILE_VERSION,
+        "editorial_profile": settings.news_draft_profile,
+        "submitted_by": HERMES_SUBMISSION_MARKER,
+        "hermes_skill_version": payload.provenance.skill_version,
+        "hermes_schema_version": payload.schema_version,
+        "hermes_submission_id": submission_id,
+        "hermes_revision_id": payload.revision.revision_id,
+        "hermes_parent_revision_id": payload.revision.parent_revision_id,
+        "hermes_remediation_attempt": payload.revision.attempt,
+        "hermes_requested_blockers": list(_safe_blocker_codes(payload.revision.requested_blockers)),
+        "article_candidate": article_candidate_handoff(
+            cluster_id=cluster.id,
+            draft_revision=revision,
+            primary_topic=classification.primary_topic,
+            content_type=classification.content_type,
+        ),
+    }
+    candidate = NewsDraftRevision(
         id=secrets.token_hex(16),
         cluster_id=cluster.id,
         primary_item_id=packet.primary_item_id,
@@ -352,42 +469,46 @@ def accept_hermes_submission(
         prompt_version=payload.provenance.prompt_version,
         source_digest=packet.source_digest,
         evidence_item_ids=list(packet.evidence_item_ids),
-        evidence_metadata={
-            "source_packet_hash": payload.source.content_hash,
-            "trusted_source_url": packet.primary_url or packet.canonical_url,
-            "source_published_at": (
-                payload.source.published_at.isoformat() if payload.source.published_at else None
-            ),
-            "primary_topic": classification.primary_topic,
-            "topics": list(classification.topics),
-            "content_type": classification.content_type,
-            "product_class": classification.product_class,
-            "evidence_level": classification.evidence_level,
-            "risk_level": classification.risk_level,
-            "audience": classification.audience,
-            "geography": list(classification.geography),
-            "classification_version": TAXONOMY_VERSION,
-            "classification_reasons": list(classification.classification_reasons),
-            "publication_policy": policy.publication_policy,
-            "risk_reasons": list(policy.risk_reasons),
-            "risk_policy_version": RISK_POLICY_VERSION,
-            "voice_profile_version": VOICE_PROFILE_VERSION,
-            "editorial_profile": settings.news_draft_profile,
-            "submitted_by": HERMES_SUBMISSION_MARKER,
-            "hermes_skill_version": payload.provenance.skill_version,
-            "hermes_schema_version": payload.schema_version,
-            "hermes_submission_id": submission_id,
-            "article_candidate": article_candidate_handoff(
-                cluster_id=cluster.id,
-                draft_revision=revision,
-                primary_topic=classification.primary_topic,
-                content_type=classification.content_type,
-            ),
-        },
+        evidence_metadata=evidence_metadata,
         draft_text=draft_text,
         warnings=list(warnings),
         generation_latency_ms=0,
     )
+    lowered_draft = draft_text.casefold()
+    publication_blocker_values: list[str] = []
+    if any(pattern in lowered_draft for pattern in PROHIBITED_EDITORIAL_PATTERNS):
+        publication_blocker_values.append("prohibited_medical_or_aas_language")
+    if any(pattern in lowered_draft for pattern in CLICKBAIT_PATTERNS):
+        publication_blocker_values.append("clickbait_or_guarantee_language")
+    if packet.topic == "research":
+        research_context = f"{fields['summary']} {fields['why_it_matters']}".casefold()
+        if not any(
+            marker in research_context
+            for marker in ("огранич", "контекст", "групп", "выборк", "применим")
+        ):
+            publication_blocker_values.append("research_context_or_limitations_missing")
+    publication_blockers = tuple(dict.fromkeys(publication_blocker_values))
+    remediation_blockers = _remediation_blockers(warnings, publication_blockers)
+    if remediation_blockers:
+        logger.info(
+            "hermes_editorial_remediation_required",
+            extra={
+                "pipeline_stage": "hermes_intake",
+                "event": "remediation_required",
+                "revision_id": payload.revision.revision_id,
+                "attempt": payload.revision.attempt,
+                "blockers": list(remediation_blockers),
+            },
+        )
+        raise HermesIntakeError(
+            "remediation_required",
+            blockers=remediation_blockers,
+            attempt=payload.revision.attempt,
+            revision_id=payload.revision.revision_id,
+        )
+    if publication_blockers:
+        raise HermesIntakeError("editorial_quality_blocked")
+    draft = candidate
     db.add(draft)
     cluster.latest_draft_revision = revision
     cluster.current_image_revision = 0
@@ -429,6 +550,11 @@ def accept_hermes_submission(
             "endpoint": HERMES_INTAKE_ENDPOINT,
             "source_id": source.id,
             "source_content_hash": payload.source.content_hash,
+            "source_content_sha256": payload.source.content_sha256,
+            "revision_id": payload.revision.revision_id,
+            "parent_revision_id": payload.revision.parent_revision_id,
+            "remediation_attempt": payload.revision.attempt,
+            "requested_blockers": list(_safe_blocker_codes(payload.revision.requested_blockers)),
             "publication_policy": policy.publication_policy,
             "risk_reason_count": len(policy.risk_reasons),
         },
@@ -438,7 +564,11 @@ def accept_hermes_submission(
     db.add(submission)
     record_audit_event(
         db,
-        action="news.hermes_intake_accepted",
+        action=(
+            "news.hermes_remediation_succeeded"
+            if payload.revision.attempt > 1
+            else "news.hermes_intake_accepted"
+        ),
         resource_type="hermes_editorial_submission",
         resource_id=submission_id,
         details={
@@ -449,6 +579,10 @@ def accept_hermes_submission(
             "taxonomy_version": TAXONOMY_VERSION,
             "risk_policy_version": RISK_POLICY_VERSION,
             "policy": policy.publication_policy,
+            "revision_id": payload.revision.revision_id,
+            "parent_revision_id": payload.revision.parent_revision_id,
+            "remediation_attempt": payload.revision.attempt,
+            "requested_blockers": list(_safe_blocker_codes(payload.revision.requested_blockers)),
         },
     )
     db.flush()

--- a/backend/fitminiapp_api/services/news_worker.py
+++ b/backend/fitminiapp_api/services/news_worker.py
@@ -178,11 +178,8 @@ def _claim_deliveries(
             )
             eligible = eligible.filter(~NewsReviewDelivery.draft_id.in_(sent_drafts_in_slot))
             remaining_batch_size = max(0, NEWS_REVIEW_BATCH_SIZE - sent_drafts_in_slot.count())
-            effective_draft_limit = (
-                remaining_batch_size
-                if effective_draft_limit is None
-                else min(effective_draft_limit, remaining_batch_size)
-            )
+            if effective_draft_limit is not None:
+                effective_draft_limit = min(effective_draft_limit, remaining_batch_size)
         if effective_draft_limit is None:
             rows = (
                 eligible.order_by(
@@ -264,6 +261,16 @@ def _mark_review_delivery_blocked(
     )
 
 
+def _release_claimed_delivery(delivery_id: int) -> None:
+    with get_session_context() as db:
+        delivery = db.get(NewsReviewDelivery, delivery_id)
+        if delivery is None or delivery.status != "processing":
+            return
+        delivery.status = "queued"
+        delivery.processing_started_at = None
+        delivery.next_attempt_at = utcnow()
+
+
 async def deliver_review_queue(
     client: httpx.AsyncClient,
     send_message: Callable[..., Awaitable[int | None]],
@@ -280,8 +287,23 @@ async def deliver_review_queue(
     with get_session_context() as db:
         cancel_non_hermes_review_deliveries(db)
     delivered = 0
+    sent_draft_ids: set[str] = set()
+    if review_slot is not None:
+        slot_start_utc = review_slot.local_start.astimezone(UTC).replace(tzinfo=None)
+        with get_session_context() as db:
+            sent_draft_ids = {
+                row.draft_id
+                for row in db.query(NewsReviewDelivery.draft_id)
+                .filter(
+                    NewsReviewDelivery.status == "sent",
+                    NewsReviewDelivery.sent_at.is_not(None),
+                    NewsReviewDelivery.sent_at >= slot_start_utc,
+                )
+                .distinct()
+                .all()
+            }
     for delivery_id in _claim_deliveries(
-        draft_limit=NEWS_REVIEW_BATCH_SIZE if review_slot is not None else None,
+        draft_limit=None,
         review_slot=review_slot,
     ):
         with get_session_context() as db:
@@ -329,6 +351,13 @@ async def deliver_review_queue(
                 attempt_count=attempt_count,
                 blockers=delivery_blockers,
             )
+            continue
+        if (
+            review_slot is not None
+            and draft_resource_id not in sent_draft_ids
+            and len(sent_draft_ids) >= NEWS_REVIEW_BATCH_SIZE
+        ):
+            _release_claimed_delivery(delivery_id)
             continue
         try:
             if artifact is not None and preview_message_id is None:
@@ -402,6 +431,8 @@ async def deliver_review_queue(
                     "image_revision": image_revision,
                 },
             )
+        if review_slot is not None:
+            sent_draft_ids.add(draft_resource_id)
         delivered += 1
         logger.info(
             "news_review_delivery_succeeded",

--- a/backend/tests/test_news_editorial.py
+++ b/backend/tests/test_news_editorial.py
@@ -856,7 +856,7 @@ def test_review_message_uses_immutable_draft_evidence_after_cluster_changes(monk
         assert review_message(db, draft)[1] == original_url
 
 
-def test_regeneration_makes_old_revision_stale_for_other_admin(monkeypatch) -> None:
+def test_regeneration_does_not_change_revision_state_for_other_admin(monkeypatch) -> None:
     _create_source()
     cluster_id = _candidate_cluster()
     with get_session_context() as db:
@@ -871,7 +871,7 @@ def test_regeneration_makes_old_revision_stale_for_other_admin(monkeypatch) -> N
                 admin_telegram_user_id=7001,
                 action="regenerate",
             ).status
-            == "queued"
+            == "unavailable"
         )
         assert (
             moderate_draft(
@@ -880,9 +880,9 @@ def test_regeneration_makes_old_revision_stale_for_other_admin(monkeypatch) -> N
                 admin_telegram_user_id=7002,
                 action="accept_for_design",
             ).status
-            == "stale"
+            == "accepted"
         )
-        assert cluster.status == "draft_ready"
+        assert cluster.status == "accepted_for_design"
 
 
 def test_owner_only_moderation_is_revision_bound_idempotent_and_never_publishes(

--- a/backend/tests/test_news_hermes.py
+++ b/backend/tests/test_news_hermes.py
@@ -32,6 +32,7 @@ def _payload() -> dict:
         "primary_url": None,
         "title": "Исследование связало силовые тренировки с восстановлением",
         "summary": "Авторы изучили силовые тренировки и восстановление у взрослых.",
+        "content": "Публичный источник описывает результаты и ограничения исследования.",
         "author": None,
         "publisher": "Journal One",
         "published_at": published_at.isoformat(),
@@ -44,8 +45,9 @@ def _payload() -> dict:
         canonical_url=source["canonical_url"],
         published_at=published_at,
     )
+    source["content_sha256"] = hashlib.sha256(source["content"].encode()).hexdigest()
     return {
-        "schema_version": "hermes-editorial-intake-v1",
+        "schema_version": "hermes-editorial-intake-v2",
         "idempotency_key": "hermes-test-idempotency-1",
         "request_nonce": "hermes-test-nonce-1",
         "source": source,
@@ -60,6 +62,12 @@ def _payload() -> dict:
             "model": "test-model",
             "prompt_version": "hermes-editorial-v1",
             "skill_version": "yfc-hermes-editorial-v1",
+        },
+        "revision": {
+            "revision_id": "hermes-test-revision-1",
+            "parent_revision_id": None,
+            "attempt": 1,
+            "requested_blockers": [],
         },
     }
 
@@ -222,6 +230,8 @@ def test_hermes_image_pending_downstream_survives_disabled_legacy_fetch(
     )
     monkeypatch.setattr(settings, "news_ingestion_enabled", True)
     monkeypatch.setattr(settings, "news_image_provider", "disabled")
+    monkeypatch.setattr(settings, "news_publication_enabled", True)
+    monkeypatch.setattr(settings, "news_channel_id", -1001234567890)
     monkeypatch.setattr(settings, "admin_telegram_user_ids", "7001")
 
     with get_session_context() as db:
@@ -286,7 +296,7 @@ def test_hermes_image_pending_downstream_survives_disabled_legacy_fetch(
         assert delivery.status == "sent"
 
 
-def test_hermes_sensitive_source_reaches_full_owner_card(client, monkeypatch) -> None:
+def test_hermes_sensitive_source_requires_bounded_remediation(client, monkeypatch) -> None:
     monkeypatch.setattr(settings, "hermes_intake_enabled", True)
     monkeypatch.setattr(settings, "hermes_intake_key_id", "hermes-test")
     monkeypatch.setattr(
@@ -294,10 +304,6 @@ def test_hermes_sensitive_source_reaches_full_owner_card(client, monkeypatch) ->
         "hermes_intake_shared_secret",
         SecretStr("test-hermes-shared-secret-that-is-long-enough"),
     )
-    monkeypatch.setattr(settings, "news_ingestion_enabled", True)
-    monkeypatch.setattr(settings, "news_image_provider", "disabled")
-    monkeypatch.setattr(settings, "admin_telegram_user_ids", "7001")
-
     with get_session_context() as db:
         db.add(
             NewsSource(
@@ -336,42 +342,101 @@ def test_hermes_sensitive_source_reaches_full_owner_card(client, monkeypatch) ->
         content=body,
         headers=_signed_headers(body),
     )
-    assert intake.status_code == 200, intake.text
-    assert intake.json()["status"] == "accepted"
-    assert intake.json()["publication_policy"] == "manual_required"
+    assert intake.status_code == 422, intake.text
+    detail = intake.json()["detail"]
+    assert detail["code"] == "remediation_required"
+    assert "medical_prescription_language" in detail["blockers"]
+    with get_session_context() as db:
+        assert db.query(HermesEditorialSubmission).count() == 0
+        assert db.query(NewsDraftRevision).count() == 0
 
-    preview_calls: list[int] = []
-    control_calls: list[int] = []
 
-    async def send_preview(_client, chat_id, *_args, **_kwargs):
-        preview_calls.append(chat_id)
-        return SimpleNamespace(message_id=511, message_date=datetime.now(UTC))
-
-    async def send_control(_client, chat_id, *_args, **_kwargs):
-        control_calls.append(chat_id)
-        return 512
-
-    async def send_publication(*_args, **_kwargs):
-        raise AssertionError("manual-sensitive intake must not publish automatically")
-
-    asyncio.run(
-        run_news_pipeline_once(
-            send_message=send_control,
-            send_preview=send_preview,
-            send_publication=send_publication,
-            publication_ready=True,
+def test_hermes_unsupported_number_without_source_evidence_requests_remediation(
+    client, monkeypatch
+) -> None:
+    monkeypatch.setattr(settings, "hermes_intake_enabled", True)
+    monkeypatch.setattr(settings, "hermes_intake_key_id", "hermes-test")
+    monkeypatch.setattr(
+        settings,
+        "hermes_intake_shared_secret",
+        SecretStr("test-hermes-shared-secret-that-is-long-enough"),
+    )
+    with get_session_context() as db:
+        db.add(
+            NewsSource(
+                id="journal-one",
+                name="Journal One",
+                source_type="primary_research",
+                fetch_kind="rss",
+                feed_url="https://example.com/feed",
+                language="en",
+                enabled=True,
+            )
         )
+
+    payload = _payload()
+    payload["idempotency_key"] = "hermes-unsupported-number-no-evidence"
+    payload["request_nonce"] = "hermes-unsupported-number-nonce"
+    payload["draft"]["summary"] = (
+        "Авторы описали результат с изменением на 99 процентов у исследованной группы."
+    )
+    body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
+
+    response = client.post(
+        "/api/v1/hermes/editorial/intake",
+        content=body,
+        headers=_signed_headers(body),
     )
 
-    assert preview_calls == [7001]
-    assert control_calls == [7001]
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert detail["code"] == "remediation_required"
+    assert detail["blockers"] == ["unsupported_number"]
     with get_session_context() as db:
-        submission = db.query(HermesEditorialSubmission).one()
-        draft = db.get(NewsDraftRevision, submission.draft_id)
-        cluster = db.get(NewsCluster, submission.cluster_id)
-        delivery = db.query(NewsReviewDelivery).one()
-        assert draft is not None and cluster is not None
-        assert "medical_prescription_language" in draft.warnings
-        assert any(flag.startswith("prohibited_") for flag in cluster.risk_flags)
-        assert cluster.status == "awaiting_review"
-        assert delivery.status == "sent"
+        assert db.query(HermesEditorialSubmission).count() == 0
+        assert db.query(NewsDraftRevision).count() == 0
+
+
+def test_hermes_number_grounded_in_source_content_is_accepted(client, monkeypatch) -> None:
+    monkeypatch.setattr(settings, "hermes_intake_enabled", True)
+    monkeypatch.setattr(settings, "hermes_intake_key_id", "hermes-test")
+    monkeypatch.setattr(
+        settings,
+        "hermes_intake_shared_secret",
+        SecretStr("test-hermes-shared-secret-that-is-long-enough"),
+    )
+    with get_session_context() as db:
+        db.add(
+            NewsSource(
+                id="journal-one",
+                name="Journal One",
+                source_type="primary_research",
+                fetch_kind="rss",
+                feed_url="https://example.com/feed",
+                language="en",
+                enabled=True,
+            )
+        )
+
+    payload = _payload()
+    payload["idempotency_key"] = "hermes-grounded-number"
+    payload["request_nonce"] = "hermes-grounded-number-nonce"
+    payload["source"]["content"] = (
+        "Публичный источник описывает результаты у 12 взрослых участников и ограничения исследования."
+    )
+    payload["source"]["content_sha256"] = hashlib.sha256(
+        payload["source"]["content"].encode()
+    ).hexdigest()
+    payload["draft"]["summary"] = (
+        "Авторы описали результаты у 12 взрослых участников и ограничения исследования."
+    )
+    body = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
+
+    response = client.post(
+        "/api/v1/hermes/editorial/intake",
+        content=body,
+        headers=_signed_headers(body),
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["status"] == "accepted"

--- a/backend/tests/test_news_publishing.py
+++ b/backend/tests/test_news_publishing.py
@@ -19,6 +19,7 @@ from fitminiapp_api.models.audit import AuditEvent
 from fitminiapp_api.models.news import (
     NewsCluster,
     NewsDraftRevision,
+    NewsEditorialAction,
     NewsImageRevision,
     NewsItem,
     NewsPublicationSnapshot,
@@ -1416,7 +1417,7 @@ def test_scheduled_review_delivery_sends_at_most_five_distinct_drafts(monkeypatc
                 **draft.evidence_metadata,
                 "submitted_by": "hermes_narrow_intake",
             }
-            draft.warnings = []
+            draft.warnings = ["unsupported_number"] if index == 0 else []
             asyncio.run(create_image_revision(db, cluster, draft, client=None))
         assert enqueue_review_deliveries(db, {7001}) == len(titles)
 
@@ -1456,18 +1457,19 @@ def test_scheduled_review_delivery_sends_at_most_five_distinct_drafts(monkeypatc
             row.status for row in db.query(NewsReviewDelivery).order_by(NewsReviewDelivery.id)
         ]
         assert statuses.count("sent") == 5
-        assert statuses.count("queued") == 1
+        assert statuses.count("failed") == 1
+        assert statuses.count("queued") == 0
 
     assert asyncio.run(deliver()) == 0
     assert len(preview_calls) == 5
     assert len(control_calls) == 5
     with get_session_context() as db:
         assert (
-            db.query(NewsReviewDelivery).filter(NewsReviewDelivery.status == "queued").count() == 1
+            db.query(NewsReviewDelivery).filter(NewsReviewDelivery.status == "queued").count() == 0
         )
 
 
-def test_sensitive_hermes_warning_reaches_owner_card_but_not_publish_button(monkeypatch) -> None:
+def test_sensitive_hermes_warning_is_not_delivered_to_owner(monkeypatch) -> None:
     cluster_id = _source_and_candidate(external_id="hermes-sensitive-card")
     draft_id, _ = _draft(cluster_id)
     monkeypatch.setattr(settings, "news_image_provider", "disabled")
@@ -1490,11 +1492,11 @@ def test_sensitive_hermes_warning_reaches_owner_card_but_not_publish_button(monk
     control_calls: list[dict[str, object]] = []
 
     async def send_preview(_client, _chat_id, *_args, **_kwargs):
-        return SimpleNamespace(message_id=631, message_date=utcnow())
+        raise AssertionError("blocked warning must not send preview")
 
     async def send_control(_client, _chat_id, text, *, reply_markup):
         control_calls.append({"text": text, "reply_markup": reply_markup})
-        return 632
+        raise AssertionError("blocked warning must not send control card")
 
     async def deliver() -> int:
         async with httpx.AsyncClient() as client:
@@ -1505,24 +1507,18 @@ def test_sensitive_hermes_warning_reaches_owner_card_but_not_publish_button(monk
                 channel_ready=True,
             )
 
-    assert asyncio.run(deliver()) == 1
-    assert len(control_calls) == 1
-    callback_values = [
-        button["callback_data"]
-        for row in control_calls[0]["reply_markup"]["inline_keyboard"]
-        for button in row
-        if "callback_data" in button
-    ]
-    assert "medical_prescription_language" in control_calls[0]["text"]
-    assert not any(value.startswith("newsp:p:") for value in callback_values)
+    assert asyncio.run(deliver()) == 0
+    assert control_calls == []
     with get_session_context() as db:
-        assert db.query(NewsReviewDelivery).one().status == "sent"
+        assert db.query(NewsReviewDelivery).one().status == "failed"
 
 
 def test_hermes_draft_reaches_telegram_when_legacy_fetch_is_disabled(monkeypatch) -> None:
     cluster_id = _source_and_candidate(external_id="hermes-downstream-enabled")
     draft_id, _ = _draft(cluster_id)
     monkeypatch.setattr(settings, "news_image_provider", "disabled")
+    monkeypatch.setattr(settings, "news_publication_enabled", True)
+    monkeypatch.setattr(settings, "news_channel_id", -1001234567890)
     monkeypatch.setattr(settings, "admin_telegram_user_ids", "7001")
     with get_session_context() as db:
         cluster = db.get(NewsCluster, cluster_id)
@@ -1602,9 +1598,7 @@ def test_owner_edited_hermes_revision_keeps_delivery_eligibility(monkeypatch) ->
         assert enqueue_review_deliveries(db, {7001}) == 1
 
 
-def test_hermes_regenerate_requeues_revision_without_legacy_candidate_generation(
-    monkeypatch,
-) -> None:
+def test_hermes_regenerate_never_requeues_same_immutable_revision(monkeypatch) -> None:
     cluster_id = _source_and_candidate(external_id="hermes-regenerate-disabled-legacy")
     draft_id, _ = _draft(cluster_id)
     monkeypatch.setattr(settings, "news_ingestion_enabled", True)
@@ -1627,41 +1621,14 @@ def test_hermes_regenerate_requeues_revision_without_legacy_candidate_generation
             admin_telegram_user_id=7001,
             action="regenerate",
         )
-        assert result.status == "queued"
-        assert result.cluster_status == "draft_ready"
-        assert cluster.status == "draft_ready"
-        assert cluster.delivery_round == 1
-        assert db.query(NewsReviewDelivery).one().status == "cancelled"
-
-    preview_calls: list[int] = []
-    control_calls: list[int] = []
-
-    async def send_preview(_client, chat_id, *_args, **_kwargs):
-        preview_calls.append(chat_id)
-        return SimpleNamespace(message_id=621, message_date=utcnow())
-
-    async def send_control(_client, chat_id, *_args, **_kwargs):
-        control_calls.append(chat_id)
-        return 622
-
-    async def unused_publication(*_args, **_kwargs):
-        raise AssertionError("publication is not part of Hermes regenerate review flow")
-
-    asyncio.run(
-        run_news_pipeline_once(
-            send_message=send_control,
-            send_preview=send_preview,
-            send_publication=unused_publication,
-            publication_ready=False,
-        )
-    )
-    assert preview_calls == [7001]
-    assert control_calls == [7001]
-    with get_session_context() as db:
-        cluster = db.get(NewsCluster, cluster_id)
-        assert cluster is not None and cluster.status == "awaiting_review"
-        deliveries = db.query(NewsReviewDelivery).order_by(NewsReviewDelivery.id).all()
-        assert [delivery.status for delivery in deliveries] == ["cancelled", "sent"]
+        assert result.status == "unavailable"
+        assert result.cluster_status == "awaiting_review"
+        assert cluster.status == "awaiting_review"
+        assert cluster.delivery_round == 0
+        assert db.query(NewsReviewDelivery).one().status == "queued"
+        db.flush()
+        action_record = db.query(NewsEditorialAction).filter_by(action="regenerate").one()
+        assert action_record.outcome == "generation_external"
 
 
 def test_hermes_fallback_draft_is_not_delivered_or_requeued(monkeypatch) -> None:
@@ -1723,7 +1690,7 @@ def test_hermes_fallback_draft_is_not_delivered_or_requeued(monkeypatch) -> None
         assert enqueue_review_deliveries(db, {7001}) == 0
 
 
-def test_overlong_hermes_preview_sends_recovery_control_card(monkeypatch) -> None:
+def test_overlong_hermes_preview_is_not_delivered_to_owner(monkeypatch) -> None:
     cluster_id = _source_and_candidate(external_id="overlong-delivery-guard")
     draft_id, _ = _draft(cluster_id)
     monkeypatch.setattr(settings, "news_image_provider", "disabled")
@@ -1768,13 +1735,13 @@ def test_overlong_hermes_preview_sends_recovery_control_card(monkeypatch) -> Non
             )
 
     delivered = asyncio.run(deliver())
-    assert delivered == 1
+    assert delivered == 0
     assert preview_calls == []
-    assert control_calls == [7001]
+    assert control_calls == []
     with get_session_context() as db:
         delivery = db.query(NewsReviewDelivery).one()
-        assert delivery.status == "sent"
-        assert delivery.last_error_code is None
+        assert delivery.status == "failed"
+        assert delivery.last_error_code == "preview_delivery_blocked"
 
 
 def test_hermes_without_image_is_not_delivered_as_text_only(monkeypatch) -> None:
@@ -1810,7 +1777,7 @@ def test_hermes_without_image_is_not_delivered_as_text_only(monkeypatch) -> None
         assert delivery.last_error_code == "preview_delivery_blocked"
 
 
-def test_over_limit_photo_control_card_shows_measurement_and_recovery_actions(
+def test_over_limit_photo_review_message_shows_not_ready_state(
     monkeypatch,
 ) -> None:
     cluster_id = _source_and_candidate(external_id="over-limit-control")
@@ -1839,7 +1806,6 @@ def test_over_limit_photo_control_card_shows_measurement_and_recovery_actions(
         assert "Опубликовать сейчас" not in labels
         assert {
             "Изменить текст",
-            "Перегенерировать текст",
             "Убрать изображение",
             "Отклонить",
         }.issubset(labels)
@@ -1896,9 +1862,7 @@ def test_legacy_plain_snapshot_does_not_block_html_renderer_approval(monkeypatch
         assert current.link_preview_disabled is True
 
 
-def test_hermes_unsupported_number_reaches_owner_review_but_cannot_publish(
-    monkeypatch,
-) -> None:
+def test_hermes_unsupported_number_never_reaches_owner_review(monkeypatch) -> None:
     cluster_id = _source_and_candidate(external_id="hermes-unsupported-number-review")
     draft_id, _ = _draft(cluster_id)
 
@@ -1948,24 +1912,11 @@ def test_hermes_unsupported_number_reaches_owner_review_but_cannot_publish(
                 channel_ready=True,
             )
 
-    assert asyncio.run(deliver()) == 1
-    assert preview_calls == [7001]
-    assert len(control_calls) == 1
-
-    control = control_calls[0]
-    assert "unsupported_number" in control["text"]
-
-    callback_values = [
-        button["callback_data"]
-        for row in control["reply_markup"]["inline_keyboard"]
-        for button in row
-        if "callback_data" in button
-    ]
-
-    assert not any(value.startswith("newsp:p:") for value in callback_values)
-    assert not any(value.startswith("newsp:s:") for value in callback_values)
+    assert asyncio.run(deliver()) == 0
+    assert preview_calls == []
+    assert control_calls == []
 
     with get_session_context() as db:
         delivery = db.query(NewsReviewDelivery).one()
-        assert delivery.status == "sent"
-        assert delivery.last_error_code is None
+        assert delivery.status == "failed"
+        assert delivery.last_error_code == "preview_delivery_blocked"

--- a/deploy/hermes-discovery/discovery_runner.py
+++ b/deploy/hermes-discovery/discovery_runner.py
@@ -1302,7 +1302,14 @@ def run_once(
     }
 
 
-def mark_candidate_status(state_dir: Path, key: str, status: str, *, stale_seconds: float) -> None:
+def mark_candidate_status(
+    state_dir: Path,
+    key: str,
+    status: str,
+    *,
+    stale_seconds: float,
+    error_code: str | None = None,
+) -> None:
     if not HEX_64_PATTERN.fullmatch(key) or status not in {
         "accepted",
         "duplicate",
@@ -1317,6 +1324,10 @@ def mark_candidate_status(state_dir: Path, key: str, status: str, *, stale_secon
         if candidate is None:
             raise DiscoveryError("candidate_not_found")
         candidate["status"] = status
+        if error_code is not None:
+            if not re.fullmatch(r"[a-z0-9_.:-]{1,64}", error_code):
+                raise DiscoveryError("candidate_status_invalid")
+            candidate["error_code"] = error_code
         candidate["updated_at"] = datetime.now(UTC).replace(microsecond=0).isoformat()
         _atomic_write_json(state_path, state)
 

--- a/deploy/hermes-discovery/hermes_worker_drain.py
+++ b/deploy/hermes-discovery/hermes_worker_drain.py
@@ -2,8 +2,8 @@
 
 This host-side adapter is intentionally not part of the discovery container.  It
 is the only component here that receives provider and YFC intake credentials.  A
-failed or uncertain worker call leaves the same job file in place; no new
-idempotency key is generated.
+transient or uncertain worker call leaves the same job file in place; terminal
+validation/remediation failures are recorded and quarantined without retry.
 """
 
 from __future__ import annotations
@@ -44,6 +44,17 @@ WORKER_ENV_NAMES = (
     "YFC_HERMES_KEY_ID",
     "YFC_HERMES_SHARED_SECRET",
     "YFC_INTAKE_TIMEOUT_SECONDS",
+)
+TERMINAL_WORKER_ERRORS = frozenset(
+    {
+        "editorial_preflight_repair_failed",
+        "editorial_remediation_exhausted",
+        "intake_rejected",
+        "source_content_digest_mismatch",
+        "source_content_too_large",
+        "source_not_allowlisted",
+        "source_prompt_injection_blocked",
+    }
 )
 
 
@@ -234,7 +245,22 @@ def drain_once() -> dict[str, Any]:
                 else:
                     completed_jobs.append({"job": job.stem, "status": code})
             else:
-                failed_jobs.append({"job": job.stem, "code": code})
+                if code in TERMINAL_WORKER_ERRORS:
+                    try:
+                        mark_candidate_status(
+                            state_dir,
+                            job.stem,
+                            "failed",
+                            stale_seconds=float(stale_seconds),
+                            error_code=code,
+                        )
+                        job.unlink()
+                    except DiscoveryError, OSError:
+                        failed_jobs.append({"job": job.stem, "code": "state_update_failed"})
+                    else:
+                        failed_jobs.append({"job": job.stem, "code": code, "status": "terminal"})
+                else:
+                    failed_jobs.append({"job": job.stem, "code": code})
     return {
         "status": "completed" if not failed_jobs else "partial",
         "processed": completed_jobs,

--- a/deploy/hermes-editorial-worker/README.md
+++ b/deploy/hermes-editorial-worker/README.md
@@ -3,7 +3,7 @@
 Это минимальный non-root container для одной bounded editorial job. Он принимает
 source metadata/content packet из `/opt/data`, вызывает только OpenAI-compatible
 `chat/completions`, проверяет structured response и отправляет подписанный
-`hermes-editorial-intake-v1` в YFC. `HERMES_PROVIDER_MODE=local_mock` сохраняет
+`hermes-editorial-intake-v2` в YFC. `HERMES_PROVIDER_MODE=local_mock` сохраняет
 текущий local-only HTTP contract (`/v1` и localhost/`host.docker.internal`); после
 `accepted` он отправляет только preview-only payload в allowlisted local preview endpoint.
 
@@ -27,13 +27,13 @@ provider-neutral contract, но external mode сейчас принимает т
 candidate `openai/gpt-oss-120b`.
 
 До HMAC intake worker выполняет детерминированный editorial preflight: числовые токены draft
-должны быть заземлены в разрешённом source packet, а консервативная plain-text photo caption
-вместе с доверенным source URL и меткой `Источник` должна укладываться в лимит 1024 UTF-16
-символа Telegram. Для этих двух blocker worker может один раз запросить исправление у того же
-approved provider в рамках общего лимита попыток. Нерешённый blocker останавливает job
-fail-closed и не вызывает ни YFC intake, ни Telegram preview/autopublish. Успешный preflight
-не является approval публикации: `manual_required`, Gate B/C и единственный publisher остаются
-на стороне YFC.
+должны быть заземлены в разрешённом source packet, а видимый plain-text photo caption с меткой
+`Источник` должна укладываться в лимит 1024 UTF-16 символа Telegram. Если финальная YFC
+проверка находит recoverable blocker, worker запрашивает bounded repair у того же approved
+provider и отправляет новую immutable revision с новым idempotency key/nonce. Общий бюджет —
+максимум две попытки; после исчерпания job получает terminal remediation failure и не
+переигрывается бесконечно. Успешный preflight не является approval публикации:
+`manual_required`, Gate B/C и единственный publisher остаются на стороне YFC.
 
 Worker не содержит source fetching, scheduler, database client, shell/tool dispatch,
 browser, MCP, plugins, Telegram Bot API или publish endpoint. Полный Hermes monolith

--- a/deploy/hermes-editorial-worker/config.schema.json
+++ b/deploy/hermes-editorial-worker/config.schema.json
@@ -4,7 +4,7 @@
   "title": "Task 129 bounded Hermes editorial worker configuration",
   "type": "object",
   "additionalProperties": false,
-  "description": "Environment contract. local_mock accepts bounded localhost HTTP endpoints. external accepts only the pinned Groq and YFC HTTPS destinations and does not enable Telegram preview. Before HMAC intake the worker runs deterministic numeric-grounding and Telegram photo-caption preflight; the provider-attempt budget includes bounded repair.",
+  "description": "Environment contract. local_mock accepts bounded localhost HTTP endpoints. external accepts only the pinned Groq and YFC HTTPS destinations and does not enable Telegram preview. Before HMAC intake the worker runs deterministic numeric-grounding and visible Telegram photo-caption preflight; the global provider-attempt budget includes YFC remediation and immutable revision repair.",
   "properties": {
     "HERMES_HOME": {"type": "string", "const": "/opt/data", "default": "/opt/data"},
     "HERMES_SOURCE_ALLOWLIST": {"type": "string", "minLength": 1, "description": "Comma-separated YFC source IDs; the worker never fetches the URL."},
@@ -13,7 +13,7 @@
     "HERMES_PROVIDER_API_KEY": {"type": "string", "minLength": 1, "writeOnly": true},
     "HERMES_PROVIDER_MODEL": {"type": "string", "pattern": "^[A-Za-z0-9_.:/@-]{1,128}$"},
     "HERMES_PROVIDER_TIMEOUT_SECONDS": {"type": "number", "minimum": 0.1, "maximum": 30, "default": 3},
-    "HERMES_PROVIDER_MAX_ATTEMPTS": {"type": "integer", "minimum": 1, "maximum": 2, "default": 2, "description": "Global provider-attempt budget, including a bounded quality-repair request."},
+    "HERMES_PROVIDER_MAX_ATTEMPTS": {"type": "integer", "minimum": 1, "maximum": 2, "default": 2, "description": "Global provider-attempt budget, including local preflight and YFC quality-remediation requests."},
     "HERMES_PROVIDER_RETRY_BACKOFF_SECONDS": {"type": "number", "minimum": 0, "maximum": 2, "default": 0.25},
     "YFC_INTAKE_URL": {"type": "string", "pattern": "^https?://[^\\s]+/api/v1/hermes/editorial/intake$"},
     "YFC_HERMES_KEY_ID": {"type": "string", "pattern": "^[A-Za-z0-9_.:-]{1,64}$"},

--- a/deploy/hermes-editorial-worker/editorial_worker.py
+++ b/deploy/hermes-editorial-worker/editorial_worker.py
@@ -12,6 +12,7 @@ import hashlib
 import hmac
 import ipaddress
 import json
+import logging
 import os
 import re
 import sys
@@ -28,7 +29,7 @@ UPSTREAM_VERSION = "0.21.0"
 UPSTREAM_TAG = "v2026.8.31"
 UPSTREAM_COMMIT = "29112bef099274229cadff79cdff7bf7b99c4b77"
 JOB_SCHEMA_VERSION = "hermes-editorial-job-v1"
-INTAKE_SCHEMA_VERSION = "hermes-editorial-intake-v1"
+INTAKE_SCHEMA_VERSION = "hermes-editorial-intake-v2"
 PROMPT_VERSION = "task143-editorial-worker-v1"
 SKILL_VERSION = "yfc-hermes-editorial-v1"
 LOCAL_MOCK_MODE = "local_mock"
@@ -61,6 +62,7 @@ DRAFT_FIELD_LIMITS = {
 }
 TELEGRAM_PHOTO_CAPTION_LIMIT = 1024
 NUMBER_PATTERN = re.compile(r"(?<![\w])\d+(?:[.,]\d+)?(?:%|\s?(?:mg|g|kg|мг|г|кг))?")
+BLOCKER_CODE_PATTERN = re.compile(r"^[a-z0-9_.:-]{1,64}$")
 EXTERNAL_GPT_OSS_SOFT_BUDGETS = (
     "Soft editorial budgets (not JSON Schema constraints): headline <= 140 characters; "
     "summary uses the remaining available caption budget; why_it_matters <= 240 characters. "
@@ -77,6 +79,36 @@ class WorkerError(RuntimeError):
     def __init__(self, code: str) -> None:
         super().__init__(code)
         self.code = code
+
+
+class IntakeRemediationRequired(WorkerError):
+    def __init__(
+        self,
+        blockers: tuple[str, ...],
+        *,
+        attempt: int | None,
+        revision_id: str | None,
+    ) -> None:
+        super().__init__("remediation_required")
+        self.blockers = blockers
+        self.attempt = attempt
+        self.revision_id = revision_id
+
+
+class ProviderResult:
+    def __init__(
+        self,
+        proposal: DraftProposal,
+        *,
+        attempts: int,
+        original_blockers: tuple[str, ...] = (),
+    ) -> None:
+        self.proposal = proposal
+        self.attempts = attempts
+        self.original_blockers = original_blockers
+
+
+logger = logging.getLogger(__name__)
 
 
 class SourcePacket(BaseModel):
@@ -105,6 +137,13 @@ class SourcePacket(BaseModel):
             raise ValueError("source_url_must_be_https")
         if parsed.username or parsed.password or parsed.fragment:
             raise ValueError("source_url_must_not_have_credentials_or_fragment")
+        return value
+
+    @field_validator("content")
+    @classmethod
+    def validate_content_bytes(cls, value: str) -> str:
+        if len(value.encode("utf-8")) > MAX_SOURCE_CONTENT_BYTES:
+            raise ValueError("source_content_too_large")
         return value
 
 
@@ -391,19 +430,7 @@ def _trusted_source_url(source: SourcePacket) -> str:
 
 
 def _source_grounding_text(source: SourcePacket) -> str:
-    values = [
-        source.title,
-        source.summary,
-        source.content,
-        source.author,
-        source.publisher,
-        source.doi,
-    ]
-    if source.published_at is not None:
-        values.append(source.published_at.isoformat())
-    if source.updated_at is not None:
-        values.append(source.updated_at.isoformat())
-    return "\n".join(value for value in values if value)
+    return "\n".join((source.title, source.summary, source.content))
 
 
 def _proposal_text(proposal: DraftProposal) -> str:
@@ -411,10 +438,11 @@ def _proposal_text(proposal: DraftProposal) -> str:
 
 
 def _telegram_photo_caption_text(proposal: DraftProposal, source: SourcePacket) -> str:
+    del source
     parts = [proposal.headline, proposal.summary]
     if proposal.why_it_matters:
         parts.append(proposal.why_it_matters)
-    parts.append(f"Источник\n{_trusted_source_url(source)}")
+    parts.append("Источник")
     return "\n\n".join(parts)
 
 
@@ -428,7 +456,8 @@ def _telegram_photo_caption_length(proposal: DraftProposal, source: SourcePacket
 
 
 def _external_caption_draft_budget(source: SourcePacket) -> int:
-    trusted_source_line = f"Источник\n{_trusted_source_url(source)}"
+    del source
+    trusted_source_line = "Источник"
     reserved_separators = 3 * _telegram_character_count("\n\n")
     return max(
         0,
@@ -444,7 +473,8 @@ def _external_gpt_oss_soft_budgets(source: SourcePacket) -> str:
         f"{EXTERNAL_GPT_OSS_SOFT_BUDGETS} Use as much of the available source-grounded "
         "detail as useful, without filler or repetition. Keep the combined UTF-16 length "
         f"of the three draft fields at or below {available_budget} characters so the final "
-        "photo caption leaves room for the trusted source label and URL. This is a soft "
+        "photo caption leaves room for the trusted source label; the trusted link target is "
+        "bound separately. This is a soft "
         "editorial budget, not a JSON Schema constraint; the worker applies hard limits "
         "locally."
     )
@@ -478,7 +508,17 @@ def _repair_request_content(
         )
     if "telegram_photo_caption_too_long" in warnings:
         instructions.append(
-            f"telegram_photo_caption_too_long: shorten the plain-text photo caption, including the trusted source URL and the Источник label, to at most {TELEGRAM_PHOTO_CAPTION_LIMIT} UTF-16 characters while preserving the supported main fact and material limitation. Do not add the URL to any draft field."
+            f"telegram_photo_caption_too_long: shorten the visible plain-text photo caption, including the Источник label, to at most {TELEGRAM_PHOTO_CAPTION_LIMIT} UTF-16 characters while preserving the supported main fact and material limitation. The trusted source link target is bound separately; do not add the URL to any draft field."
+        )
+    other_warnings = tuple(
+        warning
+        for warning in warnings
+        if warning not in {"unsupported_number", "telegram_photo_caption_too_long"}
+    )
+    if other_warnings:
+        instructions.append(
+            "other editorial warnings: remove only the listed deterministic style or claim issues "
+            f"({', '.join(other_warnings)}) while preserving supported facts, uncertainty, and limitations."
         )
     return (
         "REPAIR_REQUEST\n"
@@ -725,7 +765,13 @@ def _provider_request_once(
         raise WorkerError("provider_schema_invalid") from exc
 
 
-def _provider_request(source: SourcePacket) -> DraftProposal:
+def _provider_request_bounded(
+    source: SourcePacket,
+    *,
+    repair_warnings: tuple[str, ...] = (),
+    previous_proposal: DraftProposal | None = None,
+    attempts_used: int = 0,
+) -> ProviderResult:
     mode = _provider_mode()
     base_url = _provider_base_url(mode)
     api_key = _required_env("HERMES_PROVIDER_API_KEY")
@@ -742,9 +788,8 @@ def _provider_request(source: SourcePacket) -> DraftProposal:
         DEFAULT_PROVIDER_RETRY_BACKOFF_SECONDS,
         maximum=2,
     )
-    repair_warnings: tuple[str, ...] = ()
-    previous_proposal: DraftProposal | None = None
-    for attempt in range(max_attempts):
+    original_blockers = list(repair_warnings)
+    for attempt in range(attempts_used, max_attempts):
         try:
             proposal = _provider_request_once(
                 source,
@@ -764,12 +809,21 @@ def _provider_request(source: SourcePacket) -> DraftProposal:
             continue
         warnings = _preflight_warnings(proposal, source)
         if not warnings:
-            return proposal
+            return ProviderResult(
+                proposal,
+                attempts=attempt + 1,
+                original_blockers=tuple(dict.fromkeys(original_blockers)),
+            )
         if attempt + 1 >= max_attempts:
             raise WorkerError("editorial_preflight_repair_failed")
-        repair_warnings = warnings
+        original_blockers.extend(warnings)
+        repair_warnings = tuple(dict.fromkeys(warnings))
         previous_proposal = proposal
     raise WorkerError("provider_unavailable")
+
+
+def _provider_request(source: SourcePacket) -> DraftProposal:
+    return _provider_request_bounded(source).proposal
 
 
 def _json_response(response: httpx.Response, *, limit: int, error_code: str) -> dict[str, Any]:
@@ -785,12 +839,36 @@ def _json_response(response: httpx.Response, *, limit: int, error_code: str) -> 
     return document
 
 
-def _build_intake_payload(job: EditorialJob, proposal: DraftProposal) -> bytes:
+def _revision_value(base: str, attempt: int, *, suffix: str) -> str:
+    value = f"{base}:{suffix}{attempt}"
+    if len(value) <= 128:
+        return value
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _build_intake_payload(
+    job: EditorialJob,
+    proposal: DraftProposal,
+    *,
+    attempt: int = 1,
+    parent_revision_id: str | None = None,
+    requested_blockers: tuple[str, ...] = (),
+) -> bytes:
     source = job.source
+    idempotency_key = (
+        job.idempotency_key
+        if attempt == 1
+        else _revision_value(job.idempotency_key, attempt, suffix="revision-")
+    )
+    request_nonce = (
+        job.request_nonce
+        if attempt == 1
+        else _revision_value(job.request_nonce, attempt, suffix="nonce-")
+    )
     payload = {
         "schema_version": INTAKE_SCHEMA_VERSION,
-        "idempotency_key": job.idempotency_key,
-        "request_nonce": job.request_nonce,
+        "idempotency_key": idempotency_key,
+        "request_nonce": request_nonce,
         "source": {
             "source_id": source.source_id,
             "external_id": source.external_id,
@@ -798,12 +876,14 @@ def _build_intake_payload(job: EditorialJob, proposal: DraftProposal) -> bytes:
             "primary_url": source.primary_url,
             "title": source.title,
             "summary": source.summary,
+            "content": source.content,
             "author": source.author,
             "publisher": source.publisher,
             "published_at": source.published_at.isoformat() if source.published_at else None,
             "updated_at": source.updated_at.isoformat() if source.updated_at else None,
             "doi": source.doi,
             "content_hash": _canonical_source_hash(source),
+            "content_sha256": hashlib.sha256(source.content.encode("utf-8")).hexdigest(),
         },
         "draft": proposal.model_dump(),
         "provenance": {
@@ -811,6 +891,12 @@ def _build_intake_payload(job: EditorialJob, proposal: DraftProposal) -> bytes:
             "model": _provider_model(),
             "prompt_version": PROMPT_VERSION,
             "skill_version": SKILL_VERSION,
+        },
+        "revision": {
+            "revision_id": _revision_value(job.job_id, attempt, suffix="revision-"),
+            "parent_revision_id": parent_revision_id,
+            "attempt": attempt,
+            "requested_blockers": list(dict.fromkeys(requested_blockers))[:8],
         },
     }
     return json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode(
@@ -823,7 +909,14 @@ def _post_intake(job: EditorialJob, body: bytes) -> IntakeResponse:
     key_id = _required_env("YFC_HERMES_KEY_ID")
     secret = _required_env("YFC_HERMES_SHARED_SECRET")
     timestamp = str(int(time.time()))
-    message = timestamp.encode("ascii") + b"\n" + job.request_nonce.encode("ascii") + b"\n" + body
+    try:
+        request_document = json.loads(body.decode("utf-8"))
+        request_nonce = request_document["request_nonce"]
+        if not isinstance(request_nonce, str):
+            raise TypeError("request_nonce_invalid")
+    except (UnicodeDecodeError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise WorkerError("intake_request_invalid") from exc
+    message = timestamp.encode("ascii") + b"\n" + request_nonce.encode("ascii") + b"\n" + body
     signature = "sha256=" + hmac.new(secret.encode("utf-8"), message, hashlib.sha256).hexdigest()
     timeout_seconds = _bounded_timeout("YFC_INTAKE_TIMEOUT_SECONDS", "5")
     timeout = httpx.Timeout(timeout_seconds, connect=timeout_seconds)
@@ -837,7 +930,7 @@ def _post_intake(job: EditorialJob, body: bytes) -> IntakeResponse:
                     "Content-Type": "application/json",
                     "X-Hermes-Key-Id": key_id,
                     "X-Hermes-Timestamp": timestamp,
-                    "X-Hermes-Nonce": job.request_nonce,
+                    "X-Hermes-Nonce": request_nonce,
                     "X-Hermes-Signature": signature,
                 },
                 content=body,
@@ -851,6 +944,31 @@ def _post_intake(job: EditorialJob, body: bytes) -> IntakeResponse:
             if status_code >= 500:
                 raise WorkerError("intake_server_error")
             if status_code >= 400:
+                if status_code == 422:
+                    document = _json_response(
+                        response,
+                        limit=MAX_INTAKE_RESPONSE_BYTES,
+                        error_code="intake_response_invalid",
+                    )
+                    detail = document.get("detail")
+                    if isinstance(detail, dict) and detail.get("code") == "remediation_required":
+                        raw_blockers = detail.get("blockers", [])
+                        blockers = tuple(
+                            dict.fromkeys(
+                                value
+                                for value in raw_blockers
+                                if isinstance(value, str) and BLOCKER_CODE_PATTERN.fullmatch(value)
+                            )
+                        )[:8]
+                        if not blockers:
+                            raise WorkerError("intake_response_invalid")
+                        attempt = detail.get("attempt")
+                        revision_id = detail.get("revision_id")
+                        raise IntakeRemediationRequired(
+                            blockers,
+                            attempt=attempt if isinstance(attempt, int) else None,
+                            revision_id=revision_id if isinstance(revision_id, str) else None,
+                        )
                 raise WorkerError("intake_rejected")
             document = _json_response(
                 response, limit=MAX_INTAKE_RESPONSE_BYTES, error_code="intake_response_invalid"
@@ -919,14 +1037,78 @@ def run_job(job: EditorialJob) -> dict[str, Any]:
     if _contains_prompt_injection(job.source):
         raise WorkerError("source_prompt_injection_blocked")
     expected_hash = _canonical_source_hash(job.source)
-    # The packet has no caller-supplied hash field: the worker derives the exact YFC hash.
-    proposal = _provider_request(job.source)
-    preflight_warnings = _preflight_warnings(proposal, job.source)
-    if preflight_warnings:
-        raise WorkerError("editorial_preflight_repair_failed")
+    provider_result = _provider_request_bounded(job.source)
+    proposal = provider_result.proposal
+    provider_attempt = provider_result.attempts
+    original_blockers = provider_result.original_blockers
+    parent_revision_id: str | None = None
+    while True:
+        preflight_warnings = _preflight_warnings(proposal, job.source)
+        if preflight_warnings:
+            raise WorkerError("editorial_preflight_repair_failed")
+        revision_id = _revision_value(job.job_id, provider_attempt, suffix="revision-")
+        body = _build_intake_payload(
+            job,
+            proposal,
+            attempt=provider_attempt,
+            parent_revision_id=parent_revision_id,
+            requested_blockers=original_blockers,
+        )
+        logger.info(
+            "hermes_editorial_intake_attempt",
+            extra={
+                "pipeline_stage": "hermes_intake",
+                "event": "intake_attempt",
+                "revision_id": revision_id,
+                "attempt": provider_attempt,
+                "requested_blockers": list(original_blockers),
+            },
+        )
+        try:
+            intake = _post_intake(job, body)
+        except IntakeRemediationRequired as exc:
+            if provider_attempt >= _bounded_int(
+                "HERMES_PROVIDER_MAX_ATTEMPTS",
+                DEFAULT_PROVIDER_MAX_ATTEMPTS,
+                minimum=1,
+                maximum=2,
+            ):
+                logger.error(
+                    "hermes_editorial_remediation_failed",
+                    extra={
+                        "pipeline_stage": "hermes_intake",
+                        "event": "remediation_failed",
+                        "revision_id": revision_id,
+                        "attempt": provider_attempt,
+                        "blockers": list(exc.blockers),
+                    },
+                )
+                raise WorkerError("editorial_remediation_exhausted") from exc
+            logger.info(
+                "hermes_editorial_remediation_started",
+                extra={
+                    "pipeline_stage": "hermes_intake",
+                    "event": "remediation_started",
+                    "revision_id": revision_id,
+                    "attempt": provider_attempt,
+                    "blockers": list(exc.blockers),
+                },
+            )
+            next_result = _provider_request_bounded(
+                job.source,
+                repair_warnings=exc.blockers,
+                previous_proposal=proposal,
+                attempts_used=provider_attempt,
+            )
+            proposal = next_result.proposal
+            provider_attempt = next_result.attempts
+            original_blockers = tuple(
+                dict.fromkeys((*original_blockers, *exc.blockers, *next_result.original_blockers))
+            )
+            parent_revision_id = revision_id
+            continue
+        break
     photo_caption_length = _telegram_photo_caption_length(proposal, job.source)
-    body = _build_intake_payload(job, proposal)
-    intake = _post_intake(job, body)
     preview: PreviewResponse | None = None
     if intake.status == "accepted" and mode == LOCAL_MOCK_MODE:
         preview = _post_preview(job, intake)
@@ -945,6 +1127,11 @@ def run_job(job: EditorialJob) -> dict[str, Any]:
             "status": "passed",
             "telegram_photo_caption_length": photo_caption_length,
             "telegram_photo_caption_limit": TELEGRAM_PHOTO_CAPTION_LIMIT,
+        },
+        "remediation": {
+            "attempt": provider_attempt,
+            "blockers": list(original_blockers),
+            "parent_revision_id": parent_revision_id,
         },
         "preview": {
             "status": preview.status
@@ -979,7 +1166,7 @@ def _self_check() -> dict[str, Any]:
         "telegram": "preview-only-local-contract; absent in external mode",
         "provider_fallback": "disabled; manual/no-provider only",
         "editorial_preflight": "numeric-grounding-and-photo-caption-before-intake",
-        "editorial_repair": "same-provider; maximum-two-total-attempts; unresolved-fail-closed",
+        "editorial_repair": "same-provider; maximum-two-total-attempts; new-immutable-revision; unresolved-terminal-failure",
         "provider_cost_policy": "free-only candidate; no automatic paid tier",
         "tools_exposed": 0,
         "terminal_execution": "disabled",

--- a/deploy/hermes-editorial-worker/hermes-provenance.json
+++ b/deploy/hermes-editorial-worker/hermes-provenance.json
@@ -17,7 +17,7 @@
   "worker": {
     "version": "editorial-worker-v1",
     "jobSchema": "hermes-editorial-job-v1",
-    "intakeSchema": "hermes-editorial-intake-v1",
+    "intakeSchema": "hermes-editorial-intake-v2",
     "promptVersion": "task129-editorial-worker-v2",
     "skillVersion": "yfc-hermes-editorial-v1",
     "sourceBehaviorPatches": 0,

--- a/docs/telegram-news-editorial-automation.md
+++ b/docs/telegram-news-editorial-automation.md
@@ -24,9 +24,9 @@ NEWS_PUBLICATION_ENABLED=false
 `evidence_metadata["submitted_by"] == "hermes_narrow_intake"`. Активные non-Hermes leftovers
 обрабатываются fail-closed: owner deliveries и исполняемые publication snapshots отменяются,
 а активные legacy clusters переводятся в terminal quarantine. Уже опубликованная история остаётся
-читаемой. Hermes owner-edited revisions сохраняют marker. Действие «Перегенерировать текст»
-повторно ставит принятую immutable Hermes revision в review flow и не создаёт локальный
-candidate/draft.
+читаемой. Hermes owner-edited revisions сохраняют marker. Действие «Перегенерировать текст» не
+переигрывает принятую immutable revision: новый текст может прийти только отдельной Hermes
+revision через bounded remediation contract.
 
 Для editorial intake действует rolling-окно свежести в 60 дней: границы включаются, будущие и
 неизвестные даты отклоняются. Это product/discovery heuristic, а не медицинская норма. Owner-
@@ -36,14 +36,11 @@ candidate/draft.
 Очередь, изображения и другие downstream-этапы продолжают обрабатываться между слотами, но новые
 Telegram review cards вне этих окон не отправляются.
 
-Hermes может передавать владельцу полноценный exact preview и управляющую карточку для тем,
-которые требуют ручного решения: AAS/фармакология/пептиды/БАДы и дозировки. Такие карточки не
-включаются в autopublish: `NEWS_AUTO_PUBLISH_LOW_RISK` остаётся `false`, а существующие
-publication quality gates сохраняют право скрыть кнопку публикации до редактирования текста.
-Это расширяет только ручной editorial recall. Malformed provider response, fallback-заглушка и
-отсутствующее Hermes image по-прежнему остаются hard delivery blockers. Recoverable
-publication-quality warnings `unsupported_number` и `telegram_photo_caption_too_long` могут
-дойти до owner review, но продолжают блокировать publication до исправления.
+Темы, которые требуют ручного решения: AAS/фармакология/пептиды/БАДы и дозировки, могут попасть
+в owner review только после bounded remediation и полного ready-gate. Такие карточки не
+включаются в autopublish: `NEWS_AUTO_PUBLISH_LOW_RISK` остаётся `false`. Malformed provider
+response, fallback-заглушка, recoverable warning, missing artifact/hash/image, disabled publication
+и missing channel rights остаются delivery blockers и владельцу не отправляются.
 
 После production release целевые значения для разделения контуров такие:
 
@@ -96,48 +93,42 @@ X-Hermes-Nonce           # unique replay-protection value
 X-Hermes-Signature       # sha256=<lowercase hex digest>
 ```
 
-The payload is `hermes-editorial-intake-v1`, with one allowlisted source packet, one structured
-draft proposal and provider/model/prompt/skill provenance.  The source content hash is recomputed
-by YFC.  Idempotency key and nonce are unique in `hermes_editorial_submissions`; a repeated exact
-request returns the same draft as `duplicate`, while a changed payload or replayed nonce fails
-closed.  Body size, source count, clock skew, replay TTL and request rate are configured by the
-`HERMES_INTAKE_*` variables in `.env.example`.
+The payload is `hermes-editorial-intake-v2`, with one allowlisted source packet including bounded
+source content/evidence digest, one structured draft proposal, provider/model/prompt/skill
+provenance and an immutable revision context. The source metadata hash and content digest are
+recomputed by YFC. Idempotency key and nonce are unique in
+`hermes_editorial_submissions`; a repeated exact request returns the same draft as `duplicate`,
+while a changed payload or replayed nonce fails closed. Body size, source count, clock skew, replay
+TTL and request rate are configured by the `HERMES_INTAKE_*` variables in `.env.example`.
 
 Receipts retain only operational metadata and hashes, never the full submitted source or draft
 payload.  Normal logs contain correlation-safe ids/reason codes only.
 
-### Hermes deterministic preflight and bounded repair (Task 142)
+### Hermes deterministic preflight and bounded repair (Task 238)
 
 Перед HMAC intake worker выполняет детерминированный preflight. Числовые токены в draft должны
 быть заземлены в разрешённом source packet; идентификаторы и URL не считаются доказательством
-числового утверждения. Консервативный plain-text photo caption считается вместе с доверенным
-source URL и меткой `Источник` и должен укладываться в лимит 1024 UTF-16 символа, установленный
+числового утверждения. Видимый plain-text photo caption с меткой `Источник` (URL находится в
+HTML `href` и не является видимым текстом) должен укладываться в лимит 1024 UTF-16 символа, установленный
 [официальной документацией Telegram Bot API](https://core.telegram.org/bots/api).
-Внешний GPT-OSS prompt получает динамический мягкий бюджет для трёх полей с учётом длины
-доверенного URL и служебных разделителей, чтобы использовать доступное место для подтверждённых
-деталей без filler; лимит 1024 и hard limits полей не изменяются.
+Внешний GPT-OSS prompt получает динамический мягкий бюджет для трёх полей с учётом служебной
+метки и разделителей, чтобы использовать доступное место для подтверждённых деталей без filler;
+trusted source URL остаётся HTML `href`, а лимит 1024 и hard limits полей не изменяются.
 
-Для `unsupported_number` и `telegram_photo_caption_too_long` разрешён один bounded repair request
-к тому же approved provider. Он делит общий бюджет максимум двух provider attempts с исходным
-draft и transient retry; paid/cloud fallback, новые credentials и provider shortcut запрещены.
-Если repair не снимает blocker, worker завершает job fail-closed: HMAC intake, Telegram preview
-и autopublish не вызываются. Успешный preflight только допускает intake; он не подтверждает
-публикацию. YFC по-прежнему применяет `manual_required`, Gate B/C и остаётся единственным
-publisher.
+Для любого детерминированного recoverable blocker YFC возвращает worker-у структурированный
+`remediation_required` без создания draft. Hermes запрашивает repair у того же approved provider
+и отправляет новую immutable revision с новым idempotency key/nonce и parent revision. Общий
+provider budget — максимум две попытки; после исчерпания job получает terminal
+`editorial_remediation_exhausted` и не переигрывается бесконечно. Paid/cloud fallback, новые
+credentials и provider shortcut запрещены.
 
-YFC имеет дополнительный final delivery gate. Hard preview states — fallback/provider failure и
-отсутствующее Hermes image — остаются fail-closed и не отправляются владельцу как готовый
-review item. Recoverable publication-quality warnings `unsupported_number` и
-`telegram_photo_caption_too_long` не должны скрывать материал из owner review queue: они
-остаются publication blockers и поэтому не дают кнопок publish/schedule.
-
-При `unsupported_number`, если exact artifact и image доступны, владельцу отправляются private
-preview и управляющая карточка. При `telegram_photo_caption_too_long` exact publication artifact
-может быть недоступен из-за лимита Telegram; тогда photo preview не отправляется, но владелец
-получает recovery/control card с действиями редактирования, перегенерации, отклонения и defer.
-Публикация остаётся запрещённой, пока blocker не устранён. Операционные состояния
-`publishing_disabled` и `channel_rights_missing` не превращают blocked material в publishable
-fallback.
+YFC имеет final ready-only gate. В scheduled Telegram review попадает только материал с точным
+artifact, artifact hash, обязательным image и пустым списком blockers/warnings; recoverable
+warnings, fallback/provider failure, missing image, disabled publication и missing channel rights
+не отправляются владельцу. Поэтому карточка ready-публикации содержит как минимум
+`Опубликовать сейчас`, `Запланировать`, `Отклонить` и `Открыть источник`; edit/image
+controls остаются только вторичными emergency actions. Batch size 5 считает только отправленные
+ready-публикации, а blocked/failed candidates слот не расходуют. Автопубликации нет.
 
 ## Taxonomy and policy
 
@@ -172,10 +163,9 @@ blocked | manual_required | auto_eligible
 Чувствительные medical/pharmacology, peptides, AAS/SARMs, dosage/cycle/protocol,
 индивидуальные рекомендации, pregnancy/minors/chronic disease/symptoms, interactions,
 recalls/contamination, preliminary или conflicting evidence и любая неоднозначность имеют как
-минимум `manual_required`; Hermes intake может доставить их владельцу как полноценный preview для
-ручного решения. Prompt injection и явные unsafe/guaranteed claims по-прежнему остаются hard
-blockers. `unsupported_number` может быть доставлен владельцу для ручного исправления, но
-остаётся publication blocker. `auto_eligible` дополнительно требует
+минимум `manual_required`, но recoverable quality warning сначала должен быть устранён Hermes
+repair-циклом. Prompt injection и явные unsafe/guaranteed claims по-прежнему остаются hard
+blockers. `auto_eligible` дополнительно требует
 owner-controlled `NEWS_AUTO_PUBLISH_LOW_RISK=true`, valid source provenance, quality checks, exact
 snapshot и active kill-switch. Committed default — `false`.
 
@@ -381,9 +371,10 @@ owner-approved config/code change. Будущий optional paid fallback — Ope
 подключён, credentials не создаются и автоматическим fallback не является. Gemini и OpenRouter
 не подключаются.
 
-В external mode наружу уходит source metadata/content packet только в approved Groq endpoint и
-structured draft metadata в approved YFC intake; source URL не fetch'ится, а YFC intake получает
-content hash вместо полного source content. Retention, training/model-improvement policy,
+В external mode наружу уходит bounded source metadata/content packet только в approved Groq endpoint
+и structured draft metadata в approved YFC intake; source URL не fetch'ится, а YFC intake получает
+только bounded content для финальной numeric-grounding проверки и его digest, не сохраняя полный
+source body в БД. Retention, training/model-improvement policy,
 processing/storage region, privacy terms и фактическая cost/quota policy Groq для конкретного
 account до owner verification не считаются подтверждёнными. Качество реальной модели проверяется
 только в owner-approved shadow-run после Gate A; local fake E2E не является model-quality proof.

--- a/tests/integration/hermes_editorial_worker/test_worker_contract.py
+++ b/tests/integration/hermes_editorial_worker/test_worker_contract.py
@@ -209,7 +209,7 @@ def test_preflight_repairs_unsupported_number_with_same_provider(monkeypatch) ->
 def test_preflight_repairs_photo_caption_with_trusted_source_url(monkeypatch) -> None:
     rejected = {
         "headline": "З" * 180,
-        "summary": "С" * 810,
+        "summary": "С" * 840,
         "why_it_matters": "",
     }
     repaired = {
@@ -273,7 +273,9 @@ def test_unresolved_repair_fails_closed_before_hmac_intake(monkeypatch) -> None:
     assert calls == 2
 
 
-def test_intake_payload_excludes_source_content(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_intake_payload_binds_source_evidence_and_new_revision_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("HERMES_PROVIDER_MODEL", "local-model")
     body = editorial_worker._build_intake_payload(
         valid_job(),
@@ -284,10 +286,108 @@ def test_intake_payload_excludes_source_content(monkeypatch: pytest.MonkeyPatch)
         ),
     )
     document = json.loads(body)
-    assert "content" not in document["source"]
+    assert document["source"]["content"] == valid_job().source.content
     assert document["source"]["content_hash"] == editorial_worker._canonical_source_hash(
         valid_job().source
     )
+    assert (
+        document["source"]["content_sha256"]
+        == editorial_worker.hashlib.sha256(valid_job().source.content.encode("utf-8")).hexdigest()
+    )
+    assert document["revision"]["attempt"] == 1
+    assert document["revision"]["parent_revision_id"] is None
+
+
+def test_yfc_remediation_creates_new_immutable_revision(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HERMES_PROVIDER_MODE", editorial_worker.EXTERNAL_MODE)
+    monkeypatch.setenv("HERMES_SOURCE_ALLOWLIST", "journal-one")
+    monkeypatch.setenv("HERMES_PROVIDER_MODEL", editorial_worker.EXTERNAL_PROVIDER_MODEL)
+    proposal = editorial_worker.DraftProposal(
+        headline="Заголовок исследования",
+        summary="Проверяемый текст без неподтверждённых чисел.",
+        why_it_matters="Материал требует редакторской проверки.",
+    )
+    provider_calls: list[tuple[tuple[str, ...], int]] = []
+
+    def provider(
+        _source,
+        *,
+        repair_warnings=(),
+        previous_proposal=None,
+        attempts_used=0,
+    ):
+        provider_calls.append((tuple(repair_warnings), attempts_used))
+        assert previous_proposal is None or previous_proposal == proposal
+        return editorial_worker.ProviderResult(proposal, attempts=attempts_used + 1)
+
+    bodies: list[dict[str, object]] = []
+
+    def post(_job, body):
+        document = json.loads(body)
+        bodies.append(document)
+        if len(bodies) == 1:
+            raise editorial_worker.IntakeRemediationRequired(
+                ("unsupported_number",),
+                attempt=1,
+                revision_id=document["revision"]["revision_id"],
+            )
+        return editorial_worker.IntakeResponse(
+            status="accepted",
+            submission_id="submission-remediated",
+            cluster_id="cluster-remediated",
+            draft_id="draft-remediated",
+            publication_policy="manual_required",
+            risk_reasons=[],
+            preview_text="preview is owned by YFC",
+        )
+
+    monkeypatch.setattr(editorial_worker, "_provider_request_bounded", provider)
+    monkeypatch.setattr(editorial_worker, "_post_intake", post)
+
+    result = editorial_worker.run_job(valid_job())
+
+    assert result["remediation"]["attempt"] == 2
+    assert result["remediation"]["parent_revision_id"] == bodies[0]["revision"]["revision_id"]
+    assert len(provider_calls) == 2
+    assert provider_calls[1] == (("unsupported_number",), 1)
+    assert bodies[0]["idempotency_key"] != bodies[1]["idempotency_key"]
+    assert bodies[0]["request_nonce"] != bodies[1]["request_nonce"]
+    assert bodies[1]["revision"]["parent_revision_id"] == bodies[0]["revision"]["revision_id"]
+    assert bodies[1]["revision"]["attempt"] == 2
+
+
+def test_yfc_remediation_exhaustion_is_terminal_and_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HERMES_PROVIDER_MODE", editorial_worker.EXTERNAL_MODE)
+    monkeypatch.setenv("HERMES_SOURCE_ALLOWLIST", "journal-one")
+    monkeypatch.setenv("HERMES_PROVIDER_MODEL", editorial_worker.EXTERNAL_PROVIDER_MODEL)
+    proposal = editorial_worker.DraftProposal(
+        headline="Заголовок исследования",
+        summary="Проверяемый текст без неподтверждённых чисел.",
+        why_it_matters="Материал требует редакторской проверки.",
+    )
+    calls = 0
+
+    def provider(_source, *, repair_warnings=(), previous_proposal=None, attempts_used=0):
+        nonlocal calls
+        calls += 1
+        return editorial_worker.ProviderResult(proposal, attempts=attempts_used + 1)
+
+    def post(_job, body):
+        document = json.loads(body)
+        raise editorial_worker.IntakeRemediationRequired(
+            ("unsupported_number",),
+            attempt=document["revision"]["attempt"],
+            revision_id=document["revision"]["revision_id"],
+        )
+
+    monkeypatch.setattr(editorial_worker, "_provider_request_bounded", provider)
+    monkeypatch.setattr(editorial_worker, "_post_intake", post)
+
+    with pytest.raises(editorial_worker.WorkerError, match="editorial_remediation_exhausted"):
+        editorial_worker.run_job(valid_job())
+    assert calls == 2
 
 
 def test_untrusted_source_and_capability_fields_fail_closed() -> None:
@@ -318,6 +418,14 @@ def test_source_packet_preserves_safe_query_but_rejects_fragment() -> None:
     with pytest.raises(ValidationError):
         editorial_worker.SourcePacket.model_validate(
             valid_job().source.model_dump() | {"canonical_url": "https://example.com/unit#fragment"}
+        )
+
+
+def test_source_packet_bounds_utf8_content_bytes() -> None:
+    with pytest.raises(ValidationError, match="source_content_too_large"):
+        editorial_worker.SourcePacket.model_validate(
+            valid_job().source.model_dump()
+            | {"content": "я" * editorial_worker.MAX_SOURCE_CONTENT_BYTES}
         )
 
 
@@ -539,7 +647,7 @@ def test_local_mock_payload_does_not_use_external_gpt_oss_contract() -> None:
     assert request["temperature"] == 0
 
 
-def test_external_soft_budget_accounts_for_trusted_url_and_caption_overhead() -> None:
+def test_external_soft_budget_accounts_for_visible_caption_overhead() -> None:
     source = valid_job().source
     base_budget = editorial_worker._external_caption_draft_budget(source)
     prompt = editorial_worker._external_gpt_oss_messages(source)[0]["content"]
@@ -551,7 +659,7 @@ def test_external_soft_budget_accounts_for_trusted_url_and_caption_overhead() ->
     source_with_longer_url = source.model_copy(
         update={"primary_url": "https://example.com/" + ("long-path/" * 8)}
     )
-    assert editorial_worker._external_caption_draft_budget(source_with_longer_url) < base_budget
+    assert editorial_worker._external_caption_draft_budget(source_with_longer_url) == base_budget
 
 
 def test_external_mode_rejects_arbitrary_provider_model(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -620,11 +728,14 @@ def test_external_mode_never_requires_or_calls_telegram_preview(
     monkeypatch.delenv("TELEGRAM_PREVIEW_TIMEOUT_SECONDS", raising=False)
     monkeypatch.setattr(
         editorial_worker,
-        "_provider_request",
-        lambda _source: editorial_worker.DraftProposal(
-            headline="Заголовок",
-            summary="Проверяемый текст",
-            why_it_matters="Ограниченный смысл",
+        "_provider_request_bounded",
+        lambda _source: editorial_worker.ProviderResult(
+            editorial_worker.DraftProposal(
+                headline="Заголовок",
+                summary="Проверяемый текст",
+                why_it_matters="Ограниченный смысл",
+            ),
+            attempts=1,
         ),
     )
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Closes #238.

- Enforces a server-side Hermes ready-only owner-review gate: exact artifact, artifact hash, required image, no blockers and no warnings.
- Adds `hermes-editorial-intake-v2` with bounded source content digest and immutable remediation revision context.
- Returns structured recoverable blockers to Hermes; same-provider remediation is bounded to two attempts and uses a new idempotency key, nonce and revision identity.
- Removes fake YFC text regeneration/requeue and keeps emergency edit/image controls secondary; normal ready cards expose publish, schedule, reject and source actions.
- Counts only delivered ready drafts toward the scheduled batch; terminal worker rejection/remediation failure is quarantined without infinite retry.
- Preserves Task 230 explicit Telegram transport/proxy behavior; no production env keys or values changed.

## Verification

- `119 passed` Hermes/YFC targeted profile.
- `69 passed, 2 skipped` discovery/schedule/retirement/freshness profile.
- Ruff lint and format, compileall, JSON validation, pre-commit hooks including backend mypy: PASS.
- No live provider, Telegram, production database or paid external call was used locally.

## Release contract

- `env change required: no`.
- Autopublish remains disabled.
- No migration or dependency change.
- Production release must verify exact merged SHA, ready-only cards, artifact/hash/image/blocker evidence, batch semantics, remediation terminal state and Task 230 proxy health.