### PR TITLE
[Task 92B] Deliver privacy-safe AI Coach telemetry

### DIFF
--- a/backend/fitminiapp_api/core/logging_config.py
+++ b/backend/fitminiapp_api/core/logging_config.py
@@ -9,6 +9,7 @@ from typing import Any
 
 URL_PATTERN = re.compile(r"https?://[^\s\"'<>]+", re.IGNORECASE)
 SAFE_CODE_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9_.:-]{0,127}\Z")
+SAFE_IDENTIFIER_PATTERN = re.compile(r"[A-Za-z0-9_.:/-]{1,128}\Z")
 SAFE_REQUEST_ID_PATTERN = re.compile(r"[A-Za-z0-9._:-]{1,128}\Z")
 SAFE_METHOD_PATTERN = re.compile(r"[A-Z]{3,10}\Z")
 SAFE_ROUTE_PATTERN = re.compile(r"(?:/[A-Za-z0-9_./{}:-]{0,255}|unmatched)\Z")
@@ -16,6 +17,7 @@ SAFE_EVENT_NAMES = frozenset(
     {
         "application_started",
         "application_stopped",
+        "ai_coach_generation",
         "auth_email_delivery_failed",
         "food_provider_barcode_unavailable",
         "food_provider_search_unavailable",
@@ -53,6 +55,7 @@ SAFE_PROVIDER_NAMES = frozenset(
         "apple",
         "deterministic",
         "google",
+        "groq",
         "open_food_facts",
         "openai_compatible",
         "telegram",
@@ -73,13 +76,23 @@ STRUCTURED_FIELDS = (
     "db_pool_checked_out",
     "db_pool_overflow",
     "body_limit_bytes",
+    "job",
+    "data_class",
+    "tool_name",
+    "prompt_version",
+    "schema_version",
+    "policy_revision",
     "notification_ref",
     "notification_category",
     "delivery_error",
     "provider",
+    "configured_model",
+    "actual_model",
     "reason",
     "pipeline_stage",
     "outcome",
+    "error_code",
+    "safety_category",
     "source_ref",
     "candidate_ref",
     "topic",
@@ -89,7 +102,15 @@ STRUCTURED_FIELDS = (
     "candidate_count",
     "queue_age_seconds",
     "attempt_count",
+    "attempts",
+    "retry_count",
     "latency_ms",
+    "prompt_tokens",
+    "completion_tokens",
+    "total_tokens",
+    "cost_microunits",
+    "report_version",
+    "report_revision",
     "issue_count",
     "queued",
     "processing",
@@ -119,6 +140,12 @@ INTEGER_FIELDS = {
     "db_pool_checked_out",
     "db_pool_overflow",
     "body_limit_bytes",
+    "attempts",
+    "retry_count",
+    "prompt_tokens",
+    "completion_tokens",
+    "total_tokens",
+    "cost_microunits",
     "items_count",
     "duplicate_count",
     "candidate_count",
@@ -152,13 +179,24 @@ CODE_FIELDS = {
     "notification_ref",
     "notification_category",
     "delivery_error",
+    "job",
+    "data_class",
+    "tool_name",
+    "prompt_version",
+    "schema_version",
+    "policy_revision",
     "reason",
     "pipeline_stage",
     "outcome",
+    "error_code",
+    "safety_category",
     "source_ref",
     "candidate_ref",
     "topic",
+    "report_version",
+    "report_revision",
 }
+MODEL_FIELDS = {"configured_model", "actual_model"}
 
 
 class JsonFormatter(logging.Formatter):
@@ -214,6 +252,8 @@ class JsonFormatter(logging.Formatter):
             return value if SAFE_ROUTE_PATTERN.fullmatch(value) else None
         if field == "provider":
             return value if value in SAFE_PROVIDER_NAMES else None
+        if field in MODEL_FIELDS:
+            return value if SAFE_IDENTIFIER_PATTERN.fullmatch(value) else None
         if field in CODE_FIELDS:
             return value if SAFE_CODE_PATTERN.fullmatch(value) else None
         return None

--- a/backend/fitminiapp_api/core/logging_config.py
+++ b/backend/fitminiapp_api/core/logging_config.py
@@ -11,6 +11,7 @@ URL_PATTERN = re.compile(r"https?://[^\s\"'<>]+", re.IGNORECASE)
 SAFE_CODE_PATTERN = re.compile(r"[A-Za-z][A-Za-z0-9_.:-]{0,127}\Z")
 SAFE_IDENTIFIER_PATTERN = re.compile(r"[A-Za-z0-9_.:/-]{1,128}\Z")
 SAFE_REQUEST_ID_PATTERN = re.compile(r"[A-Za-z0-9._:-]{1,128}\Z")
+SAFE_REPORT_REVISION_PATTERN = re.compile(r"[0-9a-f]{64}\Z", re.IGNORECASE)
 SAFE_METHOD_PATTERN = re.compile(r"[A-Z]{3,10}\Z")
 SAFE_ROUTE_PATTERN = re.compile(r"(?:/[A-Za-z0-9_./{}:-]{0,255}|unmatched)\Z")
 SAFE_EVENT_NAMES = frozenset(
@@ -254,6 +255,8 @@ class JsonFormatter(logging.Formatter):
             return value if value in SAFE_PROVIDER_NAMES else None
         if field in MODEL_FIELDS:
             return value if SAFE_IDENTIFIER_PATTERN.fullmatch(value) else None
+        if field == "report_revision":
+            return value if SAFE_REPORT_REVISION_PATTERN.fullmatch(value) else None
         if field in CODE_FIELDS:
             return value if SAFE_CODE_PATTERN.fullmatch(value) else None
         return None

--- a/backend/tests/test_ai_coach.py
+++ b/backend/tests/test_ai_coach.py
@@ -137,10 +137,13 @@ def test_disabled_route_does_not_call_provider(monkeypatch) -> None:
     assert provider.calls == []
 
 
-def test_success_uses_exact_published_context_and_returns_trusted_citations(monkeypatch) -> None:
+def test_success_uses_exact_published_context_and_emits_routing_metadata(
+    monkeypatch, caplog
+) -> None:
     _enable_provider(monkeypatch)
     provider = StubProvider(calls=[])
     monkeypatch.setattr(ai_coach_service, "provider", provider)
+    caplog.set_level(logging.INFO, logger="app.ai_coach")
 
     with get_session_context() as db:
         response = ai_coach_service.generate(
@@ -157,6 +160,18 @@ def test_success_uses_exact_published_context_and_returns_trusted_citations(monk
     assert response.citations[0].source_type == "canonical_yfc"
     assert provider.calls[0][0].data_class.value == "generic"
     assert provider.calls[0][1] == ("knowledge-kbju-reference-v1",)
+    generation_record = next(
+        record for record in caplog.records if record.getMessage() == "ai_coach_generation"
+    )
+    assert generation_record.job == "nutrition_knowledge"
+    assert generation_record.data_class == "generic"
+    assert generation_record.provider == "groq"
+    assert generation_record.configured_model == "openai/gpt-oss-120b"
+    assert generation_record.actual_model == "openai/gpt-oss-120b"
+    assert generation_record.outcome == "answer"
+    assert generation_record.attempts == 1
+    assert generation_record.retry_count == 0
+    assert generation_record.error_code is None
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -84,6 +84,55 @@ def test_json_formatter_preserves_worker_lifecycle_markers() -> None:
         assert json.loads(formatter.format(record))["message"] == event_name
 
 
+def test_json_formatter_preserves_bounded_ai_coach_metadata_without_content() -> None:
+    record = logging.LogRecord(
+        name="app.ai_coach",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="ai_coach_generation",
+        args=(),
+        exc_info=None,
+    )
+    fields = {
+        "request_id": "request-ai-123",
+        "job": "nutrition_knowledge",
+        "data_class": "generic",
+        "tool_name": "get_period_report_insights",
+        "prompt_version": "ai-coach-period-report-v2",
+        "schema_version": "ai-coach-period-report-output-v1",
+        "policy_revision": "verified-generic-v1",
+        "provider": "groq",
+        "configured_model": "openai/gpt-oss-120b",
+        "actual_model": "openai/gpt-oss-120b",
+        "outcome": "answer",
+        "error_code": "provider_unavailable",
+        "safety_category": "clear",
+        "attempts": 1,
+        "retry_count": 0,
+        "latency_ms": 123,
+        "prompt_tokens": 10,
+        "completion_tokens": 20,
+        "total_tokens": 30,
+        "cost_microunits": 0,
+        "report_version": "progress-report-v1",
+        "report_revision": "report:0123456789abcdef",
+    }
+    for key, value in fields.items():
+        setattr(record, key, value)
+    record.prompt = "private prompt"
+    record.answer = "private answer"
+    record.user_id = 99887766
+
+    payload = json.loads(JsonFormatter(service="api").format(record))
+
+    assert payload["message"] == "ai_coach_generation"
+    assert {key: payload[key] for key in fields} == fields
+    assert "prompt" not in payload
+    assert "answer" not in payload
+    assert "user_id" not in payload
+
+
 def test_news_cycle_summary_preserves_required_bounded_counters() -> None:
     record = logging.LogRecord(
         name="fitminiapp_api.services.news_worker",

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -116,7 +116,7 @@ def test_json_formatter_preserves_bounded_ai_coach_metadata_without_content() ->
         "total_tokens": 30,
         "cost_microunits": 0,
         "report_version": "progress-report-v1",
-        "report_revision": "report:0123456789abcdef",
+        "report_revision": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
     }
     for key, value in fields.items():
         setattr(record, key, value)

--- a/docs/ai/ai-coach-provider-routing-evidence.md
+++ b/docs/ai/ai-coach-provider-routing-evidence.md
@@ -104,9 +104,11 @@ transient provider condition по старому snapshot.
 5. capability/output-validation failures separately from safety refusal and local quota;
 6. no raw prompt/answer/context, user id, memory value, account id or provider payload.
 
-Минимально достаточный window и thresholds не выдумываются этой task: owner должен утвердить
-их вместе с job/cohort и target reliability/cost/latency. До этого текущий route остаётся
-единственным, а `unavailable` — валидным fallback без AI.
+Owner decision от 2026-09-11 утвердил bounded observation window: наблюдать минимум 14
+календарных дней и минимум 100 реальных `ai_coach_generation` запросов. Если за 14 дней
+100 запросов не набралось, наблюдение продолжается до достижения 100 запросов. Искусственный
+production traffic запрещён. До завершения окна текущий route остаётся единственным, а
+`unavailable` — валидным fallback без AI.
 
 ## Owner checkpoint
 

--- a/docs/ai/ai-coach-provider-routing-evidence.md
+++ b/docs/ai/ai-coach-provider-routing-evidence.md
@@ -1,0 +1,133 @@
+# AI Coach: evidence для provider routing (Task 92B)
+
+Статус на 2026-09-11: `RESEARCH_FIRST`, multiprovider production implementation не одобрена.
+
+Этот документ фиксирует bounded evidence и следующий owner checkpoint. Он не выбирает второго
+provider, не разрешает paid fallback и не заменяет отдельное решение по privacy contract.
+
+## Owner decision и границы
+
+Owner decision от 2026-09-11 разрешает только research-first workstream:
+
+- сохранить текущий single-provider route и controlled `unavailable` state;
+- собирать только metadata-only evidence из текущего AI Coach operation;
+- не добавлять второго provider ради архитектурной избыточности;
+- после измеримого gap вернуться с конкретным предложением, максимум с двумя providers,
+  bounded fallback и явной privacy matrix.
+
+Поэтому в Task 92B не добавляются router, provider adapter, новые API keys, user-supplied keys,
+автоматическая покупка quota, hidden paid fallback, migration или новый production flow.
+
+## Current baseline
+
+| Область | Текущее состояние | Вывод для routing |
+| --- | --- | --- |
+| Route | `GroqDirectAdapter`, fixed HTTPS `api.groq.com`, model `openai/gpt-oss-120b` | один provider; fallback не включён |
+| Cost | runtime policy `free_only`, cost class `free` | paid/promo/unknown route не разрешён |
+| Data | generic route — `verified_generic_only`; personal route отдельный и consent-gated | data class нельзя понижать ради fallback |
+| Output | strict JSON Schema проверяется на provider и повторно в YFC | capability gap пока не доказан |
+| Retry | bounded process-local retry/cooldown, blind cascade отсутствует | повтор и failover остаются разными решениями |
+| Rollback | kill switch и controlled unavailable сохраняют deterministic core flow | безопасный одно-provider fallback уже есть |
+
+`backend/fitminiapp_api/ai_coach/service.py` уже формирует полезные metadata-only поля:
+request/job/data class, prompt/schema/policy versions, configured/actual model, outcome,
+error code, attempts, latency, nullable usage и period-report revision. До этого изменения
+JSON formatter отбрасывал значительную часть этих полей и переименовывал событие в
+`application_log`, поэтому 90B не мог построить полный aggregate.
+
+Task 92B добавляет только безопасную whitelist-передачу этих полей в JSON logs. Prompt, answer,
+raw context, memory values, user id, exact measurements и provider payload по-прежнему не
+попадают в event.
+
+## Evidence from 90B
+
+90B зафиксировал ограниченную production beta, но не provider decision:
+
+- bounded cohort — примерно 2–3 реальных пользователя, configured allowlist — 3 account IDs;
+- один owner-reported `unavailable`/rate-limit episode и слишком строгая per-user quota;
+- в доступном container window — только 2 `answer` samples, latency 888–1110 ms;
+- provider, error code, data class и attempts в старом log aggregation были недоступны;
+- domain/safety/privacy/core-flow blocker в bounded observation не наблюдался, но denominator,
+  полный период и statistical quality/error rate отсутствуют.
+
+Это evidence для устранения measurement gap, но не измеримый multi-provider trigger. В частности,
+один rate-limit episode нельзя отделить от local per-user quota, organization quota или
+transient provider condition по старому snapshot.
+
+## Evidence matrix
+
+| Возможный trigger | Текущий evidence | Статус |
+| --- | --- | --- |
+| outage/capacity | нет полного provider-attributed ряда; есть только bounded `unavailable` observation | `NOT_ESTABLISHED` |
+| rate/quota | один owner-reported episode; local quota и provider quota не разделялись | `SIGNAL_ONLY` |
+| capability/tool/structured output | текущий route имеет проверяемый strict structured-output path; провал capability не измерен | `NOT_ESTABLISHED` |
+| latency | 2 samples, 888–1110 ms, без target/SLO и полного окна | `NOT_ESTABLISHED` |
+| cost | runtime `free_only`; per-request cost aggregate отсутствует; paid fallback не разрешён | `NOT_ESTABLISHED` |
+| privacy/data location | current provider contract нужно проверять перед любым personalized/fallback route; это constraint, а не incident | `CONSTRAINT_REQUIRES_REVIEW` |
+| approved-job quality | bounded useful observation без denominator и versioned real-user sample | `NOT_ESTABLISHED` |
+
+## Official provider checks (rechecked 2026-09-11)
+
+Проверены только официальные материалы текущего provider; live inference/smoke с credentials не
+выполнялся.
+
+- Groq rate limits зависят от RPM/RPD/TPM/TPD и применяются на уровне организации; для
+  `openai/gpt-oss-120b` опубликованы Developer-plan базовые limits 30 RPM, 1K RPD, 8K TPM и
+  200K TPD, но точные лимиты конкретной организации нужно смотреть в Console.
+- Groq указывает для `openai/gpt-oss-120b` JSON Schema capability и strict structured-output
+  support; в отдельной документации отмечено, что structured outputs не совмещаются с tool use.
+  Текущий YFC не передаёт model-controlled tools: personal tool выполняется backend-side до
+  provider, поэтому это не является установленным gap.
+- Groq описывает inference как не сохраняющий customer data по умолчанию, но допускает
+  временные logs inputs/outputs для reliability/abuse monitoring до 30 дней; указанная data
+  location для retained customer data — GCP buckets в США. Это нельзя переносить на другого
+  provider без отдельной проверки и owner/privacy decision.
+
+Источники:
+
+- [Groq rate limits](https://console.groq.com/docs/rate-limits)
+- [Groq GPT-OSS 120B model](https://console.groq.com/docs/model/openai/gpt-oss-120b)
+- [Groq structured outputs](https://console.groq.com/docs/structured-outputs)
+- [Groq API errors](https://console.groq.com/docs/errors)
+- [Groq data controls and retention](https://console.groq.com/docs/your-data)
+- [Groq policies and notices](https://console.groq.com/docs/legal)
+
+## Collection contract before the next decision
+
+После штатного rollout metadata-only formatter owner/operations должны собрать агрегаты без
+выгрузки raw logs:
+
+1. outcome/error-code counts by `job`, `data_class`, configured/actual model and provider;
+2. latency bands and sample count for a known observation window;
+3. attempts/retry counts and cooldown/unavailable events;
+4. nullable usage/cost fields as reported by provider, without fabricated cost;
+5. capability/output-validation failures separately from safety refusal and local quota;
+6. no raw prompt/answer/context, user id, memory value, account id or provider payload.
+
+Минимально достаточный window и thresholds не выдумываются этой task: owner должен утвердить
+их вместе с job/cohort и target reliability/cost/latency. До этого текущий route остаётся
+единственным, а `unavailable` — валидным fallback без AI.
+
+## Owner checkpoint
+
+Текущий результат: `CONTINUE_SINGLE_PROVIDER_RESEARCH`.
+
+Для перехода к production multiprovider implementation owner должен получить новый evidence-backed
+decision, в котором есть:
+
+- воспроизводимый trigger из matrix с observation window, denominator и impact;
+- выбранный approved job и trusted data class;
+- максимум два конкретных providers/models с capability, cost/free classification, terms/date,
+  retention/data-location и privacy compatibility;
+- parity eval plan против текущего Groq route, включая safety, grounding, structured output,
+  latency/cost и no-provider path;
+- bounded retry/failover/cooldown, idempotency и kill-switch/rollback to one provider;
+- explicit approval на provider count и privacy matrix.
+
+До такого решения production router не реализуется.
+
+## Configuration and deployment impact
+
+Изменения не добавляют environment keys, secrets, dependencies, migrations или provider calls.
+`env change required: no`. Обычный PR-based release telemetry fix может быть продолжен по
+lifecycle; real provider smoke и production credentials не требуются.


### PR DESCRIPTION
## Scope\n\nDelivers the owner-approved Task 92B RESEARCH_FIRST research/observability slice only.\n\n- preserves bounded metadata for ai_coach_generation events\n- records provider/model/error/usage metadata without raw prompt, answer, context, or user ID\n- adds the provider-routing evidence brief and keeps current provider count at 1\n- does not add a router, fallback, second provider, paid path, migration, or runtime provider behavior change\n\nOwner decision: telemetry observation must cover at least 14 calendar days and 100 real ai_coach_generation requests; no artificial production traffic. Multiprovider routing remains at owner checkpoint.